### PR TITLE
optimize audio playback scheduling logic to enable seamless sequential playback and unify the sample rate

### DIFF
--- a/frontend/src/js/index.js
+++ b/frontend/src/js/index.js
@@ -112,11 +112,14 @@ function createAudioSession(onIncomingJson, opts = false) {
     let ttsStreamFinished = false;
     let pendingChunkIndex = null;
 
+    let nextScheduledTime = 0;
+    // ===========================================
+
     // Server PCM sample rate
     const TTS_SAMPLE_RATE = 48000;
 
     // Audio context local sample rate
-    const LOCAL_SAMPLE_RATE = 44100;
+    const LOCAL_SAMPLE_RATE = 48000;
 
     // VAD params
     const NEGATIVE_SPEECH_THRESHOLD = 0.2;
@@ -772,10 +775,12 @@ function createAudioSession(onIncomingJson, opts = false) {
                 // Fallback: stop current sources but keep queue
                 playingSources.forEach((src) => { try { src.stop(); } catch (_e2) { } });
                 playingSources.length = 0;
+                nextScheduledTime = 0;
             });
         } else {
             playingSources.forEach((src) => { try { src.stop(); } catch (_e) { } });
             playingSources.length = 0;
+            nextScheduledTime = 0;
         }
     }
 
@@ -794,6 +799,7 @@ function createAudioSession(onIncomingJson, opts = false) {
                         // Reset stream state and inform the UI to go idle
                         markTTSStreamState('reset');
                         onIncomingJson({ action: 'client_tts_playback_finished', data: { timestamp: Date.now() } });
+                        nextScheduledTime = 0;
                     }
                 }
             }).catch(() => { });
@@ -805,6 +811,7 @@ function createAudioSession(onIncomingJson, opts = false) {
                 if (ttsStreamFinished) sendJson({ action: 'tts_playback_finished', timestamp: Date.now() });
                 markTTSStreamState('reset');
                 onIncomingJson({ action: 'client_tts_playback_finished', data: { timestamp: Date.now() } });
+                nextScheduledTime = 0;
             }
         }
     }
@@ -820,6 +827,8 @@ function createAudioSession(onIncomingJson, opts = false) {
 
         playingSources.forEach((src) => { try { src.stop(); } catch (_e) { } });
         playingSources.length = 0;
+
+        nextScheduledTime = 0;
 
         audioQueue.length = 0;
 
@@ -897,16 +906,19 @@ function createAudioSession(onIncomingJson, opts = false) {
         }
     }
 
-    // Serial playback
+    // Serial playback with seamless audio scheduling
     function playNextAudio() {
         // Do not start when AudioContext is paused
         if (audioCtx && audioCtx.state === 'suspended') return;
+        
         // Delayed finish handling for TTS stream
         if (pendingTTSStreamFinished && playingSources.length === 0 && audioQueue.length === 0) {
             pendingTTSStreamFinished = false;
             markTTSStreamState('finished');
+            nextScheduledTime = 0;
             return;
         }
+        
         if (audioQueue.length === 0) {
             if (ttsStreamFinished) return;
 
@@ -923,16 +935,13 @@ function createAudioSession(onIncomingJson, opts = false) {
             return;
         }
 
-        if (playingSources.length > 0) {
-            return; // Wait current source end
-        }
-
         // Dequeue items shaped as { chunkIndex, audio }
         const queueItem = audioQueue.shift();
         const float32 = queueItem.audio;
         const currentChunkIndex = queueItem.chunkIndex;
 
         newAudioOutputCallback && newAudioOutputCallback(float32, audioCtx ? audioCtx.sampleRate : LOCAL_SAMPLE_RATE);
+        
         // Use local AudioContext sample rate for playback
         const buffer = audioCtx.createBuffer(1, float32.length, audioCtx.sampleRate);
         buffer.getChannelData(0).set(float32);
@@ -940,8 +949,8 @@ function createAudioSession(onIncomingJson, opts = false) {
         const src = audioCtx.createBufferSource();
         src.buffer = buffer;
         src.connect(audioCtx.destination);
-        // Adjust local playback speed (affects pitch because BufferSource changes playback rate);
-        // For pitch preservation consider a phase vocoder/WSOLA later; lightweight build only adjusts speed.)
+        
+        // Adjust local playback speed (affects pitch because BufferSource changes playback rate)
         try {
             if (typeof ttsPlaybackRate === 'number' && isFinite(ttsPlaybackRate) && ttsPlaybackRate > 0) {
                 src.playbackRate.value = ttsPlaybackRate;
@@ -950,6 +959,26 @@ function createAudioSession(onIncomingJson, opts = false) {
             }
         } catch (_) { }
 
+        const currentTime = audioCtx.currentTime;
+        
+        // If nextScheduledTime hasn't been initialized yet or is already in the past, start from the current time
+        if (nextScheduledTime < currentTime) {
+            nextScheduledTime = currentTime;
+        }
+
+        // Compute the actual playback duration of this audio chunk (taking playback rate into account)
+        const duration = buffer.duration / (src.playbackRate.value || 1.0);
+
+        // Start playback using an exact scheduled time
+        const startTime = nextScheduledTime;
+        src.start(startTime);  // ← Key: use an exact start time, not src.start()
+
+        // Update the next chunk's start time = the end time of the current chunk
+        nextScheduledTime = startTime + duration;
+
+        
+        // ===================================================
+
         src.onended = () => {
             const idx = playingSources.indexOf(src);
             if (idx !== -1) playingSources.splice(idx, 1);
@@ -957,21 +986,19 @@ function createAudioSession(onIncomingJson, opts = false) {
             // Report chunk_index to backend after playback
             sendJson({ action: "tts_chunk_played", chunk_index: currentChunkIndex, timestamp: Date.now() });
 
-            if (playingSources.length === 0) playNextAudio();
-
             if (playingSources.length === 0 && audioQueue.length === 0) {
                 // Case A: playback drained and backend already marked finished
                 if (ttsStreamFinished) {
                     sendJson({ action: "tts_playback_finished", timestamp: Date.now() });
-                    // Reset after playback drain
                     markTTSStreamState('reset');
                     onIncomingJson({ action: 'client_tts_playback_finished', data: { timestamp: Date.now() } });
+                    nextScheduledTime = 0;
                 }
                 // Case B: stream no longer active (stop or inactive resume) so fall back to idle
                 else if (!ttsStreamActive) {
-                    // Reset state and notify the frontend UI to go idle
                     markTTSStreamState('reset');
                     onIncomingJson({ action: 'client_tts_playback_finished', data: { timestamp: Date.now() } });
+                    nextScheduledTime = 0;
                 }
             }
         };
@@ -979,14 +1006,17 @@ function createAudioSession(onIncomingJson, opts = false) {
         src.onerror = () => {
             const idx = playingSources.indexOf(src);
             if (idx !== -1) playingSources.splice(idx, 1);
-            if (playingSources.length === 0) playNextAudio();
         };
 
         playingSources.push(src);
-        src.start();
+        
         try {
             onIncomingJson({ action: 'client_tts_playback_started', data: { timestamp: Date.now() } });
         } catch (_) { }
+        
+        if (audioQueue.length > 0) {
+            playNextAudio();
+        }
     }
 
     // Start capture with auto VAD mode (default) or run raw capture in pure front-end mode


### PR DESCRIPTION
## Summary

This PR refactors the client-side TTS audio playback pipeline to achieve **gapless sequential playback** by using precise `AudioBufferSourceNode.start(when)` scheduling. It also **unifies sample-rate assumptions** by consistently using the local `AudioContext.sampleRate` during playback, and resets scheduling state (`nextScheduledTime`) across all stop/reset/finish paths to avoid drift.

---

## Key Changes

### 1) Gapless serial playback via precise scheduling

* Introduce a global `nextScheduledTime` and schedule each chunk with:

  * `startTime = max(nextScheduledTime, audioCtx.currentTime)`
  * `src.start(startTime)`
  * `nextScheduledTime = startTime + durationAdjustedForPlaybackRate`
* This prevents audible gaps caused by calling `src.start()` without an explicit `when`.

### 2) Playback duration accounts for playbackRate

* Computes effective duration as:

  * `duration = buffer.duration / (src.playbackRate.value || 1.0)`
* Ensures `nextScheduledTime` advances correctly even when `ttsPlaybackRate` is applied.

### 3) Unified sample-rate handling

* Uses `audioCtx.sampleRate` when creating buffers:

  * `audioCtx.createBuffer(1, float32.length, audioCtx.sampleRate)`
* Keeps constants explicit:

  * `TTS_SAMPLE_RATE = 48000`
  * `LOCAL_SAMPLE_RATE = 48000`
* `newAudioOutputCallback` receives the effective sample rate (`audioCtx.sampleRate` when available).

### 4) Robust reset/stop behavior

* Ensures `nextScheduledTime = 0` is applied consistently in:

  * stop/reset handlers
  * playback-finished paths (`ttsStreamFinished`, inactive stream, pending finished drain)
* Prevents stale scheduling offsets after interruptions.

### 5) Finish handling stays correct with scheduling

* When queue + active sources drain:

  * Sends `tts_playback_finished` to backend when appropriate
  * Notifies UI via `client_tts_playback_finished`
  * Resets state and scheduling timestamp

---

## Behavioral Notes

* Playback will not start when `AudioContext` is `suspended`.
* Scheduling uses `AudioContext.currentTime` as the source of truth for alignment.
* Chunk playback reporting remains intact:

  * `tts_chunk_played` is sent after each chunk finishes.