### PR TITLE
feat: recording manager improvements, offline client, and protocol cleanup

### DIFF
--- a/.aidocs/codebase-overview.md
+++ b/.aidocs/codebase-overview.md
@@ -1,0 +1,155 @@
+*AI GENERATED*
+
+## Project Summary
+
+**X-Talk** is an open-source, full-duplex cascaded spoken dialogue system framework written in Python. It enables low-latency, interruptible, human-like speech interaction with the following key features:
+
+- **Low-latency speech-to-speech pipeline** (sub-second end-to-end latency)
+- **Natural user interruption support** during conversations
+- **Paralinguistic information encoding** (environment noise, emotion)
+- **Event-driven, loosely-coupled architecture** with async WebSocket support
+- **Multiple ASR/TTS/LLM provider support** (local or cloud-based)
+- **Researcher-friendly and production-ready** with pure Python backend
+
+The system follows a cascaded pipeline architecture: User Speech → ASR → LLM Agent → TTS → Audio Output, with an event bus coordinating all components.
+
+## How to Read Through the Codebase
+
+1. **Start with the high-level API**: `src/xtalk/api.py` - This is the main entry point that shows how the system is configured and connected.
+
+2. **Understand the pipeline abstraction**: `src/xtalk/pipelines/` - Read `interfaces.py` first, then `default.py` to see how models are organized.
+
+3. **Learn the event-driven architecture**: `src/xtalk/serving/`
+   - `event_bus.py` - Central pub/sub system
+   - `events.py` - All event definitions
+   - `service.py` - Per-session orchestrator
+
+4. **Explore the managers**: `src/xtalk/serving/modules/` - Each manager handles a specific responsibility (ASR, TTS, LLM, VAD, etc.)
+
+5. **Study speech components**: `src/xtalk/speech/` - ASR, TTS, VAD implementations with various provider options.
+
+6. **Review the LLM agent layer**: `src/xtalk/llm_agent/` - Conversational AI with tool support.
+
+7. **Check examples**: `examples/sample_app/` - Working server implementations demonstrating usage patterns.
+
+## Individual File Descriptions
+
+- `src/xtalk/api.py`: High-level Xtalk API class that handles configuration parsing, model initialization, session management, tool registration, and WebSocket connection handling. Main entry point for users.
+
+- `src/xtalk/pipelines/interfaces.py`: Abstract base class defining the Pipeline interface with getter methods for all models (ASR, TTS, LLM agent, VAD, captioner, etc.) and context management.
+
+- `src/xtalk/pipelines/default.py`: DefaultPipeline implementation containing core models (ASR, LLM agent, TTS) and optional models (captioner, VAD, enhancer, embeddings, rewriters). Handles model cloning for session isolation.
+
+- `src/xtalk/pipelines/context.py`: Pipeline context/state sharing utilities for maintaining conversation state across components.
+
+- `src/xtalk/serving/event_bus.py`: Central event routing and publishing system implementing pub/sub pattern with priority-based handler ordering, async task management, and error handling.
+
+- `src/xtalk/serving/events.py`: Defines all event types (AudioFrameReceived, VADSpeechStart/End, ASRResultPartial/Final, TTSChunkReady, LLMAgentResponseFinish, etc.) used for inter-component communication.
+
+- `src/xtalk/serving/interfaces.py`: Abstract interfaces for Manager and Service classes defining lifecycle methods and event handler patterns.
+
+- `src/xtalk/serving/service.py`: Service class that orchestrates per-session lifecycle, manages all managers, handles event subscriptions, and coordinates input/output gateways.
+
+- `src/xtalk/serving/service_manager.py`: WebSocket connection manager handling concurrent session management and connection lifecycle.
+
+- `src/xtalk/serving/session_limiter.py`: Concurrency limiter for controlling maximum simultaneous sessions.
+
+- `src/xtalk/serving/modules/input_gateway.py`: Translates WebSocket input messages (audio chunks, VAD signals) into internal events for the event bus.
+
+- `src/xtalk/serving/modules/output_gateway.py`: Converts internal events into WebSocket output messages (audio, text, metadata) for the client.
+
+- `src/xtalk/serving/modules/asr_manager.py`: Manages ASR pipeline including audio buffering, streaming/batch recognition modes, and transcription refinement.
+
+- `src/xtalk/serving/modules/tts_manager.py`: Orchestrates TTS synthesis including text chunking, streaming audio generation, and voice/emotion/speed control.
+
+- `src/xtalk/serving/modules/llm_agent_manager.py`: Coordinates LLM inference, tool execution (web search, voice change, etc.), and context management for conversational responses.
+
+- `src/xtalk/serving/modules/vad_manager.py`: Voice activity detection manager processing audio frames to detect speech start/end events.
+
+- `src/xtalk/serving/modules/enhancer_manager.py`: Audio enhancement/denoising manager for improving input audio quality.
+
+- `src/xtalk/serving/modules/captioner_manager.py`: Audio captioning manager generating descriptions of audio content (environment sounds, speaker characteristics).
+
+- `src/xtalk/serving/modules/speaker_manager.py`: Speaker recognition/tracking manager for identifying and maintaining speaker identity across turns.
+
+- `src/xtalk/serving/modules/embeddings_manager.py`: Text embedding and retrieval manager for semantic search and document similarity.
+
+- `src/xtalk/serving/modules/thought_manager.py`: LLM reasoning/thought display manager for exposing internal model reasoning.
+
+- `src/xtalk/serving/modules/turn_taking_manager.py`: Dialogue turn management for natural conversation flow and interruption handling.
+
+- `src/xtalk/serving/modules/latency_manager.py`: Performance metrics tracking for monitoring end-to-end latency.
+
+- `src/xtalk/serving/modules/recording_manager.py`: Session audio recording manager for logging and debugging.
+
+- `src/xtalk/speech/interfaces.py`: Abstract base classes for all speech components (ASR, TTS, VAD, Captioner, SpeechEnhancer, SpeakerEncoder, SpeechSpeedController, PuntRestorer).
+
+- `src/xtalk/speech/asr/sherpa_onnx_asr.py`: Recommended local ASR implementation using SherpaOnnx with WebSocket streaming support.
+
+- `src/xtalk/speech/asr/qwen3_asr_flash_realtime.py`: AliCloud Qwen3 ASR implementation with real-time streaming recognition.
+
+- `src/xtalk/speech/asr/paraformer_local.py`: Local FunASR Paraformer model implementation for speech recognition.
+
+- `src/xtalk/speech/asr/sensevoice_small_local.py`: Local SenseVoice small model ASR implementation.
+
+- `src/xtalk/speech/asr/zipformer_local.py`: ONNX-based Zipformer ASR implementation.
+
+- `src/xtalk/speech/asr/elevenlabs.py`: ElevenLabs cloud ASR API integration.
+
+- `src/xtalk/speech/tts/index_tts.py`: IndexTTS neural vocoder-based text-to-speech implementation.
+
+- `src/xtalk/speech/tts/index_tts2.py`: IndexTTS2 improved neural TTS implementation.
+
+- `src/xtalk/speech/tts/cosyvoice.py`: AliCloud CosyVoice TTS integration with voice cloning support.
+
+- `src/xtalk/speech/tts/gpt_sovits.py`: GPT-SoVITS voice cloning TTS implementation.
+
+- `src/xtalk/speech/tts/f5_tts.py`: F5-TTS flow matching based text-to-speech.
+
+- `src/xtalk/speech/tts/bark.py`: Bark PyTorch-based TTS with voice presets.
+
+- `src/xtalk/speech/tts/elevenlabs.py`: ElevenLabs cloud TTS API integration.
+
+- `src/xtalk/speech/tts/edge_tts.py`: Microsoft Edge TTS integration.
+
+- `src/xtalk/speech/vad/silero_vad.py`: Silero VAD model implementation for voice activity detection.
+
+- `src/xtalk/speech/captioner/qwen3_omni_captioner.py`: Qwen3 Omni model-based audio captioning implementation.
+
+- `src/xtalk/speech/speech_enhancer/speech_enhancer.py`: FastEnhancer ONNX-based audio denoising implementation.
+
+- `src/xtalk/speech/speaker_encoder/pyannote_embedding.py`: Pyannote.audio speaker embedding extraction for speaker recognition.
+
+- `src/xtalk/speech/punt_restorer/ct_punt.py`: CT-Transformer punctuation restoration implementation.
+
+- `src/xtalk/llm_agent/interfaces.py`: Abstract Agent base class defining generate/generate_stream methods with sync/async variants.
+
+- `src/xtalk/llm_agent/default.py`: DefaultAgent LangChain-based implementation with system prompts, tool usage (voice/emotion/speed control, web search, retrieval), and multi-turn conversation support.
+
+- `src/xtalk/llm_agent/tools/pipeline_control.py`: Built-in tools for voice switching, emotion control, and speech rate adjustment.
+
+- `src/xtalk/llm_agent/tools/retrievers.py`: Tools for local document retrieval and web search integration.
+
+- `src/xtalk/rewriter/interfaces.py`: Abstract Rewriter base class for text transformation pipelines.
+
+- `src/xtalk/rewriter/simple.py`: Default caption and thought rewriter implementations using LLM-based text refinement.
+
+- `src/xtalk/events.py`: Top-level event definitions and event class creation utilities.
+
+- `src/xtalk/model_types.py`: Model interface exports and type definitions for external use.
+
+- `src/xtalk/log_utils.py`: Logging configuration and utilities for consistent log formatting.
+
+- `frontend/src/index.ts`: TypeScript entry point for the browser client library with WebSocket connection, audio capture, and VAD processing.
+
+- `frontend/src/vad-processor.worklet.js`: Audio worklet for client-side voice activity detection processing.
+
+- `examples/sample_app/configurable_server.py`: Generic FastAPI server demonstrating configuration-based deployment with WebSocket endpoint.
+
+- `examples/sample_app/custom_service.py`: Example showing how to create custom services with additional managers and event handlers.
+
+- `examples/sample_app/custom_model.py`: Example demonstrating custom model registration and usage.
+
+- `examples/sample_app/mental_consultant_server.py`: Specialized demo server configured as a mental health counselor application.
+
+- `scripts/gen_event_graph.py`: Utility script to generate event flow graphs for documentation and debugging.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,25 @@
+You can input audios to test X-Talk with `scripts/offline_client.py`.
+
+First start an X-Talk server, remember the port, like 7634; then install dependencies for the offline client and prepare an audio directory with audio files and a `timestamp.txt` file for testing:
+
+```bash
+pip install websockets soundfile numpy soxr
+```
+```plaintext
+/path/to/audio_dir/
+├── audio1.wav
+├── audio2.wav
+└── timestamp.txt
+
+timestamp.txt content:
+audio1.wav:0
+audio2.wav:on_response_finish
+```
+
+Then run the offline client with the WebSocket URL of the server and the input audio directory:
+
+```bash
+    python scripts/offline_client.py --ws ws://127.0.0.1:8000/ws --with-vad --input /path/to/audio_dir --output /path/to/recording.wav
+```
+
+You will see result in `/path/to/recording.wav`. See `scripts/offline_client.py` for more details.

--- a/examples/sample_app/static/js/index.js
+++ b/examples/sample_app/static/js/index.js
@@ -321,7 +321,6 @@ function drawWaveform() {
 
     // Only draw one series: speaking for output; else for input
     let streamState = convo.state.streamState;
-    console.log('streamState:', streamState);
     if (outAnalyser && outDataArray && outBufferLength && streamState === 'speaking') {
         outAnalyser.getByteTimeDomainData(outDataArray);
         drawSeries(outDataArray, outBufferLength, getWaveformColor());

--- a/scripts/latency_measure_client.py
+++ b/scripts/latency_measure_client.py
@@ -264,9 +264,6 @@ async def latency_measure(
 
         recv_task = asyncio.create_task(recv_loop())
 
-        # Start conversation
-        await send_json(ws, {"action": "conversation_start", "timestamp": now_ms()})
-
         # Some deployments may queue you; wait briefly.
         with contextlib.suppress(asyncio.TimeoutError):
             await asyncio.wait_for(queue_granted.wait(), timeout=5.0)
@@ -319,9 +316,6 @@ async def latency_measure(
                 if last_latency
                 else "[Warn] latency_metrics received but parse failed"
             )
-
-        # End conversation (optional)
-        await send_json(ws, {"action": "conversation_end", "timestamp": now_ms()})
 
         # Clean shutdown of recv loop
         recv_task.cancel()

--- a/scripts/offline_client.py
+++ b/scripts/offline_client.py
@@ -38,7 +38,7 @@ TARGET_SR = 16000
 TTS_SR = 48000  # TTS output sample rate
 BYTES_PER_SAMPLE = 2  # int16
 SILENCE_FRAME = b"\x00" * (FRAME_SAMPLES * BYTES_PER_SAMPLE)
-VAD_LATENCY_SEC = 0.3  # extra wait after audio end, before vad_speech_end
+VAD_LATENCY_SEC = 0.5  # extra wait after audio end, before vad_speech_end
 
 
 @dataclass

--- a/scripts/offline_client.py
+++ b/scripts/offline_client.py
@@ -1,0 +1,318 @@
+# scripts/offline_client.py
+"""
+Audio exchange test client for xtalk server.
+
+Usage:
+    # With client-side VAD signals (only send audio during speech)
+    python scripts/audio_exchange_client.py --with-vad \
+        --audio greeting.wav:0 \
+        --audio question.wav:on_response_finish
+
+    # Without VAD signals (continuous silence + audio stream, server detects speech)
+    python scripts/audio_exchange_client.py \
+        --audio greeting.wav:0 \
+        --audio question.wav:5.0 \
+        --audio followup.wav:on_response_finish
+"""
+
+import argparse
+import asyncio
+import json
+import time
+import wave
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import numpy as np
+import websockets
+
+FRAME_SAMPLES = 512
+TARGET_SR = 16000
+BYTES_PER_SAMPLE = 2  # int16
+SILENCE_FRAME = b"\x00" * (FRAME_SAMPLES * BYTES_PER_SAMPLE)
+
+
+@dataclass
+class AudioTask:
+    """An audio file with its scheduled send time."""
+
+    path: str
+    timing: Union[float, str]  # float = absolute seconds, "on_response_finish" = wait
+
+
+@dataclass
+class ClientState:
+    """Track conversation state."""
+
+    start_time: float = 0.0  # monotonic start time
+    tts_bytes_received: int = 0
+    tts_finished: bool = False
+    response_finish_event: Optional[asyncio.Event] = None
+
+
+class AudioExchangeClient:
+    def __init__(
+        self,
+        ws_url: str,
+        audio_tasks: List[AudioTask],
+        with_vad: bool = False,
+    ):
+        self.ws_url = ws_url
+        self.audio_tasks = audio_tasks
+        self.with_vad = with_vad
+        self.state = ClientState()
+        self.ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._running = True
+        self._silence_task: Optional[asyncio.Task] = None
+
+    async def connect(self):
+        self.ws = await websockets.connect(self.ws_url, ping_interval=None)
+        print(f"[Connected] {self.ws_url}")
+
+    async def send_json(self, obj: dict):
+        await self.ws.send(json.dumps(obj))
+
+    async def _send_silence_loop(self):
+        """Continuously send silence frames when not in VAD mode."""
+        frame_sec = FRAME_SAMPLES / TARGET_SR
+        while self._running:
+            await self.ws.send(SILENCE_FRAME)
+            await asyncio.sleep(frame_sec)
+
+    async def send_audio_file(self, path: str):
+        """Load and send a WAV file as PCM frames."""
+        frames = self._load_wav_as_frames(path)
+        frame_sec = FRAME_SAMPLES / TARGET_SR
+
+        # Reset state for this turn
+        self.state.tts_bytes_received = 0
+        self.state.tts_finished = False
+        self.state.response_finish_event = asyncio.Event()
+
+        if self.with_vad:
+            # Send VAD start signal
+            await self.send_json(
+                {"action": "vad_speech_start", "timestamp": int(time.time() * 1000)}
+            )
+
+        # Send audio frames in real-time pacing
+        start = asyncio.get_event_loop().time()
+        for i, frame in enumerate(frames):
+            target_time = start + i * frame_sec
+            now = asyncio.get_event_loop().time()
+            if target_time > now:
+                await asyncio.sleep(target_time - now)
+            await self.ws.send(frame)
+
+        if self.with_vad:
+            # Small delay then send VAD end signal
+            await asyncio.sleep(0.3)
+            await self.send_json(
+                {"action": "vad_speech_end", "timestamp": int(time.time() * 1000)}
+            )
+
+        print(f"[Sent] {path}")
+
+    async def wait_for_response_playback(self):
+        """Wait for TTS to finish, then wait for simulated playback duration."""
+        # Wait for tts_finished signal
+        while not self.state.tts_finished:
+            await asyncio.sleep(0.05)
+
+        # Calculate and wait for playback duration
+        duration_s = self.state.tts_bytes_received / (TARGET_SR * BYTES_PER_SAMPLE)
+        print(f"[Wait] Simulating playback: {duration_s:.2f}s")
+        await asyncio.sleep(duration_s)
+
+        # Notify server playback finished
+        await self.send_json({"action": "tts_playback_finished"})
+
+    async def receive_loop(self):
+        """Handle incoming messages from server."""
+        try:
+            async for msg in self.ws:
+                if isinstance(msg, bytes):
+                    self.state.tts_bytes_received += len(msg)
+                else:
+                    data = json.loads(msg)
+                    action = data.get("action", "")
+
+                    if action == "tts_finished":
+                        self.state.tts_finished = True
+                        print("[Server] TTS generation finished")
+                    elif action == "finish_asr":
+                        text = data.get("data", {}).get("text", "")
+                        print(f"[ASR] {text}")
+                    elif action == "finish_resp":
+                        text = data.get("data", {}).get("text", "")
+                        print(f"[LLM] {text[:100]}...")
+                    elif action == "start_tts":
+                        print("[Server] TTS started")
+                    elif action == "error":
+                        print(f"[Error] {data.get('data')}")
+        except websockets.ConnectionClosed:
+            print("[Disconnected]")
+
+    async def run(self):
+        """Main execution loop."""
+        await self.connect()
+
+        # Start receive loop
+        recv_task = asyncio.create_task(self.receive_loop())
+
+        # Start silence loop if not using client-side VAD
+        if not self.with_vad:
+            self._silence_task = asyncio.create_task(self._send_silence_loop())
+
+        self.state.start_time = asyncio.get_event_loop().time()
+
+        try:
+            for i, task in enumerate(self.audio_tasks):
+                print(f"\n=== Audio {i + 1}/{len(self.audio_tasks)}: {task.path} ===")
+
+                if task.timing == "on_response_finish":
+                    # Wait for previous response to finish playing
+                    if i > 0:  # Skip wait for first audio
+                        await self.wait_for_response_playback()
+                else:
+                    # Wait until absolute timestamp
+                    target = self.state.start_time + task.timing
+                    now = asyncio.get_event_loop().time()
+                    if target > now:
+                        wait_time = target - now
+                        print(f"[Wait] {wait_time:.2f}s until timestamp {task.timing}")
+                        await asyncio.sleep(wait_time)
+
+                # Pause silence sending while sending real audio (if applicable)
+                if self._silence_task and not self.with_vad:
+                    self._silence_task.cancel()
+                    try:
+                        await self._silence_task
+                    except asyncio.CancelledError:
+                        pass
+
+                await self.send_audio_file(task.path)
+
+                # Resume silence sending after audio
+                if not self.with_vad:
+                    self._silence_task = asyncio.create_task(self._send_silence_loop())
+
+            # Wait for final response
+            print("\n[Wait] Waiting for final response...")
+            await self.wait_for_response_playback()
+
+        finally:
+            self._running = False
+            if self._silence_task:
+                self._silence_task.cancel()
+            recv_task.cancel()
+            await self.ws.close()
+            print("[Done]")
+
+    def _load_wav_as_frames(self, path: str) -> List[bytes]:
+        """Load WAV and convert to PCM16 frames at 16kHz."""
+        with wave.open(path, "rb") as wf:
+            sr = wf.getframerate()
+            n_channels = wf.getnchannels()
+            sampwidth = wf.getsampwidth()
+            raw = wf.readframes(wf.getnframes())
+
+        # Convert to float32
+        if sampwidth == 2:
+            audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+        elif sampwidth == 1:
+            audio = (
+                np.frombuffer(raw, dtype=np.uint8).astype(np.float32) - 128
+            ) / 128.0
+        else:
+            raise ValueError(f"Unsupported sample width: {sampwidth}")
+
+        # Mono
+        if n_channels > 1:
+            audio = audio.reshape(-1, n_channels).mean(axis=1)
+
+        # Resample to 16kHz
+        if sr != TARGET_SR:
+            ratio = TARGET_SR / sr
+            new_len = int(len(audio) * ratio)
+            audio = np.interp(
+                np.linspace(0, len(audio) - 1, new_len), np.arange(len(audio)), audio
+            )
+
+        # Convert to int16 frames
+        audio = np.clip(audio, -1.0, 1.0)
+        audio_int16 = (audio * 32767).astype(np.int16)
+
+        frames = []
+        for i in range(0, len(audio_int16), FRAME_SAMPLES):
+            chunk = audio_int16[i : i + FRAME_SAMPLES]
+            if len(chunk) < FRAME_SAMPLES:
+                chunk = np.pad(chunk, (0, FRAME_SAMPLES - len(chunk)))
+            frames.append(chunk.tobytes())
+        return frames
+
+
+def parse_audio_arg(arg: str) -> AudioTask:
+    """Parse 'file.wav:timing' format."""
+    if ":" not in arg:
+        raise ValueError(f"Invalid format '{arg}', expected 'file.wav:timing'")
+
+    path, timing_str = arg.rsplit(":", 1)
+
+    if timing_str == "on_response_finish":
+        timing = "on_response_finish"
+    else:
+        try:
+            timing = float(timing_str)
+        except ValueError:
+            raise ValueError(
+                f"Invalid timing '{timing_str}', expected number or 'on_response_finish'"
+            )
+
+    return AudioTask(path=path, timing=timing)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Audio exchange test client for xtalk server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # With client-side VAD (send vad_speech_start/end signals)
+  python %(prog)s --with-vad --audio greeting.wav:0 --audio question.wav:on_response_finish
+
+  # Without VAD (continuous audio stream, server detects speech)
+  python %(prog)s --audio greeting.wav:0 --audio question.wav:5.0
+
+  # Mixed timing
+  python %(prog)s --audio intro.wav:0 --audio q1.wav:on_response_finish --audio q2.wav:30.0
+        """,
+    )
+    parser.add_argument(
+        "--ws", default="ws://127.0.0.1:8000/ws", help="WebSocket URL"
+    )
+    parser.add_argument(
+        "--audio",
+        nargs="+",
+        required=True,
+        help="Audio files with timing: 'file.wav:seconds' or 'file.wav:on_response_finish'",
+    )
+    parser.add_argument(
+        "--with-vad",
+        action="store_true",
+        help="Send vad_speech_start/end signals (client-side VAD mode)",
+    )
+    args = parser.parse_args()
+
+    audio_tasks = [parse_audio_arg(a) for a in args.audio]
+
+    client = AudioExchangeClient(
+        ws_url=args.ws,
+        audio_tasks=audio_tasks,
+        with_vad=args.with_vad,
+    )
+    asyncio.run(client.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/offline_client.py
+++ b/scripts/offline_client.py
@@ -12,7 +12,7 @@ Usage:
 
 The input directory should contain audio files and a timestamp.txt file.
 Each line in timestamp.txt has the format: audio_file_name.suffix:<timestamp>
-where <timestamp> is either a float (seconds from start) or "on_response_finish".
+where <timestamp> is either a float (seconds from start) or "on_response_finish", which means replying on audio from server finishes.
 
 Example timestamp.txt:
     greeting.wav:0

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -186,7 +186,6 @@ class TTSSpeedChange(BaseEvent):
 class TTSChunkGenerated(BaseEvent):
     TYPE: ClassVar[str] = "tts.chunk_generated"
     audio_chunk: bytes = b""
-    chunk_index: int = 0  # Frame index used by frontend confirmations
 
 
 @dataclass
@@ -195,10 +194,10 @@ class TTSChunkPlayed(BaseEvent):
 
     InputGateway publishes this after receiving tts_chunk_played.
     RecordingManager subscribes and writes the chunk into right-channel buffer.
+    Chunks are processed in FIFO order (no index needed).
     """
 
     TYPE: ClassVar[str] = "tts.chunk_played_confirm"
-    chunk_index: int = 0
 
 
 @dataclass

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -417,3 +417,11 @@ class ClockSyncReceived(BaseEvent):
     client_send_ts: float = 0.0
     server_recv_ts: float = 0.0
     client_recv_ts: float = 0.0
+
+
+@dataclass
+class SessionConfigReceived(BaseEvent):
+    """Client sent per-session configuration (e.g., recording path)."""
+
+    TYPE: ClassVar[str] = "session.config_received"
+    recording_path: str | None = None

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Dict, Any, Type
 @dataclass
 class BaseEvent:
     """Base dataclass for all xtalk events."""
+
     timestamp: float = field(init=False)
     session_id: str
     TYPE: ClassVar[str] = "base"
@@ -189,7 +190,7 @@ class TTSChunkGenerated(BaseEvent):
 
 
 @dataclass
-class TTSChunkPlayedConfirm(BaseEvent):
+class TTSChunkPlayed(BaseEvent):
     """Frontend confirmed playback completion for a TTS audio chunk.
 
     InputGateway publishes this after receiving tts_chunk_played.

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -113,14 +113,6 @@ class LLMFirstSentence(BaseEvent):
 
 
 @dataclass
-class ConversationEnded(BaseEvent):
-    """Frontend conversation_end signal."""
-
-    TYPE: ClassVar[str] = "conversation.ended"
-    reason: str = ""
-
-
-@dataclass
 class TTSStarted(BaseEvent):
     TYPE: ClassVar[str] = "tts.started"
 

--- a/src/xtalk/serving/modules/input_gateway.py
+++ b/src/xtalk/serving/modules/input_gateway.py
@@ -10,7 +10,6 @@ from ..events import (
     ErrorOccurred,
     WebSocketMessageReceived,
     AudioFrameReceived,
-    ConversationEnded,
     VADSpeechStart,
     VADSpeechEnd,
     TTSPlaybackFinished,
@@ -87,23 +86,6 @@ class TextMsgHandler(EventListenerMixin):
         except Exception as e:
             logger.error(
                 "Failed to process clock sync - session: %s, error: %s",
-                self.session_id,
-                e,
-            )
-
-    async def _handle_conversation_start(self, message_data: dict) -> None:
-        """Handle frontend conversation_start signal (currently placeholder)."""
-        pass
-
-    async def _handle_conversation_end(self, message_data: dict) -> None:
-        """Handle frontend conversation_end signal."""
-        try:
-            reason = message_data.get("reason", "")
-            event = ConversationEnded(session_id=self.session_id, reason=reason)
-            await self.event_bus.publish(event)
-        except Exception as e:
-            logger.error(
-                "Failed to process conversation_end - session: %s, error: %s",
                 self.session_id,
                 e,
             )
@@ -255,10 +237,6 @@ class TextMsgHandler(EventListenerMixin):
                         await self._handle_ping(message_data, server_recv_ts)
                     elif message_type == "clock_sync":
                         await self._handle_clock_sync(message_data)
-                    elif message_type == "conversation_start":
-                        await self._handle_conversation_start(message_data)
-                    elif message_type == "conversation_end":
-                        await self._handle_conversation_end(message_data)
                     elif message_type in ["vad_speech_start", "vad_speech_end"]:
                         await self._handle_vad_signal(message_type, message_data)
                     elif message_type == "tts_playback_finished":

--- a/src/xtalk/serving/modules/input_gateway.py
+++ b/src/xtalk/serving/modules/input_gateway.py
@@ -219,12 +219,7 @@ class TextMsgHandler(EventListenerMixin):
 
     async def _handle_tts_chunk_played(self, message_data: dict) -> None:
         """Handle frontend confirmation that a TTS chunk finished playback."""
-        chunk_index = message_data.get("chunk_index", 0)
-
-        event = TTSChunkPlayed(
-            session_id=self.session_id,
-            chunk_index=chunk_index,
-        )
+        event = TTSChunkPlayed(session_id=self.session_id)
         await self.event_bus.publish(event)
 
     # ==================== Event handler methods ====================

--- a/src/xtalk/serving/modules/input_gateway.py
+++ b/src/xtalk/serving/modules/input_gateway.py
@@ -17,7 +17,7 @@ from ..events import (
     TTSVoiceChange,
     TTSEmotionChange,
     TTSSpeedChange,
-    TTSChunkPlayedConfirm,
+    TTSChunkPlayed,
     TTSModelSwitchRequested,
     LLMModelSwitchRequested,
     ClockSyncReceived,
@@ -221,7 +221,7 @@ class TextMsgHandler(EventListenerMixin):
         """Handle frontend confirmation that a TTS chunk finished playback."""
         chunk_index = message_data.get("chunk_index", 0)
 
-        event = TTSChunkPlayedConfirm(
+        event = TTSChunkPlayed(
             session_id=self.session_id,
             chunk_index=chunk_index,
         )
@@ -346,7 +346,9 @@ class InputGateway:
                 await self.websocket.accept()
 
         except Exception as e:
-            logger.error(f"Failed to accept connection - session: {self.session_id}, error: {e}")
+            logger.error(
+                f"Failed to accept connection - session: {self.session_id}, error: {e}"
+            )
 
     async def handle_message_loop(self) -> None:
         """Main receive loop that dispatches WebSocket messages."""
@@ -365,9 +367,13 @@ class InputGateway:
         except Exception as e:
             error_msg = str(e).lower()
             if "disconnect" in error_msg or "closed" in error_msg:
-                logger.info(f"WebSocket already closed - session: {self.session_id}, detail: {e}")
+                logger.info(
+                    f"WebSocket already closed - session: {self.session_id}, detail: {e}"
+                )
             else:
-                logger.error(f"WebSocket message processing error - session: {self.session_id}, error: {e}")
+                logger.error(
+                    f"WebSocket message processing error - session: {self.session_id}, error: {e}"
+                )
 
     async def _process_message(self, data: dict) -> None:
         """Process a raw WebSocket receive payload and publish events."""

--- a/src/xtalk/serving/modules/output_gateway.py
+++ b/src/xtalk/serving/modules/output_gateway.py
@@ -446,19 +446,9 @@ class OutputGateway(EventListenerMixin):
 
     @EventListenerMixin.event_handler(TTSChunkGenerated, priority=5)
     async def _send_tts_chunk_signal(self, event: TTSChunkGenerated) -> None:
-        """Send TTS audio chunks (metadata + PCM bytes) to the frontend."""
+        """Send TTS audio chunks (PCM bytes) to the frontend."""
         try:
             if hasattr(event, "audio_chunk") and event.audio_chunk:
-                chunk_index = getattr(event, "chunk_index", 0)
-                # Send metadata separately then raw PCM as binary
-                await self.send_signal(
-                    {
-                        "action": "tts_chunk_meta",
-                        "data": {
-                            "chunk_index": chunk_index,
-                        },
-                    }
-                )
                 await self._send_binary(event.audio_chunk)
 
         except Exception as e:

--- a/src/xtalk/serving/modules/recording_manager.py
+++ b/src/xtalk/serving/modules/recording_manager.py
@@ -29,7 +29,8 @@ from ..events import (
 )
 
 
-# TODO: refined time control by adding timestamps to user audio frames and TTS chunks; current implementation does not consider network latency and code execution time and may drift
+# TODO: refined time control by adding timestamps to user audio frames and TTS chunks; current implementation does not consider network latency and code execution time and may drift.
+# TODO: when interrupting during an audio chunk on frontend, that chunk's tts_chunk_played event will not be sent, and the played part of that chunk will not appear in the final recording; this will result in TTS early stops before user interruption in the recording
 class RecordingManager(Manager):
     """Record user and TTS audio streams for each session."""
 
@@ -198,7 +199,7 @@ class RecordingManager(Manager):
             self._samples_user += n
 
             # Update timer
-            self._timer_user = now + silence_duration + audio_duration
+            self._timer_user = self._timer_user + silence_duration + audio_duration
 
     async def _append_tts_audio(self, data_i16: np.ndarray) -> None:
         """Append TTS audio to right channel with time-based silence padding."""
@@ -220,7 +221,7 @@ class RecordingManager(Manager):
             self._samples_tts += n
 
             # Update timer
-            self._timer_tts = now + silence_duration + audio_duration
+            self._timer_tts = self._timer_tts + silence_duration + audio_duration
 
     # ==================== Periodic flushing ====================
 

--- a/src/xtalk/serving/modules/recording_manager.py
+++ b/src/xtalk/serving/modules/recording_manager.py
@@ -2,20 +2,12 @@
 """
 RecordingManager
 
-Session-level audio recorder that keeps aligned stereo WAV files for both
-enhanced and raw user audio against TTS output. Two files are produced:
-- `logs/session_audio/<ts>.wav` (L=enhanced user, R=TTS)
-- `logs/session_audio/<ts>_raw.wav` (L=raw user, R=TTS)
+Session-level audio recorder that produces a stereo WAV file:
+- Left channel: raw user audio
+- Right channel: TTS output
 
-Highlights:
-- Purely event-driven: listens to EnhancedAudioFrameReceived, AudioFrameReceived,
-  TTSChunkGenerated, TTSChunkPlayedConfirm, and ConversationEnded.
-- Maintains a shared timeline by padding both channels with silence before
-  appending data, ensuring left/right sample counts always match.
-- Buffers TTS chunks until the frontend confirms playback, dropping unconfirmed
-  chunks at session end.
-- Resamples everything to TARGET_SR (default 48 kHz) and periodically flushes.
-- On shutdown writes any remaining data, pads silence, and closes files cleanly.
+Recording starts on WebSocket connection (__init__) and stops on shutdown().
+Audio is saved to logs/session_audio/<timestamp>.wav.
 """
 
 import os
@@ -31,306 +23,207 @@ from ..event_bus import EventBus
 from ..interfaces import Manager
 from ..events import (
     AudioFrameReceived,
-    EnhancedAudioFrameReceived,
     TTSChunkGenerated,
     TTSChunkPlayed,
-    ConversationEnded,
 )
 
 
 class RecordingManager(Manager):
-    """Record aligned user/TTS audio streams for each session."""
+    """Record user and TTS audio streams for each session."""
 
     TARGET_SR: int = 48000  # Unified output sample rate
-    FLUSH_INTERVAL_SEC: float = 1.0  # Periodic flush interval
+    FLUSH_INTERVAL_SEC: float = 10.0  # Periodic flush interval
 
     def __init__(
         self, event_bus: EventBus, session_id: str, config: dict[str, Any] | None = None
     ):
         self.event_bus = event_bus
         self.session_id = session_id
-        # Session-level configuration
         self.config: dict[str, Any] = config or {}
 
-        # Buffers for enhanced-aligned stereo file (int16 PCM bytes)
-        self._ch_user_enh = bytearray()  # Left channel: enhanced user input
-        self._ch_tts_enh = bytearray()  # Right channel: TTS output
-        self._samples_user_enh = 0
-        self._samples_tts_enh = 0
+        # Stereo buffers (int16 PCM bytes)
+        self._ch_user = bytearray()  # Left channel: raw user input
+        self._ch_tts = bytearray()  # Right channel: TTS output
+        self._samples_user = 0
+        self._samples_tts = 0
 
-        # Buffers for raw-aligned stereo file
-        self._ch_user_raw = bytearray()  # Left channel: raw user input
-        self._ch_tts_raw = bytearray()  # Right channel: TTS output copy
-        self._samples_user_raw = 0
-        self._samples_tts_raw = 0
-
-        # FIFO queue of pending TTS chunks until playback is confirmed; each item=(bytes, sr)
+        # FIFO queue of pending TTS chunks until playback confirmed; each item=(pcm_bytes, sample_rate)
         self._pending_tts_chunks: list[tuple[bytes, int]] = []
 
-        # Output directories
+        # Time-based padding: track when each channel ends (in seconds, using time.time())
+        _now = time.time()
+        self._timer_user: float = _now  # User channel end time
+        self._timer_tts: float = _now  # TTS channel end time
+
+        # Output directory and file path
         self._out_dir = os.path.join("logs", "session_audio")
         os.makedirs(self._out_dir, exist_ok=True)
-        # Timestamp-based prefix (milliseconds, filesystem-friendly)
+
+        # Timestamp-based filename
         _ts = time.time()
-        _ts_prefix = (
+        _ts_str = (
             time.strftime("%Y%m%d_%H%M%S", time.localtime(_ts))
             + f"_{int((_ts - int(_ts)) * 1000):03d}"
         )
-        # Enhanced alignment output
-        self._out_path = os.path.join(self._out_dir, f"{_ts_prefix}.wav")
-        # Raw alignment output
-        self._out_path_raw = os.path.join(self._out_dir, f"{_ts_prefix}_raw.wav")
+        self._out_path = os.path.join(self._out_dir, f"{_ts_str}.wav")
 
         # Concurrency primitives
-        self._lock = asyncio.Lock()  # Protect channel buffers
-        self._io_lock = asyncio.Lock()  # Serialize file writes
+        self._lock = asyncio.Lock()
+        self._io_lock = asyncio.Lock()
         self._flush_task: Optional[asyncio.Task] = None
-        self._wf: Optional[wave.Wave_write] = None  # Enhanced WAV handle
-        self._wf_raw: Optional[wave.Wave_write] = None  # Raw WAV handle
 
-        # Open WAV files for the entire session
-        self._wf = wave.open(self._out_path, "wb")
+        # Open WAV file for the session
+        self._wf: Optional[wave.Wave_write] = wave.open(self._out_path, "wb")
         self._wf.setnchannels(2)
         self._wf.setsampwidth(2)
         self._wf.setframerate(self.TARGET_SR)
-
-        self._wf_raw = wave.open(self._out_path_raw, "wb")
-        self._wf_raw.setnchannels(2)
-        self._wf_raw.setsampwidth(2)
-        self._wf_raw.setframerate(self.TARGET_SR)
 
         # Start periodic flush task
         self._flush_task = asyncio.create_task(self._periodic_flush_loop())
 
     # ==================== Event handlers ====================
 
-    @Manager.event_handler(EnhancedAudioFrameReceived, priority=50)
-    async def _on_audio_frame(self, event: EnhancedAudioFrameReceived) -> None:
-        """Append enhanced user audio frames to the aligned left channel."""
+    @Manager.event_handler(AudioFrameReceived, priority=50)
+    async def _on_audio_frame(self, event: AudioFrameReceived) -> None:
+        """Append raw user audio to the left channel."""
         try:
             pcm = event.audio_data or b""
             if not pcm:
                 return
             src_sr = getattr(event, "sample_rate", 16000) or 16000
-            await self._append_user_audio_enh(pcm, src_sr)
+            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
+            await self._append_user_audio(data_i16)
         except Exception as e:
             logger.warning("RecordingManager: failed to handle audio frame: %s", e)
 
-    @Manager.event_handler(AudioFrameReceived, priority=40)
-    async def _on_raw_audio_frame(self, event: AudioFrameReceived) -> None:
-        """Append raw user audio frames to the raw-aligned left channel."""
-        try:
-            pcm = event.audio_data or b""
-            if not pcm:
-                return
-            src_sr = getattr(event, "sample_rate", 16000) or 16000
-            await self._append_user_audio_raw(pcm, src_sr)
-        except Exception as e:
-            logger.warning("RecordingManager: failed to handle raw audio frame: %s", e)
-
     @Manager.event_handler(TTSChunkGenerated, priority=50)
     async def _on_tts_chunk_generated(self, event: TTSChunkGenerated) -> None:
-        """Cache generated TTS chunks until playback is confirmed (FIFO order)."""
+        """Queue generated TTS chunks until playback is confirmed."""
         try:
             pcm = getattr(event, "audio_chunk", b"") or b""
             if not pcm:
                 return
-            # Default to 48 kHz; event may override in the future
             src_sr = getattr(event, "sample_rate", 48000) or 48000
             async with self._lock:
                 self._pending_tts_chunks.append((pcm, src_sr))
         except Exception as e:
-            logger.warning(
-                "RecordingManager: failed to cache generated tts chunk: %s", e
-            )
+            logger.warning("RecordingManager: failed to queue TTS chunk: %s", e)
 
     @Manager.event_handler(TTSChunkPlayed, priority=50)
-    async def _on_tts_chunk_played_confirm(self, event: TTSChunkPlayed) -> None:
-        """
-        Commit confirmed TTS chunks to the right channel (FIFO order).
-
-        Assumptions:
-        - This event fires after the chunk finishes playing on the client.
-        - Chunks are played in the same order they were generated.
-        """
+    async def _on_tts_chunk_played(self, event: TTSChunkPlayed) -> None:
+        """Pop one TTS chunk from queue and append to the right channel."""
         try:
             async with self._lock:
                 if not self._pending_tts_chunks:
                     return
                 pcm, src_sr = self._pending_tts_chunks.pop(0)
-            data_i16 = self._to_int16_and_resample(pcm, src_sr, self.TARGET_SR)
+            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
             await self._append_tts_audio(data_i16)
         except Exception as e:
-            logger.warning("RecordingManager: failed to commit played tts chunk: %s", e)
+            logger.warning("RecordingManager: failed to handle TTS chunk played: %s", e)
 
-    @Manager.event_handler(ConversationEnded, priority=40)
-    async def _on_conversation_end(self, event: ConversationEnded) -> None:
-        """Drop any pending TTS chunks when the conversation ends."""
-        try:
-            async with self._lock:
-                self._pending_tts_chunks.clear()
-        except Exception as e:
-            logger.warning(
-                "RecordingManager: failed to clear pending tts chunks on end: %s", e
-            )
+    # ==================== Resampling ====================
 
-    # ==================== Helpers: resampling & zero padding ====================
-
-    def _to_int16_and_resample(
+    def _resample_to_int16(
         self, pcm_bytes: bytes, src_sr: int, dst_sr: int
     ) -> np.ndarray:
-        """Resample PCM int16 bytes to target sample rate and return np.int16 array."""
+        """Resample PCM int16 bytes to target sample rate."""
         if not pcm_bytes:
             return np.zeros((0,), dtype=np.int16)
         data = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32)
         if src_sr == dst_sr or data.size == 0:
-            out = np.clip(data, -32768, 32767).astype(np.int16)
-            return out
-        # Lightweight linear interpolation resampling
+            return np.clip(data, -32768, 32767).astype(np.int16)
+        # Linear interpolation resampling
         old_n = data.size
         new_n = int(round(old_n * (dst_sr / float(src_sr))))
         if new_n <= 0:
             return np.zeros((0,), dtype=np.int16)
         x_old = np.linspace(0.0, 1.0, num=old_n, endpoint=False)
         x_new = np.linspace(0.0, 1.0, num=new_n, endpoint=False)
-        resampled = np.interp(x_new, x_old, data).astype(np.float32)
-        out = np.clip(resampled, -32768, 32767).astype(np.int16)
-        return out
+        resampled = np.interp(x_new, x_old, data)
+        return np.clip(resampled, -32768, 32767).astype(np.int16)
 
-    def _append_with_other_silent(
-        self,
-        ch_nonzero: bytearray,
-        ch_zero: bytearray,
-        samples_nonzero: int,
-        samples_zero: int,
-        data: np.ndarray,
-    ) -> tuple[int, int]:
-        """
-        Append real audio to one channel while padding the other with silence so both
-        channels remain aligned. Returns updated sample counts.
-        """
-        n = int(data.size)
+    # ==================== Channel append with time-based silence padding ====================
+
+    async def _append_user_audio(self, data_i16: np.ndarray) -> None:
+        """Append user audio to left channel with time-based silence padding."""
+        n = data_i16.size
         if n <= 0:
-            return samples_nonzero, samples_zero
-
-        # Step 1: align to global timeline
-        global_len = max(samples_nonzero, samples_zero)
-        if samples_nonzero < global_len:
-            diff = global_len - samples_nonzero
-            ch_nonzero.extend(b"\x00" * (diff * 2))
-            samples_nonzero += diff
-        if samples_zero < global_len:
-            diff = global_len - samples_zero
-            ch_zero.extend(b"\x00" * (diff * 2))
-            samples_zero += diff
-
-        # Step 2: append real audio to one channel and silence to the other
-        ch_nonzero.extend(data.tobytes())
-        samples_nonzero += n
-
-        ch_zero.extend(b"\x00" * (n * 2))
-        samples_zero += n
-
-        return samples_nonzero, samples_zero
-
-    # ==================== Appending user & TTS audio ====================
-
-    async def _append_user_audio_enh(self, pcm: bytes, src_sr: int) -> None:
-        """Append enhanced user audio (left channel)."""
-        data_i16 = self._to_int16_and_resample(pcm, src_sr, self.TARGET_SR)
+            return
         async with self._lock:
-            self._samples_user_enh, self._samples_tts_enh = (
-                self._append_with_other_silent(
-                    self._ch_user_enh,
-                    self._ch_tts_enh,
-                    self._samples_user_enh,
-                    self._samples_tts_enh,
-                    data_i16,
-                )
-            )
+            now = time.time()
+            # Pad silence for elapsed time since last audio
+            silence_duration = max(0.0, now - self._timer_user)
+            silence_samples = int(silence_duration * self.TARGET_SR)
+            if silence_samples > 0:
+                self._ch_user.extend(b"\x00" * (silence_samples * 2))
+                self._samples_user += silence_samples
 
-    async def _append_user_audio_raw(self, pcm: bytes, src_sr: int) -> None:
-        """Append raw user audio (left channel)."""
-        data_i16 = self._to_int16_and_resample(pcm, src_sr, self.TARGET_SR)
-        async with self._lock:
-            self._samples_user_raw, self._samples_tts_raw = (
-                self._append_with_other_silent(
-                    self._ch_user_raw,
-                    self._ch_tts_raw,
-                    self._samples_user_raw,
-                    self._samples_tts_raw,
-                    data_i16,
-                )
-            )
+            # Append audio chunk
+            self._ch_user.extend(data_i16.tobytes())
+            self._samples_user += n
+
+            # Update timer: current time + audio duration
+            audio_duration = n / self.TARGET_SR
+            self._timer_user = now + audio_duration
 
     async def _append_tts_audio(self, data_i16: np.ndarray) -> None:
-        """
-        Append confirmed TTS audio to the right channel of both files while padding
-        the opposite channel with silence so lengths stay aligned.
-        """
+        """Append TTS audio to right channel with time-based silence padding."""
+        n = data_i16.size
+        if n <= 0:
+            return
         async with self._lock:
-            # Enhanced file: TTS active, user padded
-            self._samples_tts_enh, self._samples_user_enh = (
-                self._append_with_other_silent(
-                    self._ch_tts_enh,
-                    self._ch_user_enh,
-                    self._samples_tts_enh,
-                    self._samples_user_enh,
-                    data_i16,
-                )
-            )
+            now = time.time()
+            # Pad silence for elapsed time since last audio
+            silence_duration = max(0.0, now - self._timer_tts)
+            silence_samples = int(silence_duration * self.TARGET_SR)
+            if silence_samples > 0:
+                self._ch_tts.extend(b"\x00" * (silence_samples * 2))
+                self._samples_tts += silence_samples
 
-            # Raw file: same behavior
-            self._samples_tts_raw, self._samples_user_raw = (
-                self._append_with_other_silent(
-                    self._ch_tts_raw,
-                    self._ch_user_raw,
-                    self._samples_tts_raw,
-                    self._samples_user_raw,
-                    data_i16,
-                )
-            )
+            # Append audio chunk
+            self._ch_tts.extend(data_i16.tobytes())
+            self._samples_tts += n
 
-    # ==================== Periodic flushing & lifecycle ====================
+            # Update timer: current time + audio duration
+            audio_duration = n / self.TARGET_SR
+            self._timer_tts = now + audio_duration
+
+    # ==================== Periodic flushing ====================
 
     async def _periodic_flush_loop(self) -> None:
         try:
             while True:
                 await asyncio.sleep(self.FLUSH_INTERVAL_SEC)
                 try:
-                    # Flush both files
-                    await self._flush_to_file_enh()
-                    await self._flush_to_file_raw()
+                    await self._flush_to_file()
                 except Exception as e:
                     logger.warning("RecordingManager: periodic flush error: %s", e)
         except asyncio.CancelledError:
             pass
 
-    async def _flush_to_file_enh(self) -> bool:
-        """Flush enhanced alignment buffers to disk."""
+    async def _flush_to_file(self) -> bool:
+        """Flush aligned buffers to disk."""
         async with self._lock:
-            ns_user = self._samples_user_enh
-            ns_tts = self._samples_tts_enh
-            n_write = min(ns_user, ns_tts)
+            n_write = min(self._samples_user, self._samples_tts)
             if n_write <= 0:
                 return False
 
             bytes_len = n_write * 2
-            user_bytes = bytes(self._ch_user_enh[:bytes_len])
-            tts_bytes = bytes(self._ch_tts_enh[:bytes_len])
+            user_bytes = bytes(self._ch_user[:bytes_len])
+            tts_bytes = bytes(self._ch_tts[:bytes_len])
 
-            del self._ch_user_enh[:bytes_len]
-            del self._ch_tts_enh[:bytes_len]
+            del self._ch_user[:bytes_len]
+            del self._ch_tts[:bytes_len]
 
-            self._samples_user_enh -= n_write
-            self._samples_tts_enh -= n_write
+            self._samples_user -= n_write
+            self._samples_tts -= n_write
 
         loop = asyncio.get_running_loop()
 
         def _interleave_and_write(u_b: bytes, t_b: bytes, n_samples: int) -> None:
             u = np.frombuffer(u_b, dtype=np.int16)
             t = np.frombuffer(t_b, dtype=np.int16)
-            # In theory u.size == t.size == n_samples
             inter = np.empty((n_samples * 2,), dtype=np.int16)
             inter[0::2] = u
             inter[1::2] = t
@@ -342,43 +235,10 @@ class RecordingManager(Manager):
             )
         return True
 
-    async def _flush_to_file_raw(self) -> bool:
-        """Flush raw alignment buffers to disk (mirrors enhanced logic)."""
-        async with self._lock:
-            ns_user = self._samples_user_raw
-            ns_tts = self._samples_tts_raw
-            n_write = min(ns_user, ns_tts)
-            if n_write <= 0:
-                return False
-
-            bytes_len = n_write * 2
-            user_bytes = bytes(self._ch_user_raw[:bytes_len])
-            tts_bytes = bytes(self._ch_tts_raw[:bytes_len])
-
-            del self._ch_user_raw[:bytes_len]
-            del self._ch_tts_raw[:bytes_len]
-
-            self._samples_user_raw -= n_write
-            self._samples_tts_raw -= n_write
-
-        loop = asyncio.get_running_loop()
-
-        def _interleave_and_write_raw(u_b: bytes, t_b: bytes, n_samples: int) -> None:
-            u = np.frombuffer(u_b, dtype=np.int16)
-            t = np.frombuffer(t_b, dtype=np.int16)
-            inter = np.empty((n_samples * 2,), dtype=np.int16)
-            inter[0::2] = u
-            inter[1::2] = t
-            self._wf_raw.writeframes(inter.tobytes())
-
-        async with self._io_lock:
-            await loop.run_in_executor(
-                None, _interleave_and_write_raw, user_bytes, tts_bytes, n_write
-            )
-        return True
+    # ==================== Lifecycle ====================
 
     async def shutdown(self) -> None:
-        """Finalize recordings by flushing remaining buffers and closing files."""
+        """Finalize recording by flushing remaining buffers and closing the file."""
         # Stop periodic flush
         if self._flush_task and not self._flush_task.done():
             self._flush_task.cancel()
@@ -388,24 +248,19 @@ class RecordingManager(Manager):
                 pass
             self._flush_task = None
 
-        # Flush aligned chunks first
+        # Final flush
         try:
-            await self._flush_to_file_enh()
-            await self._flush_to_file_raw()
+            await self._flush_to_file()
         except Exception:
             pass
 
-        # Handle any leftover samples (defensive, channels should match)
+        # Handle any leftover samples
         async with self._lock:
-            loop = asyncio.get_running_loop()
-
-            # ---- Enhanced file ----
-            ns_user = self._samples_user_enh
-            ns_tts = self._samples_tts_enh
-            ns = max(ns_user, ns_tts)
+            ns = max(self._samples_user, self._samples_tts)
             if ns > 0:
-                u = np.frombuffer(bytes(self._ch_user_enh), dtype=np.int16)
-                t = np.frombuffer(bytes(self._ch_tts_enh), dtype=np.int16)
+                u = np.frombuffer(bytes(self._ch_user), dtype=np.int16)
+                t = np.frombuffer(bytes(self._ch_tts), dtype=np.int16)
+                # Pad to match lengths
                 if u.size < ns:
                     u = np.concatenate([u, np.zeros((ns - u.size,), dtype=np.int16)])
                 if t.size < ns:
@@ -414,49 +269,24 @@ class RecordingManager(Manager):
                 inter[0::2] = u
                 inter[1::2] = t
 
+                loop = asyncio.get_running_loop()
                 async with self._io_lock:
                     await loop.run_in_executor(
                         None, self._wf.writeframes, inter.tobytes()
                     )
 
-            # Clear enhanced buffers
-            self._ch_user_enh.clear()
-            self._ch_tts_enh.clear()
-            self._samples_user_enh = 0
-            self._samples_tts_enh = 0
+            # Clear buffers
+            self._ch_user.clear()
+            self._ch_tts.clear()
+            self._samples_user = 0
+            self._samples_tts = 0
+            self._pending_tts_chunks.clear()
+            self._timer_user = 0.0
+            self._timer_tts = 0.0
 
-            # ---- Raw file ----
-            ns_user = self._samples_user_raw
-            ns_tts = self._samples_tts_raw
-            ns = max(ns_user, ns_tts)
-            if ns > 0:
-                u = np.frombuffer(bytes(self._ch_user_raw), dtype=np.int16)
-                t = np.frombuffer(bytes(self._ch_tts_raw), dtype=np.int16)
-                if u.size < ns:
-                    u = np.concatenate([u, np.zeros((ns - u.size,), dtype=np.int16)])
-                if t.size < ns:
-                    t = np.concatenate([t, np.zeros((ns - t.size,), dtype=np.int16)])
-                inter = np.empty((ns * 2,), dtype=np.int16)
-                inter[0::2] = u
-                inter[1::2] = t
-
-                async with self._io_lock:
-                    await loop.run_in_executor(
-                        None, self._wf_raw.writeframes, inter.tobytes()
-                    )
-
-            # Clear raw buffers
-            self._ch_user_raw.clear()
-            self._ch_tts_raw.clear()
-            self._samples_user_raw = 0
-            self._samples_tts_raw = 0
-
-        # Close file handles
+        # Close file handle
         try:
             if self._wf is not None:
                 self._wf.close()
-            if self._wf_raw is not None:
-                self._wf_raw.close()
         finally:
             self._wf = None
-            self._wf_raw = None

--- a/src/xtalk/serving/modules/recording_manager.py
+++ b/src/xtalk/serving/modules/recording_manager.py
@@ -33,7 +33,7 @@ from ..events import (
     AudioFrameReceived,
     EnhancedAudioFrameReceived,
     TTSChunkGenerated,
-    TTSChunkPlayedConfirm,
+    TTSChunkPlayed,
     ConversationEnded,
 )
 
@@ -145,8 +145,8 @@ class RecordingManager(Manager):
                 "RecordingManager: failed to cache generated tts chunk: %s", e
             )
 
-    @Manager.event_handler(TTSChunkPlayedConfirm, priority=50)
-    async def _on_tts_chunk_played_confirm(self, event: TTSChunkPlayedConfirm) -> None:
+    @Manager.event_handler(TTSChunkPlayed, priority=50)
+    async def _on_tts_chunk_played_confirm(self, event: TTSChunkPlayed) -> None:
         """
         Commit confirmed TTS chunks to the right channel.
 

--- a/src/xtalk/serving/modules/tts_manager.py
+++ b/src/xtalk/serving/modules/tts_manager.py
@@ -86,9 +86,6 @@ class TTSManager(Manager):
         self.speed_controller = self.pipeline.get_speed_controller()
         self.current_speed: float = 1.0
 
-        # Track chunk indices so the frontend can confirm playback
-        self._chunk_index_counter: int = 0
-
         self._resume_event = asyncio.Event()
         self._resume_event.set()
         self._last_chunk_sent_for_tts = False
@@ -281,15 +278,10 @@ class TTSManager(Manager):
                                     )
                                 )
 
-                            # Generate chunk index for playback confirmation
-                            self._chunk_index_counter += 1
-                            chunk_index = self._chunk_index_counter
-
-                            # Publish to frontend with the chunk index
+                            # Publish to frontend (chunks processed in FIFO order)
                             event = TTSChunkGenerated(
                                 session_id=self.session_id,
                                 audio_chunk=processed_audio,
-                                chunk_index=chunk_index,
                             )
                             # Ensure ordering by waiting for completion
                             await self.event_bus.publish(

--- a/src/xtalk/serving/service.py
+++ b/src/xtalk/serving/service.py
@@ -22,6 +22,7 @@ from .modules.vad_manager import VADManager
 from .modules.enhancer_manager import EnhancerManager
 from .modules.speaker_manager import SpeakerManager
 from .modules.embeddings_manager import EmbeddingsManager
+from .modules.recording_manager import RecordingManager
 from .events import BaseEvent
 from ..pipelines import Pipeline
 from .interfaces import EventListenerMixin, EventOverrides
@@ -265,6 +266,7 @@ class DefaultService(Service):
         EnhancerManager,
         SpeakerManager,
         EmbeddingsManager,
+        RecordingManager,
     ]
 
     def __init__(

--- a/src/xtalk/serving/service_manager.py
+++ b/src/xtalk/serving/service_manager.py
@@ -55,7 +55,9 @@ class ServiceManager:
 
             return True
 
-        logger.warning(f"Attempted to remove non-existent service - session_id: {session_id}")
+        logger.warning(
+            f"Attempted to remove non-existent service - session_id: {session_id}"
+        )
         return False
 
     def get_service(self, session_id: str) -> Optional[Service]:
@@ -86,7 +88,9 @@ class ServiceManager:
                 else:
                     failed_count += 1
             except Exception as e:
-                logger.error(f"Failed to stop service - session_id: {session_id}, error: {e}")
+                logger.error(
+                    f"Failed to stop service - session_id: {session_id}, error: {e}"
+                )
                 failed_count += 1
 
         return success_count

--- a/src/xtalk/speech/vad/__init__.py
+++ b/src/xtalk/speech/vad/__init__.py
@@ -1,0 +1,9 @@
+__all__ = []
+
+# Silero VAD
+try:
+    from .silero_vad import SileroVAD as SileroVAD
+
+    __all__.append("SileroVAD")
+except:
+    pass


### PR DESCRIPTION
## Summary

This PR includes several improvements to the recording system, a new offline test client, and protocol cleanup:

### Recording Manager Improvements
- Simplify RecordingManager to single stereo WAV file with time-based alignment (user audio on left channel, TTS on right)
- Add lazy initialization on first audio frame to avoid initial silence gaps
- Support client-configurable recording paths via `session_config` message
- Make recording opt-in via config flag (disabled by default)
- Fix timing drift issues with accumulated time updates

### New Offline Test Client
- Add `scripts/offline_client.py` for testing server with pre-recorded audio files
- Support directory-based input with `timestamp.txt` for scheduled audio injection
- Support both server-side VAD and client-side VAD modes
- Add `--output` option to specify custom recording path on server

### Protocol Cleanup
- Remove unused conversation start/end protocol (dead code)
- Remove TTS chunk index logic, use FIFO queue order instead
- Rename `TTSChunkPlayedConfirm` to `TTSChunkPlayed` for consistency

### Other Changes
- Add VAD module init with optional SileroVAD export
- Add AI-generated codebase documentation
- Remove debug console.log from waveform drawing

## Test plan
- [x] Run offline client with sample audio directory
- [x] Verify recording produces valid stereo WAV file
- [x] Test client-side VAD mode with `--vad` flag
- [x] Verify session_config message sets custom recording path

🤖 Generated with [Claude Code](https://claude.com/claude-code)