### PR TITLE
feat: add LLM-based turn detection for improved turn-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,17 @@ Below is an example config file for X-Talk when you want to have all models host
             }
         }
     },
-    "speech_speed_controller": "RubberbandSpeedController"
+    "speech_speed_controller": "RubberbandSpeedController",
+    "turn_detector": {
+        "type": "LLMTurnDetector",
+        "params": {
+            "model": {
+                "api_key": "none",
+                "model": "cpatonn/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit",
+                "base_url": "http://127.0.0.1:8000/v1"
+            }
+        }
+    },
 }
 ```
 

--- a/src/xtalk/api.py
+++ b/src/xtalk/api.py
@@ -38,6 +38,7 @@ class Xtalk:
         "vad": ["xtalk.speech.vad"],
         "speech_enhancer": ["xtalk.speech.speech_enhancer"],
         "speech_speed_controller": ["xtalk.speech.speech_speed_controller"],
+        "turn_detector": ["xtalk.speech.turn_detector"],
     }
 
     # Cache for file-path modules to avoid re-importing the same file repeatedly

--- a/src/xtalk/model_types.py
+++ b/src/xtalk/model_types.py
@@ -11,6 +11,7 @@ from .speech import (
     SpeechEnhancer,
     SpeakerEncoder,
     SpeechSpeedController,
+    TurnDetector,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "SpeechEnhancer",
     "SpeakerEncoder",
     "SpeechSpeedController",
+    "TurnDetector",
 ]

--- a/src/xtalk/pipelines/default.py
+++ b/src/xtalk/pipelines/default.py
@@ -18,6 +18,7 @@ from ..speech.interfaces import (
     SpeechEnhancer,
     SpeechSpeedController,
     SpeakerEncoder,
+    TurnDetector,
 )
 from .interfaces import Pipeline, PipelineOutput
 
@@ -81,6 +82,9 @@ class DefaultPipeline(Pipeline):
     embeddings_model: Optional[Embeddings] = field(
         default=None, metadata={"init_key": "embeddings", "clone": False}
     )
+    turn_detector_model: Optional[TurnDetector] = field(
+        default=None, metadata={"init_key": "turn_detector", "clone": True}
+    )
 
     def __init__(
         self,
@@ -98,6 +102,7 @@ class DefaultPipeline(Pipeline):
         speaker_encoder: Optional[SpeakerEncoder] = None,
         speech_speed_controller: Optional[SpeechSpeedController] = None,
         embeddings: Optional[Embeddings] = None,
+        turn_detector: Optional[TurnDetector] = None,
     ):
         # Assign directly to dataclass fields
         self.asr_model = asr
@@ -112,6 +117,7 @@ class DefaultPipeline(Pipeline):
         self.speaker_encoder = speaker_encoder
         self._speed_controller = speech_speed_controller
         self.embeddings_model = embeddings
+        self.turn_detector_model = turn_detector
 
         # Normalize rewriters: BaseChatModel -> Default*Rewriter; Rewriter -> use as-is
         if isinstance(caption_rewriter, BaseChatModel):
@@ -187,6 +193,9 @@ class DefaultPipeline(Pipeline):
 
     def get_embeddings_model(self) -> Embeddings | None:
         return self.embeddings_model
+
+    def get_turn_detector_model(self) -> TurnDetector | None:
+        return self.turn_detector_model
 
     # --------------------------
     # runtime switchers (retain original logic)

--- a/src/xtalk/pipelines/interfaces.py
+++ b/src/xtalk/pipelines/interfaces.py
@@ -13,6 +13,7 @@ from ..speech.interfaces import (
     SpeechEnhancer,
     SpeakerEncoder,
     SpeechSpeedController,
+    TurnDetector,
 )
 from ..rewriter.interfaces import Rewriter
 from ..llm_agent.interfaces import Agent
@@ -157,4 +158,7 @@ class Pipeline(ABC):
         return None
 
     def get_embeddings_model(self) -> Embeddings | None:
+        return None
+
+    def get_turn_detector_model(self) -> TurnDetector | None:
         return None

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -427,7 +427,7 @@ class SessionConfigReceived(BaseEvent):
 
 @dataclass
 class TurnDetectorStopSpeaking(BaseEvent):
-    """Turn detector determined agent should stop speaking."""
+    """Turn detector determined ai should stop speaking."""
 
     TYPE: ClassVar[str] = "turn_detector.stop_speaking"
     semantic: str = ""
@@ -435,7 +435,7 @@ class TurnDetectorStopSpeaking(BaseEvent):
 
 @dataclass
 class TurnDetectorStartGeneration(BaseEvent):
-    """Turn detector determined agent should start generation."""
+    """Turn detector determined ai should start generation."""
 
     TYPE: ClassVar[str] = "turn_detector.start_generation"
     semantic: str = ""

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Dict, Any, Type
 @dataclass
 class BaseEvent:
     """Base dataclass for all xtalk events."""
+
     timestamp: float = field(init=False)
     session_id: str
     TYPE: ClassVar[str] = "base"
@@ -209,11 +210,6 @@ class TTSPlaybackFinished(BaseEvent):
 class VerificationResult(BaseEvent):
     TYPE: ClassVar[str] = "verification.result"
     is_valid: bool = False
-    text: str = ""
-    confidence: float = 0.0
-    reason: str = ""
-    text_length: int = 0
-    chunk_count: int = 0
 
 
 @dataclass

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -420,3 +420,22 @@ class SessionConfigReceived(BaseEvent):
 
     TYPE: ClassVar[str] = "session.config_received"
     recording_path: str | None = None
+
+
+# ==================== Turn Detection Events ====================
+
+
+@dataclass
+class TurnDetectorStopSpeaking(BaseEvent):
+    """Turn detector determined agent should stop speaking."""
+
+    TYPE: ClassVar[str] = "turn_detector.stop_speaking"
+    semantic: str = ""
+
+
+@dataclass
+class TurnDetectorStartGeneration(BaseEvent):
+    """Turn detector determined agent should start generation."""
+
+    TYPE: ClassVar[str] = "turn_detector.start_generation"
+    semantic: str = ""

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -77,19 +77,21 @@ class VADSpeechEnd(BaseEvent):
     speech_probability: float = 0.0
 
 
-# TODO: remove unused fields and remove turn id?
+# TODO: remove unused fields
 @dataclass
 class ASRResultPartial(BaseEvent):
     TYPE: ClassVar[str] = "asr.result_partial"
     text: str = ""
     confidence: float = 0.0
-    is_final: bool = False
+    # Indicates whether user has a pause on his speech (often triggered by VAD end)
+    speech_pause: bool = False
     display_text: str = ""  # Cleaned text for frontend display
     turn_id: int = 0
 
 
 @dataclass
 class ASRResultFinal(BaseEvent):
+    # Emit when ready for generation
     TYPE: ClassVar[str] = "asr.result_final"
     text: str = ""
     confidence: float = 0.0

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -198,6 +198,7 @@ class TTSPlaybackFinished(BaseEvent):
     TYPE: ClassVar[str] = "tts.playback_finished"
 
 
+# TODO: remove this event and its related logic on frontend
 @dataclass
 class VerificationResult(BaseEvent):
     TYPE: ClassVar[str] = "verification.result"

--- a/src/xtalk/serving/modules/asr_manager.py
+++ b/src/xtalk/serving/modules/asr_manager.py
@@ -28,7 +28,7 @@ from ..events import (
 )
 from ..interfaces import Manager
 from ...pipelines import Pipeline
-from ...speech.interfaces import TurnType
+from ...speech.interfaces import TurnDetectionAction
 
 
 @dataclass
@@ -308,7 +308,7 @@ class ASRManager(Manager):
             # Remove last punctuation
             text = text[:-1] if unicodedata.category(text[-1]).startswith("P") else text
             detection_result = self.turn_detector_model.detect(audio=None, text=text)
-            if detection_result == TurnType.COMPLETE:
+            if detection_result == TurnDetectionAction.COMPLETE:
                 validation_result["is_valid"] = True
             return validation_result
 

--- a/src/xtalk/serving/modules/asr_manager.py
+++ b/src/xtalk/serving/modules/asr_manager.py
@@ -108,7 +108,7 @@ class ASRManager(Manager):
             self.config.get("semantic_timeout_sec", 0.5)
         )
         # turn
-        self._turn_id = 0
+        self._turn_id = 1
         # Sentence-ending punctuation list
         self._seg_punct = "，,。．.!！?？;；:：\n"
         # Segment throttle threshold (ms)
@@ -202,9 +202,6 @@ class ASRManager(Manager):
                 self.audio_buffer.append(item)
             # Clear once moved to avoid reusing old frames next turn
             self.pre_buffer.clear()
-
-        # Increment turn id
-        self._turn_id += 1
 
     @Manager.event_handler(
         TurnASREndRequested,
@@ -407,6 +404,8 @@ class ASRManager(Manager):
                     semantic_tag=semantic_tag,
                     wait_for_completion=True,
                 )
+                # Increment turn id
+                self._turn_id += 1
                 await self._cancel_semantic_timeout()
 
     async def _start_consumer(self) -> None:

--- a/src/xtalk/serving/modules/asr_manager.py
+++ b/src/xtalk/serving/modules/asr_manager.py
@@ -77,6 +77,9 @@ class AudioConsumer:
         self._asr_model = pipeline.get_asr_model()
         self._asr_model.reset()
         self._session_id = session_id
+        # Flag to avoid repeat pause or end
+        self._ended = True
+        self._paused = False
         # Cache for recognition used in _recognize_and_publish
         self._recognized_text = ""
         # Assume PCM 16bit mono
@@ -106,12 +109,22 @@ class AudioConsumer:
         # Pump pre-buffer to recognition queue; start consumer
         # Break start-once invariance warning
         if self._consumer_running():
-            logger.warning(f"AudioConsumer started repeatedly")
-        await self._audio_queue.put(await self._pre_buffer.get())
+            logger.warning(f"AudioConsumer started repeatedly; do early return")
+            return
+        self._ended = False
+        self._paused = False
         self._start_consumer()
+        await self._audio_queue.put(await self._pre_buffer.get())
 
     async def pause(self):
         # Stop consumer, do one recognition and publish
+        # Break pause-once invariance warning
+        if self._paused or self._ended:
+            logger.warning(
+                f"AudioConsumer paused repeatedly/pause after end; do early return"
+            )
+            return
+        self._paused = True
         await self._stop_consumer()
         audio = await self._audio_queue.get()
         # Sentence end but not end of recognition
@@ -119,6 +132,11 @@ class AudioConsumer:
 
     async def end(self):
         # Stop consumer, do one recognition, publish ASRResultFinal, clean up states (including reset ASR) and increment turn
+        # Break stop-once invariance warning
+        if self._ended:
+            logger.warning(f"AudioConsumer ended repeatedly; do early return")
+            return
+        self._ended = True
         await self._stop_consumer()
         audio = await self._audio_queue.get()
         await self._recognize_and_publish(audio, is_asr_end=True, is_final_chunk=True)
@@ -166,7 +184,8 @@ class AudioConsumer:
     async def _recognize_and_publish(
         self, audio: bytes, is_asr_end: bool = False, is_final_chunk: bool = False
     ):
-        # Do ASR recognition once and publish result ASRResultPartal/Final based on is_asr_end; if not final, may use cache to determine whether to publish
+        # Do ASR recognition once and publish result ASRResultPartal/Final based on is_asr_end; if not final, may use cache to determine whether to publish;
+        # is_final_chunk means whether user has a pause on his speech, passed on to ASRResultPartial
         if is_asr_end and not is_final_chunk:
             raise ValueError("ASR ends but chunk is not final chunk")
         recognized_text = self._recognized_text
@@ -186,7 +205,7 @@ class AudioConsumer:
                 )
             )
         else:
-            if recognized_text == self._recognized_text:
+            if recognized_text == self._recognized_text and not is_final_chunk:
                 return
             self._recognized_text = recognized_text
             await self._publish_event(
@@ -195,6 +214,7 @@ class AudioConsumer:
                     text=recognized_text,
                     display_text=recognized_text,
                     turn_id=self._turn_id,
+                    speech_pause=is_final_chunk,
                 )
             )
 

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -28,7 +28,7 @@ from ..events import (
     TurnDetectorStartGeneration,
 )
 from ...pipelines import Pipeline
-from ...speech.interfaces import TurnDetectionAction
+from ...speech.interfaces import TurnDetectionAction, TurnDetectionResult
 
 
 class TurnDetectorManager(Manager):
@@ -84,9 +84,7 @@ class TurnDetectorManager(Manager):
             await self._handle_detection_result(result)
 
         except Exception as e:
-            logger.error(
-                "[TurnDetectorManager] ASR partial processing failed: %s", e
-            )
+            logger.error("[TurnDetectorManager] ASR partial processing failed: %s", e)
 
     @Manager.event_handler(ASRResultFinal)
     async def _on_asr_final(self, event: ASRResultFinal) -> None:
@@ -106,7 +104,7 @@ class TurnDetectorManager(Manager):
         except Exception as e:
             logger.error("[TurnDetectorManager] ASR final processing failed: %s", e)
 
-    async def _handle_detection_result(self, result) -> None:
+    async def _handle_detection_result(self, result: TurnDetectionResult) -> None:
         """Handle turn detection result and emit appropriate events."""
         if result.action == TurnDetectionAction.STOP_SPEAKING:
             evt = TurnDetectorStopSpeaking(

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""
+TurnDetectorManager
+
+Manages turn detection by processing audio and ASR results through the TurnDetector.
+Subscribes to:
+- EnhancedAudioFrameReceived: feeds audio to turn detector
+- ASRResultPartial/ASRResultFinal: feeds text and finality to turn detector
+
+Emits:
+- TurnDetectorStopSpeaking: when action is STOP_SPEAKING
+- TurnDetectorStartGeneration: when action is START_GENERATION
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Any
+
+from ...log_utils import logger
+
+from ..event_bus import EventBus
+from ..interfaces import Manager
+from ..events import (
+    EnhancedAudioFrameReceived,
+    ASRResultPartial,
+    ASRResultFinal,
+    TurnDetectorStopSpeaking,
+    TurnDetectorStartGeneration,
+)
+from ...pipelines import Pipeline
+from ...speech.interfaces import TurnDetectionAction
+
+
+class TurnDetectorManager(Manager):
+    """Manager for turn detection processing."""
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        session_id: str,
+        pipeline: Pipeline,
+        config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.event_bus = event_bus
+        self.session_id = session_id
+        self.pipeline = pipeline
+        self.config: dict[str, Any] = config or {}
+
+        # Get turn detector from pipeline
+        self.turn_detector = self.pipeline.get_turn_detector_model()
+
+    # ----------------------------
+    # Event handling
+    # ----------------------------
+    @Manager.event_handler(EnhancedAudioFrameReceived)
+    async def _on_audio_frame(self, event: EnhancedAudioFrameReceived) -> None:
+        """Process audio frames through turn detector."""
+        try:
+            if self.turn_detector is None:
+                return
+
+            if not event.audio_data:
+                return
+
+            result = await self.turn_detector.async_detect(audio=event.audio_data)
+            await self._handle_detection_result(result)
+
+        except Exception as e:
+            logger.error("[TurnDetectorManager] audio frame processing failed: %s", e)
+
+    @Manager.event_handler(ASRResultPartial)
+    async def _on_asr_partial(self, event: ASRResultPartial) -> None:
+        """Process partial ASR results through turn detector."""
+        try:
+            if self.turn_detector is None:
+                return
+
+            if not event.text:
+                return
+
+            result = await self.turn_detector.async_detect(
+                text=event.text, asr_final=False
+            )
+            await self._handle_detection_result(result)
+
+        except Exception as e:
+            logger.error(
+                "[TurnDetectorManager] ASR partial processing failed: %s", e
+            )
+
+    @Manager.event_handler(ASRResultFinal)
+    async def _on_asr_final(self, event: ASRResultFinal) -> None:
+        """Process final ASR results through turn detector."""
+        try:
+            if self.turn_detector is None:
+                return
+
+            if not event.text:
+                return
+
+            result = await self.turn_detector.async_detect(
+                text=event.text, asr_final=True
+            )
+            await self._handle_detection_result(result)
+
+        except Exception as e:
+            logger.error("[TurnDetectorManager] ASR final processing failed: %s", e)
+
+    async def _handle_detection_result(self, result) -> None:
+        """Handle turn detection result and emit appropriate events."""
+        if result.action == TurnDetectionAction.STOP_SPEAKING:
+            evt = TurnDetectorStopSpeaking(
+                session_id=self.session_id, semantic=result.semantic.value
+            )
+            await self.event_bus.publish(evt)
+        elif result.action == TurnDetectionAction.START_GENERATION:
+            evt = TurnDetectorStartGeneration(
+                session_id=self.session_id, semantic=result.semantic.value
+            )
+            await self.event_bus.publish(evt)
+        # DO_NOTHING requires no action
+
+    # ----------------------------
+    # Lifecycle
+    # ----------------------------
+    async def shutdown(self) -> None:  # type: ignore[override]
+        """No-op shutdown hook."""
+        return None

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -5,7 +5,7 @@ TurnDetectorManager
 Manages turn detection by processing audio and ASR results through the TurnDetector.
 Subscribes to:
 - EnhancedAudioFrameReceived: feeds audio to turn detector
-- ASRResultPartial/ASRResultFinal: feeds text and finality to turn detector
+- ASRResultPartial: feeds text to turn detector
 
 Emits:
 - TurnDetectorStopSpeaking: when action is STOP_SPEAKING
@@ -23,7 +23,6 @@ from ..interfaces import Manager
 from ..events import (
     EnhancedAudioFrameReceived,
     ASRResultPartial,
-    ASRResultFinal,
     TurnDetectorStopSpeaking,
     TurnDetectorStartGeneration,
 )
@@ -85,24 +84,6 @@ class TurnDetectorManager(Manager):
 
         except Exception as e:
             logger.error("[TurnDetectorManager] ASR partial processing failed: %s", e)
-
-    @Manager.event_handler(ASRResultFinal)
-    async def _on_asr_final(self, event: ASRResultFinal) -> None:
-        """Process final ASR results through turn detector."""
-        try:
-            if self.turn_detector is None:
-                return
-
-            if not event.text:
-                return
-
-            result = await self.turn_detector.async_detect(
-                text=event.text, asr_final=True
-            )
-            await self._handle_detection_result(result)
-
-        except Exception as e:
-            logger.error("[TurnDetectorManager] ASR final processing failed: %s", e)
 
     async def _handle_detection_result(self, result: TurnDetectionResult) -> None:
         """Handle turn detection result and emit appropriate events."""

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -85,18 +85,23 @@ class TurnDetectorManager(Manager):
         except Exception as e:
             logger.error("[TurnDetectorManager] ASR partial processing failed: %s", e)
 
-    async def _handle_detection_result(self, result: TurnDetectionResult) -> None:
+    async def _handle_detection_result(
+        self, result: TurnDetectionResult | list[TurnDetectionResult]
+    ) -> None:
         """Handle turn detection result and emit appropriate events."""
-        if result.action == TurnDetectionAction.STOP_SPEAKING:
-            evt = TurnDetectorStopSpeaking(
-                session_id=self.session_id, semantic=result.semantic.value
-            )
-            await self.event_bus.publish(evt)
-        elif result.action == TurnDetectionAction.START_GENERATION:
-            evt = TurnDetectorStartGeneration(
-                session_id=self.session_id, semantic=result.semantic.value
-            )
-            await self.event_bus.publish(evt)
+        if not isinstance(result, list):
+            result = [result]
+        for item in result:
+            if item.action == TurnDetectionAction.STOP_SPEAKING:
+                evt = TurnDetectorStopSpeaking(
+                    session_id=self.session_id, semantic=item.semantic.value
+                )
+                await self.event_bus.publish(evt)
+            elif item.action == TurnDetectionAction.START_GENERATION:
+                evt = TurnDetectorStartGeneration(
+                    session_id=self.session_id, semantic=item.semantic.value
+                )
+                await self.event_bus.publish(evt)
         # DO_NOTHING requires no action
 
     # ----------------------------

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -78,7 +78,7 @@ class TurnDetectorManager(Manager):
                 return
 
             result = await self.turn_detector.async_detect(
-                text=event.text, asr_final=False
+                text=event.text, speech_pause=event.speech_pause
             )
             await self._handle_detection_result(result)
 

--- a/src/xtalk/serving/modules/turn_taking_manager.py
+++ b/src/xtalk/serving/modules/turn_taking_manager.py
@@ -23,14 +23,15 @@ class TurnTakingManager(Manager):
         self.event_bus = event_bus
         self.session_id = session_id
 
-    @Manager.event_handler(TurnDetectorStartGeneration)
+    @Manager.event_handler(TurnDetectorStartGeneration, priority=99)
     async def _on_turn_detector_start_generation(
         self, event: TurnDetectorStartGeneration
     ):
         # TODO: utilize event.semantic
         await self.event_bus.publish(TurnASREndRequested(session_id=self.session_id))
 
-    @Manager.event_handler(TurnDetectorStopSpeaking)
+    # Stop speaking must be handled before starting generation
+    @Manager.event_handler(TurnDetectorStopSpeaking, priority=100)
     async def _on_turn_detector_stop_speaking(self, event: TurnDetectorStopSpeaking):
         # TODO: utilize event.semantic
         await self.event_bus.publish(

--- a/src/xtalk/serving/modules/turn_taking_manager.py
+++ b/src/xtalk/serving/modules/turn_taking_manager.py
@@ -7,7 +7,10 @@ from ..events import (
     TurnLLMAgentStartRequested,
     TurnLLMAgentStopRequested,
     TurnASRStartRequested,
+    TurnASRPauseRequested,
     TurnASREndRequested,
+    TurnDetectorStartGeneration,
+    TurnDetectorStopSpeaking,
     ASRResultFinal,
     TTSPlaybackFinished,
 )
@@ -20,23 +23,32 @@ class TurnTakingManager(Manager):
         self.event_bus = event_bus
         self.session_id = session_id
 
-    @Manager.event_handler(VADSpeechStart)
-    async def _on_vad_start(self, _event: VADSpeechStart):
-        """VAD start: stop LLM and notify ASR to start."""
-        # TODO: introduce turn detection to handle llm agent pause/stop
+    @Manager.event_handler(TurnDetectorStartGeneration)
+    async def _on_turn_detector_start_generation(
+        self, event: TurnDetectorStartGeneration
+    ):
+        # TODO: utilize event.semantic
+        await self.event_bus.publish(TurnASREndRequested(session_id=self.session_id))
+
+    @Manager.event_handler(TurnDetectorStopSpeaking)
+    async def _on_turn_detector_stop_speaking(self, event: TurnDetectorStopSpeaking):
+        # TODO: utilize event.semantic
         await self.event_bus.publish(
             TurnLLMAgentStopRequested(
                 session_id=self.session_id,
             ),
             wait_for_completion=True,
         )
+
+    @Manager.event_handler(VADSpeechStart)
+    async def _on_vad_start(self, _event: VADSpeechStart):
+        """VAD start: stop LLM and notify ASR to start."""
         await self.event_bus.publish(TurnASRStartRequested(session_id=self.session_id))
 
     @Manager.event_handler(VADSpeechEnd)
     async def _on_vad_end(self, _event: VADSpeechEnd):
         """VAD end: finalize the turn."""
-        # TODO: introduce turn detection to signal turn ASR end; here only signals TurnASRPause
-        await self.event_bus.publish(TurnASREndRequested(session_id=self.session_id))
+        await self.event_bus.publish(TurnASRPauseRequested(session_id=self.session_id))
 
     @Manager.event_handler(ASRResultFinal)
     async def _on_asr_final(self, event: ASRResultFinal):

--- a/src/xtalk/serving/service.py
+++ b/src/xtalk/serving/service.py
@@ -23,6 +23,7 @@ from .modules.enhancer_manager import EnhancerManager
 from .modules.speaker_manager import SpeakerManager
 from .modules.embeddings_manager import EmbeddingsManager
 from .modules.recording_manager import RecordingManager
+from .modules.turn_detector_manager import TurnDetectorManager
 from .events import BaseEvent
 from ..pipelines import Pipeline
 from .interfaces import EventListenerMixin, EventOverrides
@@ -267,6 +268,7 @@ class DefaultService(Service):
         SpeakerManager,
         EmbeddingsManager,
         RecordingManager,
+        TurnDetectorManager,
     ]
 
     def __init__(

--- a/src/xtalk/speech/__init__.py
+++ b/src/xtalk/speech/__init__.py
@@ -7,6 +7,7 @@ from .interfaces import (
     SpeechEnhancer,
     SpeakerEncoder,
     SpeechSpeedController,
+    TurnDetector,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "SpeechEnhancer",
     "SpeakerEncoder",
     "SpeechSpeedController",
+    "TurnDetector",
 ]

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -394,19 +394,37 @@ class TurnDetectionResult:
 class TurnDetector(ABC):
     @abstractmethod
     def detect(
-        self, audio: Optional[bytes] = None, text: Optional[str] = None
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        asr_final: Optional[bool] = None,
     ) -> TurnDetectionResult:
         """
         Detect turn with audio and/or text.
 
         Args:
             audio (bytes): Audio data frame at this instant. PCM 16bit mono, 16000Hz bytes.
-            text: Text of the turn
+            text: Text of the turn, from ASR result.
+            asr_final: Whether text is ASR final result, or still partial recognition.
+
+            Either audio or (text, asr_final) will be present.
 
         Returns:
             TurnDetectionResult
         """
         pass
+
+    async def async_detect(
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        asr_final: Optional[bool] = None,
+    ) -> TurnDetectionResult:
+        """Async wrapper for detect()."""
+        loop = asyncio.get_running_loop()
+        func = partial(self.detect, audio=audio, text=text, asr_final=asr_final)
+        result: TurnDetectionResult = await loop.run_in_executor(None, func)
+        return result
 
     @abstractmethod
     def clone(self) -> "TurnDetector":

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -1,8 +1,9 @@
 from abc import abstractmethod, ABC
-from typing import Iterable, AsyncIterator, Any
+from typing import Iterable, AsyncIterator, Any, Optional
 import numpy as np
 import asyncio
 from functools import partial
+from enum import Enum
 from .utils import MockStreamRecognizer
 
 
@@ -367,3 +368,31 @@ class SpeechSpeedController(ABC):
         return await loop.run_in_executor(
             None, lambda: self.process(audio_bytes, speed)
         )
+
+
+class TurnType(Enum):
+    COMPLETE = 1  # user finished speaking
+    INCOMPLETE = 2  # user not finished speaking
+    BACKCHANNEL = 3  # user is chiming in
+
+
+class TurnDetector(ABC):
+    @abstractmethod
+    def detect(
+        self, audio: Optional[bytes] = None, text: Optional[str] = None
+    ) -> TurnType:
+        """
+        Detect turn with audio and/or text.
+
+        Args:
+            audio (bytes): The audio data of the turn. PCM 16bit mono, 16000Hz bytes.
+            text: Text of the turn
+
+        Returns:
+            TurnType
+        """
+        pass
+
+    @abstractmethod
+    def clone(self) -> "TurnDetector":
+        pass

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -4,6 +4,7 @@ import numpy as np
 import asyncio
 from functools import partial
 from enum import Enum
+from dataclasses import dataclass
 from .utils import MockStreamRecognizer
 
 
@@ -370,26 +371,40 @@ class SpeechSpeedController(ABC):
         )
 
 
-class TurnType(Enum):
-    COMPLETE = 1  # user finished speaking
-    INCOMPLETE = 2  # user not finished speaking
-    BACKCHANNEL = 3  # user is chiming in
+class TurnDetectionAction(Enum):
+    DO_NOTHING = 1
+    STOP_SPEAKING = 2
+    START_GENERATION = 3
+
+
+class TurnDetectionSemantic(Enum):
+    IDLE = "idle"
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"
+    WAIT = "wait"
+    BACKCHANNEL = "backchannel"
+
+
+@dataclass(frozen=True)
+class TurnDetectionResult:
+    action: TurnDetectionAction
+    semantic: TurnDetectionSemantic
 
 
 class TurnDetector(ABC):
     @abstractmethod
     def detect(
         self, audio: Optional[bytes] = None, text: Optional[str] = None
-    ) -> TurnType:
+    ) -> TurnDetectionResult:
         """
         Detect turn with audio and/or text.
 
         Args:
-            audio (bytes): The audio data of the turn. PCM 16bit mono, 16000Hz bytes.
+            audio (bytes): Audio data frame at this instant. PCM 16bit mono, 16000Hz bytes.
             text: Text of the turn
 
         Returns:
-            TurnType
+            TurnDetectionResult
         """
         pass
 

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -399,6 +399,7 @@ class TurnDetector(ABC):
         self,
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
+        speech_pause: Optional[bool] = None,
     ) -> TurnDetectionResult:
         """
         Detect turn with audio and/or text.
@@ -406,8 +407,9 @@ class TurnDetector(ABC):
         Args:
             audio (bytes): Audio data frame at this instant. PCM 16bit mono, 16000Hz bytes.
             text: Text of the turn, from ASR result.
+            speech_pause: indicates whether user has a pause on his speech (often triggered by VAD end); only sent alongside text
 
-            Either audio or text will be present.
+            Either audio or (text, speech_pause) will be present.
 
         Returns:
             TurnDetectionResult
@@ -418,10 +420,11 @@ class TurnDetector(ABC):
         self,
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
+        speech_pause: Optional[bool] = None,
     ) -> TurnDetectionResult:
         """Async wrapper for detect()."""
         loop = asyncio.get_running_loop()
-        func = partial(self.detect, audio=audio, text=text)
+        func = partial(self.detect, audio=audio, text=text, speech_pause=speech_pause)
         result: TurnDetectionResult = await loop.run_in_executor(None, func)
         return result
 

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -399,7 +399,6 @@ class TurnDetector(ABC):
         self,
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
-        asr_final: Optional[bool] = None,
     ) -> TurnDetectionResult:
         """
         Detect turn with audio and/or text.
@@ -407,9 +406,8 @@ class TurnDetector(ABC):
         Args:
             audio (bytes): Audio data frame at this instant. PCM 16bit mono, 16000Hz bytes.
             text: Text of the turn, from ASR result.
-            asr_final: Whether text is ASR final result, or still partial recognition.
 
-            Either audio or (text, asr_final) will be present.
+            Either audio or text will be present.
 
         Returns:
             TurnDetectionResult
@@ -420,11 +418,10 @@ class TurnDetector(ABC):
         self,
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
-        asr_final: Optional[bool] = None,
     ) -> TurnDetectionResult:
         """Async wrapper for detect()."""
         loop = asyncio.get_running_loop()
-        func = partial(self.detect, audio=audio, text=text, asr_final=asr_final)
+        func = partial(self.detect, audio=audio, text=text)
         result: TurnDetectionResult = await loop.run_in_executor(None, func)
         return result
 

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -400,7 +400,7 @@ class TurnDetector(ABC):
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult:
+    ) -> TurnDetectionResult | list[TurnDetectionResult]:
         """
         Detect turn with audio and/or text.
 
@@ -412,7 +412,7 @@ class TurnDetector(ABC):
             Either audio or (text, speech_pause) will be present.
 
         Returns:
-            TurnDetectionResult
+            TurnDetectionResult | list[TurnDetectionResult]; STOP_SPEAKING action will be processed before START_GENERATION
         """
         pass
 
@@ -421,11 +421,13 @@ class TurnDetector(ABC):
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult:
+    ) -> TurnDetectionResult | list[TurnDetectionResult]:
         """Async wrapper for detect()."""
         loop = asyncio.get_running_loop()
         func = partial(self.detect, audio=audio, text=text, speech_pause=speech_pause)
-        result: TurnDetectionResult = await loop.run_in_executor(None, func)
+        result: TurnDetectionResult | list[TurnDetectionResult] = (
+            await loop.run_in_executor(None, func)
+        )
         return result
 
     @abstractmethod

--- a/src/xtalk/speech/turn_detector/__init__.py
+++ b/src/xtalk/speech/turn_detector/__init__.py
@@ -1,0 +1,3 @@
+from .llm_turn_detector import LLMTurnDetector
+
+__all__ = ["LLMTurnDetector"]

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -1,4 +1,4 @@
-from ..interfaces import TurnDetector, TurnType
+from ..interfaces import TurnDetector, TurnDetectionAction
 from langchain_openai import ChatOpenAI
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -39,7 +39,7 @@ User: "yes, exactly" *(no further action implied)* → backchannel
     def clone(self) -> "TurnDetector":
         return LLMTurnDetector(self._model)
 
-    def detect(self, audio=None, text=None) -> TurnType:
+    def detect(self, audio=None, text=None) -> TurnDetectionAction:
         if not text:
             raise RuntimeError("Text for LLMTurnDetector should not be empty")
         messages: List = [
@@ -48,8 +48,8 @@ User: "yes, exactly" *(no further action implied)* → backchannel
         ]
         response = self._model.invoke(messages).content
         if "backchannel" in response.lower():
-            return TurnType.BACKCHANNEL
+            return TurnDetectionAction.BACKCHANNEL
         elif "incomplete" in response.lower():
-            return TurnType.INCOMPLETE
+            return TurnDetectionAction.INCOMPLETE
         else:
-            return TurnType.COMPLETE
+            return TurnDetectionAction.COMPLETE

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -4,6 +4,7 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 
 
+# TODO: re-implement
 class LLMTurnDetector(TurnDetector):
     SYSTEM_PROMPT = """Classify user input as ["complete", "incomplete", "backchannel"].
 

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -1,0 +1,55 @@
+from ..interfaces import TurnDetector, TurnType
+from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+
+
+class LLMTurnDetector(TurnDetector):
+    SYSTEM_PROMPT = """Classify user input as ["complete", "incomplete", "backchannel"].
+
+You are a classifier in a spoken dialogue system. Your task is to label each single user message based on whether it requires a model response.
+
+### Labeling Rules
+- **complete**: The message contains a clear question, instruction, or statement that should receive a meaningful model response immediately.
+- **incomplete**: The message is truncated, ambiguous, missing critical information, or is part of ongoing input where the model should wait instead of responding now.
+- **backchannel**: The message is a short feedback signal used only to maintain conversational flow (e.g., "yeah", "uh-huh", "right"), carries no primary intent, and does not require a model response.
+
+### Constraints
+- Classify the message itself only, not the surrounding context.
+- Output **one label only**.
+- Do not generate any explanation, only return the label string.
+- Be robust to casual speech, fillers, and interruptions.
+- Treat acknowledgements without actionable intent as backchannel.
+- Treat actionable or reply-worthy content as complete, even if it does not finish a multi-step task.
+
+### Examples
+User: "How do I rename a git branch?" → complete  
+User: "I was thinking the architecture could maybe use…" → incomplete  
+User: "uh-huh" → backchannel  
+User: "Deploy it to Windows, Linux, and macOS." → complete  
+User: "vLLM needs to load the model from…" *(stops mid-sentence)* → incomplete  
+User: "yes, exactly" *(no further action implied)* → backchannel
+"""
+
+    def __init__(self, model: dict | BaseChatModel) -> None:
+        if isinstance(model, dict):
+            model = ChatOpenAI(**model)
+        self._model = model
+
+    def clone(self) -> "TurnDetector":
+        return LLMTurnDetector(self._model)
+
+    def detect(self, audio=None, text=None) -> TurnType:
+        if not text:
+            raise RuntimeError("Text for LLMTurnDetector should not be empty")
+        messages: List = [
+            SystemMessage(content=self.SYSTEM_PROMPT),
+            HumanMessage(content=text),
+        ]
+        response = self._model.invoke(messages).content
+        if "backchannel" in response.lower():
+            return TurnType.BACKCHANNEL
+        elif "incomplete" in response.lower():
+            return TurnType.INCOMPLETE
+        else:
+            return TurnType.COMPLETE

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -72,31 +72,48 @@ Return **only** the label string.
 
 ### 1) **wait**
 
-Choose **wait** if the transcript contains an explicit pause/hold request, e.g.:
+Choose **wait** only if the utterance is a **pure pause/hold request** — i.e., the transcript contains a pause/hold phrase and **does NOT contain any additional meaningful/semantic content after it**.
 
+**Pause/hold keywords examples:**
 * English: “wait”, “hold on”, “hang on”, “one sec/second”, “a moment”, “give me a second”, “pause”, “let me think”
 * Chinese: “等一下/等等/稍等/先别说/先停一下/给我一分钟/我想一下”
-* Any variant like “stop, wait” where the intent is to pause the assistant
 
-If “wait” is present but clearly means something else (rare), follow the other rules.
+#### Semantic continuation override (CRITICAL)
+
+If a pause/hold phrase appears but the user continues with **any concrete semantic information afterwards**, **do NOT output `wait`**. Instead, proceed to rules **2) incomplete** and **3) complete** to classify the utterance as a whole.
+
+**What counts as “concrete semantic information” (any of these):**
+* A **question** or interrogative cue: “怎么/为什么/能不能/what/how/why…”
+* A **command/request**: “帮我…/给我…/打开…/explain…/do…”
+* A **statement with content words** (not just fillers), e.g. mentions objects/actions/names/numbers:
+  * “等一下，我要找一下文件”
+  * “等一下，刚才那个接口的报错是 403”
+  * “等一下，我的意思是你先改这段逻辑”
+* Any continuation markers with real content: “然后…/其实…/我的意思是…/就是说…/I mean…/actually…”
+
+**What does NOT count as semantic continuation (still `wait`-eligible):**
+Only short fillers/politeness/acknowledgements after the pause phrase, such as:
+* Chinese: “嗯/啊/哦/好/行/可以/谢谢/让我想想(仅此一句且没有别的内容)”
+* English: “uh/um/okay/yeah/sure/thanks/let me think (and nothing else)”
+
+**Tie-break inside Rule 1:**
+* If pause/hold phrase is present **and** there is **no semantic continuation** → output **`wait`**.
+* If pause/hold phrase is present **but** there **is semantic continuation** → **NOT `wait`**, go to rules 2–3.
 
 ### 2) **incomplete**
 
 Choose **incomplete** if **any** of these are true:
 
 **A. Truncation / cut-off indicators**
-
 * Transcript ends with unfinished connectors: “and”, “so”, “but”, “because”, “if”, “then”, “like”, “which”, “that...”
 * Ends with filler or restart signals: “uh”, “um”, “er”, “I mean”, “well...”, “你知道”, “就是”, “然后...”
 * Ends with a dangling preposition/article: “to”, “with”, “for”, “a/an/the”, “的/了/在/把” (when clearly hanging)
 
 **B. Mid-thought structure**
-
 * Starts a clause but doesn't complete it: “I want to...”, “Can you...”, “Let's...”, “Could we...”, “我想.../能不能.../我们...”
 * Contains self-correction or continuation cues without finishing: “no—”, “actually—”, “wait— I mean—”, “不是...我是说...”
 
 **C. ASR partialness signs**
-
 * Very short fragment that looks like a partial start (1-3 content words) and not a full intent, e.g. “so the...”, “about the...”, “那个...”, “就是...”
 * Strong repetition/restarts: “I I I...”, “we we...”, “我我我...”
 
@@ -117,7 +134,7 @@ Choose **complete** if neither of the above applies and the utterance forms a co
 
 ## Output format
 
-Return only the label string with no extra text.    
+Return only the label string with no extra text.
 """
     CHECK_COMPLETION_PROMPT = """You are a real-time speech-UI classifier. Given an ASR transcript of what the user just said (may be partial, noisy, or cut off), classify whether the user's utterance is:
 

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -119,6 +119,49 @@ Choose **complete** if neither of the above applies and the utterance forms a co
 
 Return only the label string with no extra text.    
 """
+    CHECK_COMPLETION_PROMPT = """You are a real-time speech-UI classifier. Given an ASR transcript of what the user just said (may be partial, noisy, or cut off), classify whether the user's utterance is:
+
+* **incomplete**: the user is still speaking / the thought is unfinished, or ASR looks truncated.
+* **complete**: the user finished a coherent utterance (question/command/statement) and is yielding the floor.
+
+### 1) **incomplete**
+
+Choose **incomplete** if **any** of these are true:
+
+**A. Truncation / cut-off indicators**
+
+* Transcript ends with unfinished connectors: “and”, “so”, “but”, “because”, “if”, “then”, “like”, “which”, “that...”
+* Ends with filler or restart signals: “uh”, “um”, “er”, “I mean”, “well...”, “你知道”, “就是”, “然后...”
+* Ends with a dangling preposition/article: “to”, “with”, “for”, “a/an/the”, “的/了/在/把” (when clearly hanging)
+
+**B. Mid-thought structure**
+
+* Starts a clause but doesn't complete it: “I want to...”, “Can you...”, “Let's...”, “Could we...”, “我想.../能不能.../我们...”
+* Contains self-correction or continuation cues without finishing: “no—”, “actually—”, “wait— I mean—”, “不是...我是说...”
+
+**C. ASR partialness signs**
+
+* Very short fragment that looks like a partial start (1-3 content words) and not a full intent, e.g. “so the...”, “about the...”, “那个...”, “就是...”
+* Strong repetition/restarts: “I I I...”, “we we...”, “我我我...”
+
+### 2) **complete**
+
+Choose **complete** if neither of the above applies and the utterance forms a complete communicative unit, e.g.:
+
+* A full question: ends naturally or with “?”, has an interrogative (“what/why/how/能不能/怎么”)
+* A full command/request: “Open X”, “Explain Y”, “帮我把...”
+* A complete statement: “I'm done”, “That's fine”, “We should do A first”
+* Even if short, it clearly conveys a finished intent: “yes”, “no”, “okay”, “got it”, “不用了”, “可以”
+
+## Tie-breakers
+
+* If the transcript ends with a period-like finality (or clear completion) vs. a dangling connector, prefer **complete**.
+* If it includes both acknowledgement and a new clause starter (e.g., “yeah but...”, “好的然后...”), choose **incomplete** unless it clearly finishes.
+
+## Output format
+
+Return only the label string with no extra text.
+"""
 
     def __init__(self, model: dict | BaseChatModel) -> None:
         if isinstance(model, dict):
@@ -138,7 +181,7 @@ Return only the label string with no extra text.
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult:
+    ) -> TurnDetectionResult | list[TurnDetectionResult]:
         return asyncio.run(self.async_detect(audio, text, speech_pause))
 
     async def async_detect(
@@ -146,7 +189,7 @@ Return only the label string with no extra text.
         audio: Optional[bytes] = None,
         text: Optional[str] = None,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult:
+    ) -> TurnDetectionResult | list[TurnDetectionResult]:
         if text == None:
             return TurnDetectionResult(
                 action=TurnDetectionAction.DO_NOTHING,
@@ -194,10 +237,28 @@ Return only the label string with no extra text.
                     )
                 if "interrupt" in response.lower():
                     self._listening = True
-                    return TurnDetectionResult(
-                        action=TurnDetectionAction.STOP_SPEAKING,
-                        semantic=TurnDetectionSemantic.INCOMPLETE,
-                    )
+                    result = [
+                        TurnDetectionResult(
+                            action=TurnDetectionAction.STOP_SPEAKING,
+                            semantic=TurnDetectionSemantic.INCOMPLETE,
+                        )
+                    ]
+                    # Need to additional check for start generation if meet speech paused (indicating a potential end of speech)
+                    if speech_pause:
+                        messages = [
+                            SystemMessage(content=self.CHECK_COMPLETION_PROMPT),
+                            HumanMessage(content=text),
+                        ]
+                        response = (await self._model.ainvoke(messages)).content
+                        if "complete" in response.lower():
+                            result[0].semantic = TurnDetectionSemantic.COMPLETE
+                            result.append(
+                                TurnDetectionResult(
+                                    action=TurnDetectionAction.START_GENERATION,
+                                    semantic=TurnDetectionSemantic.COMPLETE,
+                                )
+                            )
+                    return result
             return TurnDetectionResult(
                 action=TurnDetectionAction.DO_NOTHING,
                 semantic=TurnDetectionSemantic.IDLE,

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -127,6 +127,8 @@ Return only the label string with no extra text.
         # If AI is listening, try to determine whether to start generation and toggle state;
         # else determine whether to stop speaking and toggle state
         self._listening = True
+        # FIXED: lock listening
+        self._listening_lock = asyncio.Lock()
 
     def clone(self) -> "TurnDetector":
         return LLMTurnDetector(self._model)
@@ -146,49 +148,57 @@ Return only the label string with no extra text.
         speech_pause: Optional[bool] = None,
     ) -> TurnDetectionResult:
         if text == None:
-            return
-        if self._listening:
-            messages = [
-                SystemMessage(content=self.START_GENERATION_PROMPT),
-                HumanMessage(content=text),
-            ]
-            response = (await self._model.ainvoke(messages)).content
-            if speech_pause and "complete" in response.lower():
-                self._listening = False
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.START_GENERATION,
-                    semantic=TurnDetectionSemantic.COMPLETE,
-                )
-            if "incomplete" in response.lower():
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.DO_NOTHING,
-                    semantic=TurnDetectionSemantic.INCOMPLETE,
-                )
-            if "wait" in response.lower():
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.DO_NOTHING,
-                    semantic=TurnDetectionSemantic.WAIT,
-                )
-        else:
-            messages = [
-                SystemMessage(content=self.STOP_SPEAKING_PROMPT),
-                HumanMessage(content=text),
-            ]
-            response = (await self._model.ainvoke(messages)).content
-            if "backchannel" in response.lower():
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.DO_NOTHING,
-                    semantic=TurnDetectionSemantic.BACKCHANNEL,
-                )
-            if "wait" in response.lower():
-                self._listening = True
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.STOP_SPEAKING,
-                    semantic=TurnDetectionSemantic.WAIT,
-                )
-            if "interrupt" in response.lower():
-                self._listening = True
-                return TurnDetectionResult(
-                    action=TurnDetectionAction.STOP_SPEAKING,
-                    semantic=TurnDetectionSemantic.INCOMPLETE,
-                )
+            return TurnDetectionResult(
+                action=TurnDetectionAction.DO_NOTHING,
+                semantic=TurnDetectionSemantic.IDLE,
+            )
+        async with self._listening_lock:
+            if self._listening:
+                messages = [
+                    SystemMessage(content=self.START_GENERATION_PROMPT),
+                    HumanMessage(content=text),
+                ]
+                response = (await self._model.ainvoke(messages)).content
+                if speech_pause and "complete" in response.lower():
+                    self._listening = False
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.START_GENERATION,
+                        semantic=TurnDetectionSemantic.COMPLETE,
+                    )
+                if "incomplete" in response.lower():
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.DO_NOTHING,
+                        semantic=TurnDetectionSemantic.INCOMPLETE,
+                    )
+                if "wait" in response.lower():
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.DO_NOTHING,
+                        semantic=TurnDetectionSemantic.WAIT,
+                    )
+            else:
+                messages = [
+                    SystemMessage(content=self.STOP_SPEAKING_PROMPT),
+                    HumanMessage(content=text),
+                ]
+                response = (await self._model.ainvoke(messages)).content
+                if "backchannel" in response.lower():
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.DO_NOTHING,
+                        semantic=TurnDetectionSemantic.BACKCHANNEL,
+                    )
+                if "wait" in response.lower():
+                    self._listening = True
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.STOP_SPEAKING,
+                        semantic=TurnDetectionSemantic.WAIT,
+                    )
+                if "interrupt" in response.lower():
+                    self._listening = True
+                    return TurnDetectionResult(
+                        action=TurnDetectionAction.STOP_SPEAKING,
+                        semantic=TurnDetectionSemantic.INCOMPLETE,
+                    )
+            return TurnDetectionResult(
+                action=TurnDetectionAction.DO_NOTHING,
+                semantic=TurnDetectionSemantic.IDLE,
+            )

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -1,56 +1,194 @@
-from ..interfaces import TurnDetector, TurnDetectionAction
+from ..interfaces import (
+    TurnDetector,
+    TurnDetectionAction,
+    TurnDetectionResult,
+    TurnDetectionSemantic,
+)
 from langchain_openai import ChatOpenAI
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
+from typing import Optional
+import asyncio
 
 
 # TODO: re-implement
 class LLMTurnDetector(TurnDetector):
-    SYSTEM_PROMPT = """Classify user input as ["complete", "incomplete", "backchannel"].
+    STOP_SPEAKING_PROMPT = """You are a classifier. Given a user utterance that is a *text transcription* from a live speech conversation (ASR output), decide whether it is:
 
-You are a classifier in a spoken dialogue system. Your task is to label each single user message based on whether it requires a model response.
+* **backchannel**: short acknowledgements / continuer signals that do **not** take the floor or change the topic.
+* **wait**: explicit request for the assistant to pause/hold or “one moment”.
+* **interrupt**: user is cutting in to take the floor, correct/redirect, ask a question, or stop/modify what the assistant is saying.
 
-### Labeling Rules
-- **complete**: The message contains a clear question, instruction, or statement that should receive a meaningful model response immediately.
-- **incomplete**: The message is truncated, ambiguous, missing critical information, or is part of ongoing input where the model should wait instead of responding now.
-- **backchannel**: The message is a short feedback signal used only to maintain conversational flow (e.g., "yeah", "uh-huh", "right"), carries no primary intent, and does not require a model response.
+**Output exactly one label from:** `["backchannel", "wait", "interrupt"]`
 
-### Constraints
-- Classify the message itself only, not the surrounding context.
-- Output **one label only**.
-- Do not generate any explanation, only return the label string.
-- Be robust to casual speech, fillers, and interruptions.
-- Treat acknowledgements without actionable intent as backchannel.
-- Treat actionable or reply-worthy content as complete, even if it does not finish a multi-step task.
+## Decision rules (use the first matching rule)
 
-### Examples
-User: "How do I rename a git branch?" → complete  
-User: "I was thinking the architecture could maybe use…" → incomplete  
-User: "uh-huh" → backchannel  
-User: "Deploy it to Windows, Linux, and macOS." → complete  
-User: "vLLM needs to load the model from…" *(stops mid-sentence)* → incomplete  
-User: "yes, exactly" *(no further action implied)* → backchannel
+### 1) **wait**
+
+Label as **wait** if the utterance explicitly asks to pause or hold, e.g.:
+
+* “wait”, “hold on”, “one sec/second”, “a moment”, “give me a second”
+* “stop for a bit”, “pause”, “hang on”, “let me think”
+* “等一下/等等/稍等/先别说/先停一下/给我一分钟”
+
+### 2) **backchannel**
+
+Label as **backchannel** if it's primarily a continuer/acknowledgement and **does not** introduce new content or a request, e.g.:
+
+* “uh-huh”, “mm-hmm”, “yeah”, “yep”, “ok”, “right”, “I see”, “got it”
+* “嗯/啊哈/对/好/行/懂了/明白/是的”
+* brief laughter tokens like “haha” when used as acknowledgement
+
+**Heuristic:** typically ≤ 3-4 words, no question, no directive verbs (stop/pause/repeat), no new task/topic.
+
+### 3) **interrupt**
+
+Label as **interrupt** otherwise, including:
+
+* asking a question mid-stream: “but why...?”, “what about...?”
+* correcting/redirecting: “no, I meant...”, “actually...”, “not that...”
+* stopping/modifying assistant speech without asking to “wait”: “stop”, “don't say that”, “let's switch”
+* adding substantial info: names, numbers, constraints, new topic, instructions
+
+## Tie-breakers / ASR noise handling
+
+* If it contains both acknowledgement and a new request/topic (e.g., “yeah but...”, “ok so do X”), choose **interrupt**.
+* If it contains “wait/hold on/等一下” anywhere and it's a genuine pause request, choose **wait** even if there's also an acknowledgement.
+* If it's unclear but longer than a simple acknowledgement or includes content words beyond agreement, choose **interrupt**.
+
+## Output format
+
+Return **only** the label string.
+"""
+    START_GENERATION_PROMPT = """You are a real-time speech-UI classifier. Given an ASR transcript of what the user just said (may be partial, noisy, or cut off), classify whether the user's utterance is:
+
+* **incomplete**: the user is still speaking / the thought is unfinished, or ASR looks truncated.
+* **complete**: the user finished a coherent utterance (question/command/statement) and is yielding the floor.
+* **wait**: the user explicitly asks the assistant to pause/hold while they think or do something.
+
+**Output exactly one label from:** `["incomplete", "complete", "wait"]`
+
+## Decision rules (apply in order)
+
+### 1) **wait**
+
+Choose **wait** if the transcript contains an explicit pause/hold request, e.g.:
+
+* English: “wait”, “hold on”, “hang on”, “one sec/second”, “a moment”, “give me a second”, “pause”, “let me think”
+* Chinese: “等一下/等等/稍等/先别说/先停一下/给我一分钟/我想一下”
+* Any variant like “stop, wait” where the intent is to pause the assistant
+
+If “wait” is present but clearly means something else (rare), follow the other rules.
+
+### 2) **incomplete**
+
+Choose **incomplete** if **any** of these are true:
+
+**A. Truncation / cut-off indicators**
+
+* Transcript ends with unfinished connectors: “and”, “so”, “but”, “because”, “if”, “then”, “like”, “which”, “that...”
+* Ends with filler or restart signals: “uh”, “um”, “er”, “I mean”, “well...”, “你知道”, “就是”, “然后...”
+* Ends with a dangling preposition/article: “to”, “with”, “for”, “a/an/the”, “的/了/在/把” (when clearly hanging)
+
+**B. Mid-thought structure**
+
+* Starts a clause but doesn't complete it: “I want to...”, “Can you...”, “Let's...”, “Could we...”, “我想.../能不能.../我们...”
+* Contains self-correction or continuation cues without finishing: “no—”, “actually—”, “wait— I mean—”, “不是...我是说...”
+
+**C. ASR partialness signs**
+
+* Very short fragment that looks like a partial start (1-3 content words) and not a full intent, e.g. “so the...”, “about the...”, “那个...”, “就是...”
+* Strong repetition/restarts: “I I I...”, “we we...”, “我我我...”
+
+### 3) **complete**
+
+Choose **complete** if neither of the above applies and the utterance forms a complete communicative unit, e.g.:
+
+* A full question: ends naturally or with “?”, has an interrogative (“what/why/how/能不能/怎么”)
+* A full command/request: “Open X”, “Explain Y”, “帮我把...”
+* A complete statement: “I'm done”, “That's fine”, “We should do A first”
+* Even if short, it clearly conveys a finished intent: “yes”, “no”, “okay”, “got it”, “不用了”, “可以”
+
+## Tie-breakers
+
+* If the transcript ends with a period-like finality (or clear completion) vs. a dangling connector, prefer **complete**.
+* If it includes both acknowledgement and a new clause starter (e.g., “yeah but...”, “好的然后...”), choose **incomplete** unless it clearly finishes.
+* When uncertain, prefer **incomplete** (safer for turn-taking) unless it's an explicit pause request (**wait**).
+
+## Output format
+
+Return only the label string with no extra text.    
 """
 
     def __init__(self, model: dict | BaseChatModel) -> None:
         if isinstance(model, dict):
             model = ChatOpenAI(**model)
         self._model = model
+        # If AI is listening, try to determine whether to start generation and toggle state;
+        # else determine whether to stop speaking and toggle state
+        self._listening = True
 
     def clone(self) -> "TurnDetector":
         return LLMTurnDetector(self._model)
 
-    def detect(self, audio=None, text=None) -> TurnDetectionAction:
-        if not text:
-            raise RuntimeError("Text for LLMTurnDetector should not be empty")
-        messages: List = [
-            SystemMessage(content=self.SYSTEM_PROMPT),
-            HumanMessage(content=text),
-        ]
-        response = self._model.invoke(messages).content
-        if "backchannel" in response.lower():
-            return TurnDetectionAction.BACKCHANNEL
-        elif "incomplete" in response.lower():
-            return TurnDetectionAction.INCOMPLETE
+    def detect(
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        speech_pause: Optional[bool] = None,
+    ) -> TurnDetectionResult:
+        return asyncio.run(self.async_detect(audio, text, speech_pause))
+
+    async def async_detect(
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        speech_pause: Optional[bool] = None,
+    ) -> TurnDetectionResult:
+        if text == None:
+            return
+        if self._listening:
+            messages = [
+                SystemMessage(content=self.START_GENERATION_PROMPT),
+                HumanMessage(content=text),
+            ]
+            response = (await self._model.ainvoke(messages)).content
+            if speech_pause and "complete" in response.lower():
+                self._listening = False
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.START_GENERATION,
+                    semantic=TurnDetectionSemantic.COMPLETE,
+                )
+            if "incomplete" in response.lower():
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.DO_NOTHING,
+                    semantic=TurnDetectionSemantic.INCOMPLETE,
+                )
+            if "wait" in response.lower():
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.DO_NOTHING,
+                    semantic=TurnDetectionSemantic.WAIT,
+                )
         else:
-            return TurnDetectionAction.COMPLETE
+            messages = [
+                SystemMessage(content=self.STOP_SPEAKING_PROMPT),
+                HumanMessage(content=text),
+            ]
+            response = (await self._model.ainvoke(messages)).content
+            if "backchannel" in response.lower():
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.DO_NOTHING,
+                    semantic=TurnDetectionSemantic.BACKCHANNEL,
+                )
+            if "wait" in response.lower():
+                self._listening = True
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.STOP_SPEAKING,
+                    semantic=TurnDetectionSemantic.WAIT,
+                )
+            if "interrupt" in response.lower():
+                self._listening = True
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.STOP_SPEAKING,
+                    semantic=TurnDetectionSemantic.INCOMPLETE,
+                )

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -254,12 +254,11 @@ Return only the label string with no extra text.
                     )
                 if "interrupt" in response.lower():
                     self._listening = True
-                    result = [
-                        TurnDetectionResult(
-                            action=TurnDetectionAction.STOP_SPEAKING,
-                            semantic=TurnDetectionSemantic.INCOMPLETE,
-                        )
-                    ]
+                    result = TurnDetectionResult(
+                        action=TurnDetectionAction.STOP_SPEAKING,
+                        semantic=TurnDetectionSemantic.INCOMPLETE,
+                    )
+
                     # Need to additional check for start generation if meet speech paused (indicating a potential end of speech)
                     if speech_pause:
                         messages = [
@@ -268,13 +267,16 @@ Return only the label string with no extra text.
                         ]
                         response = (await self._model.ainvoke(messages)).content
                         if "complete" in response.lower():
-                            result[0].semantic = TurnDetectionSemantic.COMPLETE
-                            result.append(
+                            result = [
+                                TurnDetectionResult(
+                                    action=TurnDetectionAction.STOP_SPEAKING,
+                                    semantic=TurnDetectionSemantic.COMPLETE,
+                                ),
                                 TurnDetectionResult(
                                     action=TurnDetectionAction.START_GENERATION,
                                     semantic=TurnDetectionSemantic.COMPLETE,
-                                )
-                            )
+                                ),
+                            ]
                     return result
             return TurnDetectionResult(
                 action=TurnDetectionAction.DO_NOTHING,


### PR DESCRIPTION
## Summary

- Add `TurnDetector` interface and `LLMTurnDetector` implementation for intelligent turn detection using LLM prompts
- Integrate turn detection into the pipeline with `TurnDetectorManager` that processes ASR results and emits turn detection events
- Add `speech_pause` signal to `ASRResultPartial` event to indicate when user has paused speaking (triggered by VAD end)
- Update `TurnTakingManager` to respond to turn detection events (`TurnDetectorStartGeneration`, `TurnDetectorStopSpeaking`) with priority-based handlers
- Improve `AudioConsumer` with state flags to prevent duplicate pause/end processing

### Key Features
- **Dual-mode detection**: Different prompts for "listening" mode (start generation detection) vs "speaking" mode (stop speaking detection)
- **Semantic classification**: Classifies utterances as incomplete/complete/wait/backchannel/interrupt
- **Interrupt handling**: Supports interrupt with completion check for natural turn-taking
- **Async-safe**: Uses async lock to prevent race conditions in turn state transitions

## Test plan
- [x] Verify turn detection correctly identifies complete vs incomplete utterances
- [x] Test interrupt scenarios where user cuts in during AI speech
- [x] Confirm backchannel signals (e.g., "uh-huh", "yeah") don't trigger generation
- [x] Validate wait requests properly pause AI response

🤖 Generated with [Claude Code](https://claude.com/claude-code)