### PR TITLE
fix: add conditional turn-taking behavior based on turn detector to ensure backward compatible

### DIFF
--- a/src/xtalk/serving/modules/turn_taking_manager.py
+++ b/src/xtalk/serving/modules/turn_taking_manager.py
@@ -14,14 +14,20 @@ from ..events import (
     ASRResultFinal,
     TTSPlaybackFinished,
 )
+from ...pipelines import Pipeline
 
 
 class TurnTakingManager(Manager):
     def __init__(
-        self, event_bus: EventBus, session_id: str, config: dict[str, Any] | None = None
+        self,
+        event_bus: EventBus,
+        session_id: str,
+        pipeline: Pipeline,
+        config: dict[str, Any] | None = None,
     ):
         self.event_bus = event_bus
         self.session_id = session_id
+        self._turn_detector_model = pipeline.get_turn_detector_model()
 
     @Manager.event_handler(TurnDetectorStartGeneration, priority=99)
     async def _on_turn_detector_start_generation(
@@ -43,13 +49,27 @@ class TurnTakingManager(Manager):
 
     @Manager.event_handler(VADSpeechStart)
     async def _on_vad_start(self, _event: VADSpeechStart):
-        """VAD start: stop LLM and notify ASR to start."""
+        """VAD start: notify ASR to start (with turn detector)/stop LLM and notify ASR to start(without turn detector)"""
+        if self._turn_detector_model is None:
+            await self.event_bus.publish(
+                TurnLLMAgentStopRequested(
+                    session_id=self.session_id,
+                ),
+                wait_for_completion=True,
+            )
         await self.event_bus.publish(TurnASRStartRequested(session_id=self.session_id))
 
     @Manager.event_handler(VADSpeechEnd)
     async def _on_vad_end(self, _event: VADSpeechEnd):
-        """VAD end: finalize the turn."""
-        await self.event_bus.publish(TurnASRPauseRequested(session_id=self.session_id))
+        """VAD end: pause ASR recognition (with turn detector)/finalize the turn (without turn detector)"""
+        if self._turn_detector_model is None:
+            await self.event_bus.publish(
+                TurnASREndRequested(session_id=self.session_id)
+            )
+        else:
+            await self.event_bus.publish(
+                TurnASRPauseRequested(session_id=self.session_id)
+            )
 
     @Manager.event_handler(ASRResultFinal)
     async def _on_asr_final(self, event: ASRResultFinal):


### PR DESCRIPTION
When turn detector is available, VAD start only notifies ASR to start (without stopping LLM), and VAD end pauses ASR. When no turn detector is configured, fall back to original behavior of stopping LLM on VAD start and ending ASR on VAD end.