### PR TITLE
Enhance web search and get time tool call

### DIFF
--- a/src/xtalk/llm_agent/default.py
+++ b/src/xtalk/llm_agent/default.py
@@ -66,7 +66,7 @@ Examples:
 
 2. Your response should not contain content that cannot be synthesize by the TTS model, such as parentheses, ordered lists (starting by - ), etc. Numbers should be written in English words rather than Arabic numerals.
 
-3. Your response should be very concise and to the point, avoiding lengthy explanations.
+3. Your response should be informative and adequately detailed, but avoid unnecessary repetition or filler. Keep it suitable for spoken delivery.
 
 4. If you find user input (ASR result) unclear, incomplete, or likely incorrect — for example:
 - contains obvious ASR hallucinations,
@@ -94,6 +94,10 @@ The system should distinguish users based on their speaker IDs, with one user ma
 - NEVER say "I cannot access real-time information" or "I don't have internet access". You have search tools — USE THEM.
 - NEVER answer specific factual questions from memory alone — search first, then answer based on search results.
 
+7. When citing times, numbers, names, or other specific facts from search results, you SHOULD reproduce them faithfully. Do NOT reinterpret or convert values based on your assumptions. For example, if search results say "10:30", treat it as 10:30 AM unless the source explicitly says PM or evening.
+
+8. SEARCH QUERY RULE: When constructing a web_search query, ALWAYS replace relative time references ("今天", "昨天", "明天", "上个月", "去年", "today", "yesterday", etc.) with the actual date from <current_date>. For example, if today is 2026-02-28 and the user asks "今天NBA有哪些比赛", your query should be "2026年2月28日 NBA比赛赛程", NOT "今天NBA有哪些比赛".
+
 你是一位友好的对话伙伴，你的回复会通过 TTS 转成语音。请遵守以下规则：
 
 1. 用和用户相同的语言回复。
@@ -105,7 +109,7 @@ The system should distinguish users based on their speaker IDs, with one user ma
 
 2. 你的回复中不能出现 TTS 无法合成的内容，例如括号、编号列表（以- 开始）等。数字要用英文单词书写，不要使用阿拉伯数字。
 
-3. 你的回复要非常简洁，不要做长篇解释。
+3. 你的回复应当信息充分、适当详细，但避免不必要的重复或废话。回复长度要适合语音播报。
 
 4. 如果你发现用户输入（ASR 结果）不清晰、不完整或可能有误，例如：
 - 包含明显的 ASR 幻觉内容；
@@ -130,6 +134,10 @@ The system should distinguish users based on their speaker IDs, with one user ma
 - 黄金原则：如果你不能百分之百确定答案准确且是最新的，就调用 web_search。有疑问时，永远先搜索。
 - 绝对不要说"我无法获取实时信息"或"我没有联网能力"。你拥有搜索工具，请使用它们。
 - 绝对不要仅凭记忆回答具体的事实性问题——先搜索，再根据搜索结果回答。
+
+7. 引用搜索结果中的时间、数字、名称等具体事实时，应该忠实于原文，不要根据自己的推测重新解读。例如搜索结果写"10:30"，应说"上午十点三十分"，除非原文明确标注是下午或晚上。
+
+8. 搜索用语规则：构造 web_search 的 query 时，必须将"今天"、"昨天"、"明天"、"上个月"、"去年"等相对时间词替换为 <current_date> 中的具体日期。例如今天是2026-02-28，用户问"今天NBA有哪些比赛"，你的 query 应为"2026年2月28日 NBA比赛赛程"，而不是"今天NBA有哪些比赛"。
 """
     )
     _CONTEXT_AWARE_PROMPT: str = (

--- a/src/xtalk/llm_agent/tools/retrievers.py
+++ b/src/xtalk/llm_agent/tools/retrievers.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
+import calendar
 import os
+import re
+from datetime import datetime, timedelta
+
 from langchain.tools import tool, BaseTool
 from langchain_chroma import Chroma  # type: ignore
 
@@ -13,6 +17,236 @@ def _resolve_env(*names: str) -> Optional[str]:
         if v and v.strip():
             return v.strip()
     return None
+
+
+# ---------------------------------------------------------------------------
+# Relative-time resolution for search queries
+# ---------------------------------------------------------------------------
+
+_HAS_RELATIVE_TIME = re.compile(
+    r"今[天日]|昨[天日]|前天|后天|後天|大前天|大后天|大後天"
+    r"|明[天日]|今年|去年|前年|明年|后年|後年|大前年"
+    r"|[上下]个?月|本月|[上下]个?周|本周|[上下]个?星期|[上下]个?礼拜|[上下]个?禮拜"
+    r"|上上个?月|下下个?月|上上个?周|下下个?周"
+    r"|半年前|半年后|半年後|年初|年[底末]|月初|月[底末]"
+    r"|\d+\s*[天周年]前|\d+\s*[天周年][后後]"
+    r"|\d+\s*个?月前|\d+\s*个?月[后後]"
+    r"|\d+\s*个?星期前|\d+\s*个?礼拜前"
+    r"|today|yesterday|tomorrow|last\s+week|this\s+week|next\s+week"
+    r"|last\s+month|this\s+month|next\s+month"
+    r"|last\s+year|this\s+year|next\s+year"
+    r"|\d+\s*days?\s*ago|\d+\s*weeks?\s*ago"
+    r"|\d+\s*months?\s*ago|\d+\s*years?\s*ago"
+    r"|day\s+before\s+yesterday|day\s+after\s+tomorrow",
+    re.IGNORECASE,
+)
+
+
+def _add_months(dt: datetime, months: int) -> datetime:
+    """Month-level date arithmetic without external dependencies."""
+    month = dt.month - 1 + months
+    year = dt.year + month // 12
+    month = month % 12 + 1
+    day = min(dt.day, calendar.monthrange(year, month)[1])
+    return dt.replace(year=year, month=month, day=day)
+
+
+def _resolve_relative_time(query: str) -> str:
+    """Replace relative time expressions with absolute dates in search queries.
+
+    Covers Chinese and English daily expressions: 今天/昨天/前天/明天/后天,
+    今年/去年/前年/明年, 本月/上个月/下个月, 本周/上周/下周, 上周三/下周一,
+    N天前/后, N个月前/后, N年前/后, 半年前/后, today/yesterday/tomorrow,
+    last/this/next week/month/year, N days/weeks/months/years ago, etc.
+    """
+    if not _HAS_RELATIVE_TIME.search(query):
+        return query
+
+    now = datetime.now()
+
+    def _cn_date(dt: datetime) -> str:
+        return dt.strftime("%Y年%m月%d日")
+
+    def _cn_month(dt: datetime) -> str:
+        return dt.strftime("%Y年%m月")
+
+    # Chinese weekday mapping: 一=Monday(0) .. 日/天=Sunday(6)
+    _CN_WD = {
+        "一": 0, "二": 1, "三": 2, "四": 3,
+        "五": 4, "六": 5, "日": 6, "天": 6,
+    }
+
+    def _last_wd(name: str) -> str:
+        wd = _CN_WD.get(name, 0)
+        delta = (now.weekday() - wd) % 7 or 7
+        return _cn_date(now - timedelta(days=delta))
+
+    def _this_wd(name: str) -> str:
+        wd = _CN_WD.get(name, 0)
+        delta = (wd - now.weekday()) % 7
+        return _cn_date(now + timedelta(days=delta))
+
+    def _next_wd(name: str) -> str:
+        wd = _CN_WD.get(name, 0)
+        delta = (wd - now.weekday()) % 7
+        if delta <= 0:
+            delta += 7
+        return _cn_date(now + timedelta(days=delta + 7))
+
+    # English weekday mapping
+    _EN_WD = {
+        "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+        "friday": 4, "saturday": 5, "sunday": 6,
+        "mon": 0, "tue": 1, "wed": 2, "thu": 3,
+        "fri": 4, "sat": 5, "sun": 6,
+    }
+
+    def _en_last_wd(name: str) -> str:
+        wd = _EN_WD.get(name.lower(), 0)
+        delta = (now.weekday() - wd) % 7 or 7
+        return (now - timedelta(days=delta)).strftime("%Y-%m-%d")
+
+    def _en_this_wd(name: str) -> str:
+        wd = _EN_WD.get(name.lower(), 0)
+        delta = (wd - now.weekday()) % 7
+        return (now + timedelta(days=delta)).strftime("%Y-%m-%d")
+
+    def _en_next_wd(name: str) -> str:
+        wd = _EN_WD.get(name.lower(), 0)
+        delta = (wd - now.weekday()) % 7
+        if delta <= 0:
+            delta += 7
+        return (now + timedelta(days=delta + 7)).strftime("%Y-%m-%d")
+
+    # Rules: (regex_pattern, replacement_callback)
+    # Ordered by specificity — longer / more specific patterns first.
+    # Negative lookbehinds prevent false positives like 目前天气 → 目(前天)气.
+    rules: List[Tuple[str, Any]] = [
+        # ---- Chinese: N + unit + 前/后 ----
+        (r"(\d+)\s*年半前", lambda m: f"{now.year - int(m.group(1))}年"),
+        (r"(\d+)\s*年半[后後]", lambda m: f"{now.year + int(m.group(1)) + 1}年"),
+        (r"(\d+)\s*年前", lambda m: f"{now.year - int(m.group(1))}年"),
+        (r"(\d+)\s*年[后後]", lambda m: f"{now.year + int(m.group(1))}年"),
+        (r"半年前", lambda m: _cn_month(_add_months(now, -6))),
+        (r"半年[后後]", lambda m: _cn_month(_add_months(now, 6))),
+        (r"(\d+)\s*个?半?月前",
+         lambda m: _cn_month(_add_months(now, -int(m.group(1))))),
+        (r"(\d+)\s*个?半?月[后後]",
+         lambda m: _cn_month(_add_months(now, int(m.group(1))))),
+        (r"(\d+)\s*(?:周|个?星期|个?礼拜|個?禮拜)前",
+         lambda m: _cn_date(now - timedelta(weeks=int(m.group(1))))),
+        (r"(\d+)\s*(?:周|个?星期|个?礼拜|個?禮拜)[后後]",
+         lambda m: _cn_date(now + timedelta(weeks=int(m.group(1))))),
+        (r"(\d+)\s*天前",
+         lambda m: _cn_date(now - timedelta(days=int(m.group(1))))),
+        (r"(\d+)\s*天[后後]",
+         lambda m: _cn_date(now + timedelta(days=int(m.group(1))))),
+
+        # ---- Chinese: weekday with 上/这/下 prefix ----
+        (r"上(?:个?)?(?:周|星期|礼拜|禮拜)([一二三四五六日天])",
+         lambda m: _last_wd(m.group(1))),
+        (r"(?:这个?|本)(?:周|星期|礼拜|禮拜)([一二三四五六日天])",
+         lambda m: _this_wd(m.group(1))),
+        (r"下(?:个?)?(?:周|星期|礼拜|禮拜)([一二三四五六日天])",
+         lambda m: _next_wd(m.group(1))),
+
+        # ---- Chinese: fixed day expressions ----
+        (r"大前天", lambda m: _cn_date(now - timedelta(days=3))),
+        (r"大[后後]天", lambda m: _cn_date(now + timedelta(days=3))),
+        (r"(?<!目)(?<!以)(?<!之)(?<!日)前天",
+         lambda m: _cn_date(now - timedelta(days=2))),
+        (r"(?<!以)(?<!往)(?<!日)[后後]天",
+         lambda m: _cn_date(now + timedelta(days=2))),
+        (r"昨[天日]", lambda m: _cn_date(now - timedelta(days=1))),
+        (r"(?<!说)(?<!证)明[天日]",
+         lambda m: _cn_date(now + timedelta(days=1))),
+        (r"(?<!如)(?<!至)今[天日]", lambda m: _cn_date(now)),
+
+        # ---- Chinese: fixed year expressions ----
+        (r"大前年", lambda m: f"{now.year - 3}年"),
+        (r"(?<!目)前年", lambda m: f"{now.year - 2}年"),
+        (r"去年", lambda m: f"{now.year - 1}年"),
+        (r"今年", lambda m: f"{now.year}年"),
+        (r"明年", lambda m: f"{now.year + 1}年"),
+
+        # ---- Chinese: fixed month expressions ----
+        (r"上上个?月", lambda m: _cn_month(_add_months(now, -2))),
+        (r"上个?月", lambda m: _cn_month(_add_months(now, -1))),
+        (r"(?:这个?|本)月", lambda m: _cn_month(now)),
+        (r"下下个?月", lambda m: _cn_month(_add_months(now, 2))),
+        (r"下个?月", lambda m: _cn_month(_add_months(now, 1))),
+
+        # ---- Chinese: fixed week expressions ----
+        (r"上上(?:个?)?(?:周|星期|礼拜|禮拜)",
+         lambda m: _cn_date(now - timedelta(weeks=2))),
+        (r"上(?:个?)?(?:周|星期|礼拜|禮拜)",
+         lambda m: _cn_date(now - timedelta(weeks=1))),
+        (r"(?:这个?|本)(?:周|星期|礼拜)",
+         lambda m: _cn_date(now)),
+        (r"下下(?:个?)?(?:周|星期|礼拜|禮拜)",
+         lambda m: _cn_date(now + timedelta(weeks=2))),
+        (r"下(?:个?)?(?:周|星期|礼拜|禮拜)",
+         lambda m: _cn_date(now + timedelta(weeks=1))),
+
+        # ---- Chinese: period start/end ----
+        (r"年初", lambda m: f"{now.year}年1月"),
+        (r"年[底末]", lambda m: f"{now.year}年12月"),
+        (r"月初", lambda m: _cn_month(now) + "初"),
+        (r"月[底末]", lambda m: _cn_month(now) + "底"),
+
+        # ---- English: N + unit + ago ----
+        (r"(\d+)\s*years?\s*ago",
+         lambda m: str(now.year - int(m.group(1)))),
+        (r"(\d+)\s*months?\s*ago",
+         lambda m: _add_months(now, -int(m.group(1))).strftime("%Y-%m")),
+        (r"(\d+)\s*weeks?\s*ago",
+         lambda m: (now - timedelta(weeks=int(m.group(1)))).strftime("%Y-%m-%d")),
+        (r"(\d+)\s*days?\s*ago",
+         lambda m: (now - timedelta(days=int(m.group(1)))).strftime("%Y-%m-%d")),
+
+        # ---- English: fixed expressions ----
+        (r"\bthe\s+day\s+before\s+yesterday\b",
+         lambda m: (now - timedelta(days=2)).strftime("%Y-%m-%d")),
+        (r"\bthe\s+day\s+after\s+tomorrow\b",
+         lambda m: (now + timedelta(days=2)).strftime("%Y-%m-%d")),
+        (r"\byesterday\b",
+         lambda m: (now - timedelta(days=1)).strftime("%Y-%m-%d")),
+        (r"\btomorrow\b",
+         lambda m: (now + timedelta(days=1)).strftime("%Y-%m-%d")),
+        (r"\btoday\b",
+         lambda m: now.strftime("%Y-%m-%d")),
+
+        # ---- English: last/this/next + unit ----
+        (r"\blast\s+year\b", lambda m: str(now.year - 1)),
+        (r"\bthis\s+year\b", lambda m: str(now.year)),
+        (r"\bnext\s+year\b", lambda m: str(now.year + 1)),
+        (r"\blast\s+month\b",
+         lambda m: _add_months(now, -1).strftime("%Y-%m")),
+        (r"\bthis\s+month\b", lambda m: now.strftime("%Y-%m")),
+        (r"\bnext\s+month\b",
+         lambda m: _add_months(now, 1).strftime("%Y-%m")),
+        (r"\blast\s+week\b",
+         lambda m: (now - timedelta(weeks=1)).strftime("%Y-%m-%d")),
+        (r"\bthis\s+week\b", lambda m: now.strftime("%Y-%m-%d")),
+        (r"\bnext\s+week\b",
+         lambda m: (now + timedelta(weeks=1)).strftime("%Y-%m-%d")),
+
+        # ---- English: last/this/next + weekday ----
+        (r"\blast\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+         r"|mon|tue|wed|thu|fri|sat|sun)\b",
+         lambda m: _en_last_wd(m.group(1))),
+        (r"\bthis\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+         r"|mon|tue|wed|thu|fri|sat|sun)\b",
+         lambda m: _en_this_wd(m.group(1))),
+        (r"\bnext\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+         r"|mon|tue|wed|thu|fri|sat|sun)\b",
+         lambda m: _en_next_wd(m.group(1))),
+    ]
+
+    for pattern, fn in rules:
+        query = re.sub(pattern, fn, query, flags=re.IGNORECASE)
+
+    return query
 
 
 WEB_SEARCH_TOOL = "web_search"
@@ -77,6 +311,7 @@ LANGUAGE RULE: The search query MUST use the SAME language as the user's questio
             return "Search service is unavailable: missing SERPER_API_KEY."
 
         try:
+            query = _resolve_relative_time(query)
             headers = {
                 "X-API-KEY": resolved_key,
                 "Content-Type": "application/json",
@@ -100,7 +335,11 @@ LANGUAGE RULE: The search query MUST use the SAME language as the user's questio
             ]
             if not items:
                 return "No relevant results found."
-            lines = []
+            lines = [
+                "[The following are factual results from a search engine. "
+                "Cite all times, numbers, and names exactly as shown — "
+                "do NOT modify or reinterpret them.]"
+            ]
             for i, it in enumerate(items, 1):
                 title = (it.get("title") or "").strip()
                 snippet = (it.get("snippet") or "").strip()
@@ -118,7 +357,7 @@ TIME_TOOL = "get_time"
 
 
 def build_time_tool() -> BaseTool:
-    """Build a current-time tool that supports optional timezone/format."""
+    """Build a current-time tool with optional timezone, format, and date offset."""
 
     args_schema: Dict[str, Any] = {
         "type": "object",
@@ -132,34 +371,74 @@ def build_time_tool() -> BaseTool:
                 "description": "strftime format, default '%Y-%m-%d %H:%M:%S'.",
                 "default": "%Y-%m-%d %H:%M:%S",
             },
+            "offset_days": {
+                "type": "integer",
+                "description": "Offset in days. E.g. -1 = yesterday, 1 = tomorrow, -3 = 3 days ago, 7 = a week later. Default 0.",
+                "default": 0,
+            },
+            "offset_months": {
+                "type": "integer",
+                "description": "Offset in months. E.g. -1 = last month, 1 = next month, -6 = half a year ago. Default 0.",
+                "default": 0,
+            },
+            "offset_years": {
+                "type": "integer",
+                "description": "Offset in years. E.g. -1 = last year, 1 = next year. Default 0.",
+                "default": 0,
+            },
         },
         "required": [],
         "additionalProperties": False,
     }
 
-    time_description = """Get the current date and time.
+    time_description = """Get the current date and time, with optional date offset for relative date questions.
 You MUST call this tool when the user asks about:
-- Current time (e.g. '现在几点', '几点了', 'what time is it')
-- Current date (e.g. '今天几号', '今天是什么日期', 'what is today's date')
+- Current time (e.g. '现在几点', 'what time is it')
+- Current date (e.g. '今天几号', 'what is today's date')
 - Day of week (e.g. '今天星期几', 'what day is it')
-- Any question that requires knowing the current datetime
-Do NOT guess or fabricate the current time — always use this tool."""
+- Relative dates — use offset parameters instead of calculating yourself:
+  * '昨天几号' / 'yesterday' → offset_days=-1
+  * '前天' / 'day before yesterday' → offset_days=-2
+  * '明天星期几' / 'tomorrow' → offset_days=1
+  * '后天' / 'day after tomorrow' → offset_days=2
+  * '上个月是几月' / 'last month' → offset_months=-1
+  * '下个月' / 'next month' → offset_months=1
+  * '去年是哪一年' / 'last year' → offset_years=-1
+  * '3天前是几号' / '3 days ago' → offset_days=-3
+  * '两个月后' / '2 months later' → offset_months=2
+  * '上周三' / 'last Wednesday' → calculate the correct offset_days
+- Any question that requires knowing a specific datetime
+IMPORTANT: Do NOT calculate dates yourself — always use offset parameters and let this tool compute the exact date."""
 
     @tool(TIME_TOOL, args_schema=args_schema)
-    def get_time(timezone: str | None = None, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
-        """Get the current date and time."""
-        from datetime import datetime
-
+    def get_time(
+        timezone: str | None = None,
+        fmt: str = "%Y-%m-%d %H:%M:%S",
+        offset_days: int = 0,
+        offset_months: int = 0,
+        offset_years: int = 0,
+    ) -> str:
+        """Get the current date and time, optionally offset by days/months/years."""
         tzinfo = None
         if timezone:
             try:
-                from zoneinfo import ZoneInfo  # Python 3.9+
+                from zoneinfo import ZoneInfo
 
                 tzinfo = ZoneInfo(timezone)
             except Exception:
                 tzinfo = None
 
         now = datetime.now(tzinfo)
+
+        if offset_years or offset_months:
+            total_months = now.month - 1 + offset_months + offset_years * 12
+            year = now.year + total_months // 12
+            month = total_months % 12 + 1
+            day = min(now.day, calendar.monthrange(year, month)[1])
+            now = now.replace(year=year, month=month, day=day)
+        if offset_days:
+            now = now + timedelta(days=offset_days)
+
         try:
             return now.strftime(fmt)
         except Exception:


### PR DESCRIPTION
增强工具调用的实时性：

1. web search: 在 query 里注入具体的时间，提高搜索结果的可靠性和准确性，例如对于包含“昨天”，“去年”，“上个月”这类相对时间的问题，通过 _resolve_relative_time 计算出准确的时间，并注入到 web search query 里，保证搜索结果的实时性。

2. get time: 之前get time 只能查询“今天”，增加相对时间查询能力，比如“昨天”，“上个月”，“去年”等。