### PR TITLE
Refine recording scheduling and TTS streaming delivery

### DIFF
--- a/docs/api/server/xtalk/model_types.md
+++ b/docs/api/server/xtalk/model_types.md
@@ -376,6 +376,14 @@ class TTS(ABC)
 
 Abstract base class for text-to-speech engines.
 
+### Notes
+
+``synthesize`` is the required baseline API for every implementation.
+Streaming-capable engines should additionally override
+``synthesize_stream``; non-streaming engines should inherit the default
+compatibility wrapper. The inherited streaming helpers do not by
+themselves declare native streaming capability.
+
 ### Methods
 
 #### synthesize
@@ -397,6 +405,11 @@ Synthesize audio for a full text input.
 
 - `bytes`
   PCM 16-bit mono audio bytes at 48 kHz.
+
+##### Notes
+
+Every TTS implementation, including streaming backends, must provide
+this method.
 
 #### synthesize_stream
 
@@ -420,6 +433,13 @@ Stream synthesized audio chunks for a text input.
 - `bytes`
   PCM 16-bit mono audio bytes at 48 kHz.
 
+##### Notes
+
+Override this method only when the backend supports native streaming
+synthesis. The default implementation yields a single chunk produced
+by ``synthesize`` for compatibility and should not be treated as a
+declaration of streaming support.
+
 #### async_synthesize
 
 _Defined in `xtalk.speech.interfaces`._
@@ -442,6 +462,11 @@ Asynchronously synthesize audio for text.
 - `bytes`
   Synthesized PCM audio bytes.
 
+##### Notes
+
+This method is an optional async optimization. Implementations may
+inherit the default executor-based wrapper.
+
 #### async_synthesize_stream
 
 _Defined in `xtalk.speech.interfaces`._
@@ -463,6 +488,12 @@ Asynchronously stream synthesized audio chunks.
 
 - `bytes`
   Streamed PCM audio chunks.
+
+##### Notes
+
+This method is an optional async optimization for streaming-capable
+backends. When not overridden, it asynchronously iterates over
+``synthesize_stream``.
 
 #### clone
 

--- a/docs/tutorial/introduce_a_new_model.md
+++ b/docs/tutorial/introduce_a_new_model.md
@@ -109,11 +109,17 @@ Your new TTS class must inherit from `xtalk.speech.interfaces.TTS` and implement
 
   - Return a new TTS instance:
     - It should have isolated runtime state to avoid cross-session interference and it may share read-only resources if your backend supports that.
-    
+
+> **Note**
+> Follow this integration contract for new TTS implementations:
+> - Non-streaming TTS: implement `synthesize`; optionally override `async_synthesize` for async efficiency.
+> - Streaming TTS: still implement `synthesize`, and additionally override `synthesize_stream`. You may also override `async_synthesize` and `async_synthesize_stream` for async efficiency.
+> - Do not override `synthesize_stream` for a non-streaming backend just to adapt signatures. The base-class default already wraps `synthesize` into one chunk for compatibility, and that inherited wrapper should not be treated as native streaming support.
+
 **Optional methods**
 
 - **`synthesize_stream(self, text: str, **kwargs) -> Iterable[bytes]`**
-  - If your backend supports streaming synthesis, you can override this method.
+  - Override this method only if your backend supports true streaming synthesis.
 - **`set_voice(self, voice_names: list[str])`**
 
   - This method works with the `TTSVoiceChange` event in `TTSManager` to switch voices via language model tool calls.
@@ -125,7 +131,9 @@ Your new TTS class must inherit from `xtalk.speech.interfaces.TTS` and implement
   - Current tool call result only carries `emotion` as `str`. However, you may also want `list[float]` as emotion vector for future use.
     
 - **`async def async_synthesize(self, text: str, **kwargs: Any)`**
+  - Optional async optimization for both streaming and non-streaming backends.
 - **`async def async_synthesize_stream(
         self, text: str, **kwargs: Any
-    )`**    
+    )`**
+  - Optional async optimization for streaming backends. If omitted, the base class asynchronously iterates over `synthesize_stream`.
     

--- a/docs/tutorial/introduce_a_new_model.zh.md
+++ b/docs/tutorial/introduce_a_new_model.zh.md
@@ -110,10 +110,16 @@ class EchoAgent(Agent):
   - 返回一个新的 TTS 实例：
     - 它应当拥有隔离的运行时状态，避免跨会话相互影响；如果后端支持，也可以共享只读资源。
 
+> **Note**
+> 新接入的 TTS 实现请遵循以下约定：
+> - 非流式 TTS：实现 `synthesize`；如需提升异步效率，可选重写 `async_synthesize`。
+> - 流式 TTS：仍然必须实现 `synthesize`，并额外重写 `synthesize_stream`；如需提升异步效率，也可以重写 `async_synthesize` 与 `async_synthesize_stream`。
+> - 非流式后端不要为了适配接口而重写 `synthesize_stream`。基类默认已经会把 `synthesize` 包装成单个 chunk 作为兼容行为，这种继承得到的包装不应被视为原生流式能力。
+
 **可选方法**
 
 - **`synthesize_stream(self, text: str, **kwargs) -> Iterable[bytes]`**
-  - 如果您的后端支持流式合成，可以重写此方法。
+  - 仅当您的后端支持真正的流式合成时，才应重写此方法。
 - **`set_voice(self, voice_names: list[str])`**
 
   - 此方法配合 `TTSManager` 中的 `TTSVoiceChange` 事件使用，用于通过语言模型工具调用切换音色。
@@ -123,8 +129,10 @@ class EchoAgent(Agent):
 
   - 此方法配合 `TTSManager` 中的 `TTSEmotionChange` 事件使用，用于通过语言模型工具调用切换情绪。
   - 当前工具调用结果中的 `emotion` 仅为 `str`。不过，未来您也可能希望支持以 `list[float]` 形式传入情绪向量。
-
+ 
 - **`async def async_synthesize(self, text: str, **kwargs: Any)`**
+  - 适用于流式与非流式后端的可选异步优化。
 - **`async def async_synthesize_stream(
         self, text: str, **kwargs: Any
     )`**
+  - 面向流式后端的可选异步优化；如果不重写，基类会异步迭代 `synthesize_stream`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,8 @@ soulx-duplug = [
   "websockets",
 ]
 example = [
-  "pypdf"
+  "pypdf",
+  "fastapi==0.128.0"
 ]
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -57,7 +57,6 @@ SERVICE_CONFIG_PATCH = {
     "send_full_audio_to_client": True,
     "enable_persistence": False,
 }
-NO_RESPONSE_GRACE_SECONDS = 5.0
 NON_ACTIVITY_ACTIONS = {"thought_updated"}
 PREFERRED_TEST_CONFIG_NAMES = (
     "test_config.json",
@@ -1204,7 +1203,6 @@ class CaseRunner:
         self._ws_closed = asyncio.Event()
         self._activity_lock = asyncio.Lock()
         self._last_activity: float = 0.0
-        self._scheduler_done_at: float | None = None
         self._full_audio_bytes = bytearray()
         self._receiver_task: asyncio.Task[None] | None = None
         self._playback: PlaybackSimulator | None = None
@@ -1250,7 +1248,6 @@ class CaseRunner:
             )
 
             await self._send_scheduled_inputs(websocket, self._scheduled_inputs)
-            self._scheduler_done_at = asyncio.get_running_loop().time()
             self._scheduler_done.set()
             await self._wait_until_idle(websocket)
         finally:
@@ -1469,28 +1466,17 @@ class CaseRunner:
             async with self._activity_lock:
                 last_activity = self._last_activity
             quiet_for = asyncio.get_running_loop().time() - last_activity
+            last_user_end = await self._anchors.get("last_user_end")
             ai_end_seen = await self._anchors.get("last_ai_end")
             last_full_audio_at = self._last_full_audio_at
-            scheduler_quiet_for = 0.0
-            if self._scheduler_done_at is not None:
-                scheduler_quiet_for = (
-                    asyncio.get_running_loop().time() - self._scheduler_done_at
-                )
-            no_response_grace_elapsed = scheduler_quiet_for >= max(
-                self._settle_seconds,
-                NO_RESPONSE_GRACE_SECONDS,
-            )
             if self._scheduler_done.is_set() and playback_idle:
-                if ai_end_seen is not None:
+                if last_user_end is None:
+                    if quiet_for >= self._settle_seconds:
+                        return
+                elif ai_end_seen is not None and ai_end_seen >= last_user_end:
                     if (
                         last_full_audio_at is not None
                         and last_full_audio_at >= ai_end_seen
-                        and quiet_for >= self._settle_seconds
-                    ):
-                        return
-                elif no_response_grace_elapsed:
-                    if (
-                        last_full_audio_at is not None
                         and quiet_for >= self._settle_seconds
                     ):
                         return

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -15,6 +15,7 @@ import base64
 import io
 import json
 import math
+import multiprocessing
 import re
 import shutil
 import socket
@@ -54,7 +55,7 @@ EMBEDDED_SERVER_HOST = "127.0.0.1"
 EMBEDDED_SERVER_PORT = 0
 SERVICE_CONFIG_PATCH = {
     "recording": True,
-    "send_full_audio_to_client": True,
+    "send_full_audio_to_client": False,
     "enable_persistence": False,
 }
 NON_ACTIVITY_ACTIONS = {"thought_updated"}
@@ -854,8 +855,7 @@ class EmbeddedServer:
         self._config = config
         self._host = host
         self._port = port if port > 0 else pick_free_port(host)
-        self._server: uvicorn.Server | None = None
-        self._task: asyncio.Task[None] | None = None
+        self._process: multiprocessing.Process | None = None
 
     @property
     def http_base_url(self) -> str:
@@ -869,26 +869,19 @@ class EmbeddedServer:
 
     async def __aenter__(self) -> "EmbeddedServer":
         """Start the embedded server."""
-        app = FastAPI(title="Xtalk Automated Test Server")
-        xtalk_instance = Xtalk.from_config(self._config)
-        xtalk_instance.mount_routes(app)
-
-        uvicorn_config = uvicorn.Config(
-            app=app,
-            host=self._host,
-            port=self._port,
-            log_level="error",
-            lifespan="off",
+        ctx = multiprocessing.get_context("spawn")
+        self._process = ctx.Process(
+            target=_run_embedded_server_process,
+            args=(self._config, self._host, self._port),
+            name="xtalk-test-server",
         )
-        self._server = uvicorn.Server(uvicorn_config)
-        self._server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
-        self._task = asyncio.create_task(self._server.serve())
+        self._process.start()
 
         deadline = time.monotonic() + 15.0
         while True:
-            if self._server.started:
+            if self._is_port_open():
                 return self
-            if self._task.done():
+            if self._process.exitcode is not None:
                 raise RuntimeError("Embedded server exited before startup completed")
             if time.monotonic() >= deadline:
                 raise TimeoutError("Timed out waiting for embedded server startup")
@@ -896,10 +889,34 @@ class EmbeddedServer:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         """Stop the embedded server."""
-        if self._server is not None:
-            self._server.should_exit = True
-        if self._task is not None:
-            await self._task
+        if self._process is None:
+            return
+        if self._process.is_alive():
+            self._process.terminate()
+            self._process.join(timeout=5.0)
+        if self._process.is_alive():
+            self._process.kill()
+            self._process.join(timeout=5.0)
+        self._process.close()
+        self._process = None
+
+    def _is_port_open(self) -> bool:
+        """Return whether the embedded server port is accepting TCP connections."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            return sock.connect_ex((self._host, self._port)) == 0
+
+
+def _run_embedded_server_process(
+    config: dict[str, Any],
+    host: str,
+    port: int,
+) -> None:
+    """Run the embedded FastAPI/Uvicorn server inside a dedicated process."""
+    app = FastAPI(title="Xtalk Automated Test Server")
+    xtalk_instance = Xtalk.from_config(config)
+    xtalk_instance.mount_routes(app)
+    uvicorn.run(app, host=host, port=port, log_level="error", lifespan="off")
 
 
 class AnchorClock:
@@ -1461,24 +1478,17 @@ class CaseRunner:
             if self._playback is not None:
                 playback_idle = await self._playback.is_idle()
 
-            await websocket.send(b"\x00" * ClientVADController.FRAME_BYTES)
-
             async with self._activity_lock:
                 last_activity = self._last_activity
             quiet_for = asyncio.get_running_loop().time() - last_activity
             last_user_end = await self._anchors.get("last_user_end")
             ai_end_seen = await self._anchors.get("last_ai_end")
-            last_full_audio_at = self._last_full_audio_at
             if self._scheduler_done.is_set() and playback_idle:
                 if last_user_end is None:
                     if quiet_for >= self._settle_seconds:
                         return
                 elif ai_end_seen is not None and ai_end_seen >= last_user_end:
-                    if (
-                        last_full_audio_at is not None
-                        and last_full_audio_at >= ai_end_seen
-                        and quiet_for >= self._settle_seconds
-                    ):
+                    if quiet_for >= self._settle_seconds:
                         return
             if self._ws_closed.is_set():
                 return
@@ -1490,6 +1500,8 @@ class CaseRunner:
 
     async def _materialize_output(self) -> None:
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        if await self._copy_server_recording():
+            return
         full_audio_bytes = bytes(self._full_audio_bytes)
         if not full_audio_bytes:
             raise RuntimeError(
@@ -1505,6 +1517,23 @@ class CaseRunner:
             sample_rate=48000,
             channels=2,
         )
+
+    async def _copy_server_recording(self) -> bool:
+        """Copy the server-side recording file when it is available locally."""
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if self._temp_recording_path.exists():
+                try:
+                    size = self._temp_recording_path.stat().st_size
+                except OSError:
+                    size = 0
+                if size > 44:
+                    await asyncio.to_thread(
+                        shutil.copyfile, self._temp_recording_path, self._output_path
+                    )
+                    return True
+            await asyncio.sleep(0.1)
+        return False
 
 
 def validate_vad_configuration(config: dict[str, Any], *, with_vad: bool) -> None:

--- a/src/xtalk/serving/events.py
+++ b/src/xtalk/serving/events.py
@@ -223,9 +223,8 @@ class TTSChunkGenerated(BaseEvent):
 class TTSChunkPlayed(BaseEvent):
     """Frontend confirmed playback completion for a TTS audio chunk.
 
-    InputGateway publishes this after receiving tts_chunk_played.
-    RecordingManager subscribes and writes the chunk into right-channel buffer.
-    Chunks are processed in FIFO order (no index needed).
+    InputGateway publishes this after receiving tts_chunk_played so downstream
+    listeners can observe frontend playback completion in FIFO order.
     """
 
     TYPE: ClassVar[str] = "tts.chunk_played_confirm"

--- a/src/xtalk/serving/modules/input_gateway.py
+++ b/src/xtalk/serving/modules/input_gateway.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import asyncio
 import json
 
 from fastapi import WebSocket, WebSocketDisconnect
@@ -271,6 +272,7 @@ class InputGateway(EventListenerMixin):
         self.websocket = websocket
         self.config: dict[str, Any] = config or {}
         self.input_sample_rate = _resolve_input_sample_rate(self.config)
+        self._pending_text_tasks: set[asyncio.Task[None]] = set()
 
         self.text_msg_handler = TextMsgHandler(event_bus, session_id, websocket)
 
@@ -298,7 +300,9 @@ class InputGateway(EventListenerMixin):
                 data = await self.websocket.receive()
                 if data.get("type") == "websocket.disconnect":
                     break
-
+                if data.get("type") == "websocket.receive" and "text" in data:
+                    self._schedule_text_message(data["text"])
+                    continue
                 await self._process_message(data)
         except WebSocketDisconnect as e:
             logger.info(
@@ -321,6 +325,40 @@ class InputGateway(EventListenerMixin):
                     self.session_id,
                     e,
                 )
+        finally:
+            await self._wait_for_pending_text_tasks()
+
+    def _schedule_text_message(self, text_message: str) -> None:
+        """Run text message handling without blocking binary frame reception."""
+        task = asyncio.create_task(self._run_text_message_task(text_message))
+        self._pending_text_tasks.add(task)
+        task.add_done_callback(self._pending_text_tasks.discard)
+
+    async def _run_text_message_task(self, text_message: str) -> None:
+        """Handle one text message and surface task failures through logging."""
+        try:
+            await self._handle_text_message(text_message)
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "disconnect" in error_msg or "closed" in error_msg:
+                logger.info(
+                    "WebSocket text message task stopped after disconnect - session: %s, detail: %s",
+                    self.session_id,
+                    e,
+                )
+            else:
+                logger.error(
+                    "WebSocket text message task failed - session: %s, error: %s",
+                    self.session_id,
+                    e,
+                )
+
+    async def _wait_for_pending_text_tasks(self) -> None:
+        """Await all in-flight text message tasks before shutting down the loop."""
+        if not self._pending_text_tasks:
+            return
+        pending = tuple(self._pending_text_tasks)
+        await asyncio.gather(*pending, return_exceptions=True)
 
     async def _process_message(self, data: dict) -> None:
         """Process a raw WebSocket receive payload and publish events."""

--- a/src/xtalk/serving/modules/output_gateway.py
+++ b/src/xtalk/serving/modules/output_gateway.py
@@ -59,6 +59,7 @@ class OutputGateway(EventListenerMixin):
         self.session_id = session_id
         self.websocket = websocket
         self.config: dict[str, Any] = config or {}
+        self._full_audio_chunk_bytes = 128 * 1024
 
     # ── WebSocket helpers ───────────────────────────────────────────
 
@@ -271,15 +272,18 @@ class OutputGateway(EventListenerMixin):
     async def _send_full_audio_frame_signal(self, event: FullAudioFrameReady) -> None:
         if not event.audio_chunk:
             return
-        await self._forward(
-            "full_audio_frame",
-            {
-                "audio_base64": base64.b64encode(event.audio_chunk).decode("ascii"),
-                "sample_rate": int(event.sample_rate),
-                "channels": int(event.channels),
-                "format": event.format,
-            },
-        )
+        total_bytes = len(event.audio_chunk)
+        for start in range(0, total_bytes, self._full_audio_chunk_bytes):
+            chunk = event.audio_chunk[start : start + self._full_audio_chunk_bytes]
+            await self._forward(
+                "full_audio_frame",
+                {
+                    "audio_base64": base64.b64encode(chunk).decode("ascii"),
+                    "sample_rate": int(event.sample_rate),
+                    "channels": int(event.channels),
+                    "format": event.format,
+                },
+            )
 
     @EventListenerMixin.event_handler(TTSVoiceChange, priority=5)
     async def _send_voice_changed_signal(self, event: TTSVoiceChange) -> None:

--- a/src/xtalk/serving/modules/recording_manager.py
+++ b/src/xtalk/serving/modules/recording_manager.py
@@ -224,10 +224,6 @@ class RecordingManager(Manager):
         elapsed_sec = max(0.0, current - self._origin_mono)
         return int(elapsed_sec * self.TARGET_SR)
 
-    def _total_user_samples_locked(self) -> int:
-        """Return the absolute left-channel length in samples."""
-        return self._emitted_user_samples + self._user_buffer.total_samples
-
     def _total_tts_samples_locked(self) -> int:
         """Return the absolute right-channel length in samples."""
         return self._emitted_tts_samples + self._tts_buffer.total_samples
@@ -257,29 +253,6 @@ class RecordingManager(Manager):
                 break
             interval_sec = self._user_frame_samples / self.TARGET_SR
             self._user_next_tick_mono += interval_sec
-
-    def _align_user_to_target_locked(
-        self, target_total: int, boundary_mono: Optional[float] = None
-    ) -> None:
-        """Extend the left channel to a target sample position with silence."""
-        if boundary_mono is not None:
-            self._advance_user_until_locked(boundary_mono)
-        missing = max(0, target_total - self._total_user_samples_locked())
-        if missing > 0:
-            self._user_buffer.append_silence(missing)
-        if (
-            boundary_mono is not None
-            and self._user_next_tick_mono is not None
-            and self._user_frame_samples > 0
-        ):
-            interval_sec = self._user_frame_samples / self.TARGET_SR
-            self._user_next_tick_mono = boundary_mono + interval_sec
-
-    def _align_user_to_clock_locked(self, now_mono: float) -> None:
-        """Extend the left channel to the current clock boundary with silence."""
-        self._align_user_to_target_locked(
-            self._clock_samples_locked(now_mono), boundary_mono=now_mono
-        )
 
     def _truncate_tts_buffer_locked(self, target_total_samples: int) -> None:
         """Trim the unflushed right channel to an absolute sample position."""
@@ -349,8 +322,8 @@ class RecordingManager(Manager):
 
     def _prepare_shutdown_locked(self, now_mono: float) -> None:
         """Fold queued scheduler state into channel buffers before finalization."""
-        if self._user_next_tick_mono is not None or self._user_queue:
-            self._align_user_to_clock_locked(now_mono)
+        if self._user_next_tick_mono is not None:
+            self._advance_user_until_locked(now_mono)
         while self._user_queue:
             self._user_buffer.append_pcm(self._user_queue.popleft())
 
@@ -424,10 +397,6 @@ class RecordingManager(Manager):
                             self._clear_tts_playback_locked()
                             self._tts_record_point_mono = now_mono
                             if not self._tts_queue:
-                                self._align_user_to_target_locked(
-                                    self._total_tts_samples_locked(),
-                                    boundary_mono=now_mono,
-                                )
                                 should_flush = True
                                 self._tts_wakeup.clear()
                                 break
@@ -475,17 +444,29 @@ class RecordingManager(Manager):
         interleaved[1::2] = tts
         return interleaved.tobytes()
 
+    @staticmethod
+    def _pad_pcm_bytes(pcm_bytes: bytes, n_samples: int) -> bytes:
+        """Pad mono PCM bytes with trailing silence to the requested length."""
+        target_len = n_samples * 2
+        if len(pcm_bytes) >= target_len:
+            return pcm_bytes
+        return pcm_bytes + (b"\x00" * (target_len - len(pcm_bytes)))
+
     async def _drain_aligned_stereo_chunk(self) -> bytes:
-        """Drain the aligned portion shared by both channels as stereo PCM."""
+        """Drain buffered audio and pad the shorter channel only in the output."""
         async with self._lock:
-            n_write = min(self._user_buffer.total_samples, self._tts_buffer.total_samples)
+            user_samples = self._user_buffer.total_samples
+            tts_samples = self._tts_buffer.total_samples
+            n_write = max(user_samples, tts_samples)
             if n_write <= 0:
                 return b""
 
             user_bytes = self._user_buffer.consume_prefix(n_write)
             tts_bytes = self._tts_buffer.consume_prefix(n_write)
-            self._emitted_user_samples += n_write
-            self._emitted_tts_samples += n_write
+            self._emitted_user_samples += user_samples
+            self._emitted_tts_samples += tts_samples
+            user_bytes = self._pad_pcm_bytes(user_bytes, n_write)
+            tts_bytes = self._pad_pcm_bytes(tts_bytes, n_write)
         return self._interleave_stereo(user_bytes, tts_bytes, n_write)
 
     async def _flush_outputs(self) -> bool:
@@ -678,9 +659,6 @@ class RecordingManager(Manager):
             self._tts_paused = False
 
             if self._tts_playing_ends_at is None and not self._tts_queue:
-                self._align_user_to_target_locked(
-                    self._total_tts_samples_locked(), boundary_mono=now_mono
-                )
                 should_flush = True
 
             self._tts_wakeup.set()
@@ -700,9 +678,6 @@ class RecordingManager(Manager):
 
                 now_mono = time.monotonic()
                 self._finalize_tts_to_boundary_locked(now_mono)
-                self._align_user_to_target_locked(
-                    self._total_tts_samples_locked(), boundary_mono=now_mono
-                )
                 self._tts_wakeup.set()
             await self._flush_all_outputs()
         except Exception as e:

--- a/src/xtalk/serving/modules/recording_manager.py
+++ b/src/xtalk/serving/modules/recording_manager.py
@@ -3,8 +3,8 @@
 RecordingManager
 
 Session-level audio recorder that produces a stereo WAV file:
-- Left channel: raw user audio
-- Right channel: TTS output
+- Left channel: scheduled user audio
+- Right channel: scheduled TTS audio
 
 Recording file is initialized lazily on first audio frame or when a
 SessionConfigReceived event is received. If the client sends a session_config
@@ -18,40 +18,123 @@ Client usage:
     }));
 """
 
+import asyncio
 import os
 import time
 import wave
-import asyncio
 from collections import deque
-from typing import Optional, Any, Literal
+from typing import Any, Optional
 
 import numpy as np
 
 from ...log_utils import logger
 from ..event_bus import EventBus
-from ..interfaces import Manager
 from ..events import (
     AudioFrameReceived,
     FullAudioFrameReady,
-    TTSChunkGenerated,
-    TTSChunkPlayed,
     TTSPaused,
+    TTSChunkGenerated,
     TTSResumed,
     TTSStarted,
     TTSStopped,
     SessionConfigReceived,
 )
+from ..interfaces import Manager
 
 
-# TODO: refined time control by adding timestamps to user audio frames and TTS chunks; current implementation does not consider network latency and code execution time and may drift.
-# TODO: interrupted chunk capture is estimated from backend timing only; without
-# frontend playback-progress signals, chunk-internal stop positions remain
-# approximate.
+class _MonoBuffer:
+    """Sparse mono PCM buffer that keeps silence as sample counts."""
+
+    def __init__(self) -> None:
+        self._segments: deque[np.ndarray | int] = deque()
+        self.total_samples: int = 0
+
+    def clear(self) -> None:
+        """Remove all buffered samples."""
+        self._segments.clear()
+        self.total_samples = 0
+
+    def append_pcm(self, data_i16: np.ndarray) -> None:
+        """Append PCM samples to the tail."""
+        if data_i16.size <= 0:
+            return
+        self._segments.append(data_i16.copy())
+        self.total_samples += int(data_i16.size)
+
+    def append_silence(self, n_samples: int) -> None:
+        """Append silence to the tail."""
+        if n_samples <= 0:
+            return
+        if self._segments and isinstance(self._segments[-1], int):
+            self._segments[-1] += n_samples
+        else:
+            self._segments.append(n_samples)
+        self.total_samples += n_samples
+
+    def truncate(self, keep_samples: int) -> None:
+        """Keep only the first ``keep_samples`` samples."""
+        keep = max(0, min(keep_samples, self.total_samples))
+        while self.total_samples > keep and self._segments:
+            tail = self._segments[-1]
+            tail_samples = tail if isinstance(tail, int) else int(tail.size)
+            overflow = self.total_samples - keep
+            if tail_samples <= overflow:
+                self._segments.pop()
+                self.total_samples -= tail_samples
+                continue
+
+            remain = tail_samples - overflow
+            if isinstance(tail, int):
+                self._segments[-1] = remain
+            else:
+                self._segments[-1] = tail[:remain].copy()
+            self.total_samples = keep
+
+    def consume_prefix(self, n_samples: int) -> bytes:
+        """Remove and materialize a prefix as PCM int16 bytes."""
+        remaining = min(max(0, n_samples), self.total_samples)
+        parts: list[bytes] = []
+        while remaining > 0 and self._segments:
+            head = self._segments[0]
+            head_samples = head if isinstance(head, int) else int(head.size)
+            take = min(remaining, head_samples)
+            if isinstance(head, int):
+                parts.append(b"\x00" * (take * 2))
+                if take == head_samples:
+                    self._segments.popleft()
+                else:
+                    self._segments[0] = head_samples - take
+            else:
+                parts.append(head[:take].tobytes())
+                if take == head_samples:
+                    self._segments.popleft()
+                else:
+                    self._segments[0] = head[take:].copy()
+            self.total_samples -= take
+            remaining -= take
+        return b"".join(parts)
+
+    def materialize(self) -> np.ndarray:
+        """Materialize the entire buffer into a contiguous PCM array."""
+        if self.total_samples <= 0:
+            return np.zeros((0,), dtype=np.int16)
+
+        out = np.zeros((self.total_samples,), dtype=np.int16)
+        cursor = 0
+        for segment in self._segments:
+            if isinstance(segment, int):
+                cursor += segment
+                continue
+            next_cursor = cursor + int(segment.size)
+            out[cursor:next_cursor] = segment
+            cursor = next_cursor
+        return out
+
+
 class RecordingManager(Manager):
     """Record user and TTS audio streams for each session."""
 
-    TARGET_SR: int = 48000  # Unified output sample rate
-    FLUSH_INTERVAL_SEC: float = 10.0  # Periodic flush interval
+    TARGET_SR: int = 48000
 
     def __init__(
         self, event_bus: EventBus, session_id: str, config: dict[str, Any] | None = None
@@ -68,39 +151,43 @@ class RecordingManager(Manager):
         if not self._enabled:
             return
 
-        # Defer file creation until SessionConfigReceived or first audio
         self._file_initialized = False
         self._out_dir: str = ""
         self._out_path: str = ""
-
-        # Stereo buffers (int16 PCM bytes)
-        self._ch_user = bytearray()  # Left channel: raw user input
-        self._ch_tts = bytearray()  # Right channel: TTS output
-        self._samples_user = 0
-        self._samples_tts = 0
-
-        # FIFO queue of pending TTS chunks until playback confirmed/estimated.
-        self._pending_tts_chunks: deque[np.ndarray] = deque()
-        self._pending_tts_samples = 0
-        self._estimated_played_samples = 0
-        self._tts_state: Literal["idle", "playing", "paused"] = "idle"
-        self._last_progress_mono_ts: Optional[float] = None
-
-        # Time-based padding: track when each channel ends (in seconds, using time.time())
-        # Initialized lazily on first audio to avoid initial silence gap
-        self._timer_user: Optional[float] = None  # User channel end time
-        self._timer_tts: Optional[float] = None  # TTS channel end time
-
-        # Concurrency primitives
-        self._lock = asyncio.Lock()
-        self._io_lock = asyncio.Lock()
-        self._flush_task: Optional[asyncio.Task] = asyncio.create_task(
-            self._periodic_flush_loop()
-        )
         self._wf: Optional[wave.Wave_write] = None
 
+        self._user_buffer = _MonoBuffer()
+        self._tts_buffer = _MonoBuffer()
+        self._emitted_user_samples = 0
+        self._emitted_tts_samples = 0
+
+        self._origin_mono: Optional[float] = None
+
+        self._user_queue: deque[np.ndarray] = deque()
+        self._user_frame_samples = 0
+        self._user_next_tick_mono: Optional[float] = None
+        self._user_wakeup = asyncio.Event()
+
+        self._tts_queue: deque[np.ndarray] = deque()
+        self._tts_wakeup = asyncio.Event()
+        self._tts_paused = False
+        self._tts_stop_allowed = False
+        self._tts_record_point_mono: Optional[float] = None
+        self._tts_playing_chunk: Optional[np.ndarray] = None
+        self._tts_playing_start_sample: Optional[int] = None
+        self._tts_playing_ends_at: Optional[float] = None
+
+        self._lock = asyncio.Lock()
+        self._io_lock = asyncio.Lock()
+        self._user_task: Optional[asyncio.Task] = asyncio.create_task(
+            self._user_scheduler_loop()
+        )
+        self._tts_task: Optional[asyncio.Task] = asyncio.create_task(
+            self._tts_scheduler_loop()
+        )
+
     def _init_file(self, custom_path: str | None = None) -> None:
-        """Initialize WAV file. Called lazily on first audio or config message."""
+        """Initialize the WAV file lazily."""
         if not self._recording_enabled or self._file_initialized:
             return
 
@@ -109,293 +196,269 @@ class RecordingManager(Manager):
             self._out_dir = os.path.dirname(custom_path) or "."
         else:
             self._out_dir = os.path.join("logs", "session_audio")
-            _ts = time.time()
-            _ts_str = (
-                time.strftime("%Y%m%d_%H%M%S", time.localtime(_ts))
-                + f"_{int((_ts - int(_ts)) * 1000):03d}"
+            now_wall = time.time()
+            now_str = (
+                time.strftime("%Y%m%d_%H%M%S", time.localtime(now_wall))
+                + f"_{int((now_wall - int(now_wall)) * 1000):03d}"
             )
-            self._out_path = os.path.join(self._out_dir, f"{_ts_str}.wav")
+            self._out_path = os.path.join(self._out_dir, f"{now_str}.wav")
 
         os.makedirs(self._out_dir, exist_ok=True)
 
-        # Open WAV file for the session
         self._wf = wave.open(self._out_path, "wb")
         self._wf.setnchannels(2)
         self._wf.setsampwidth(2)
         self._wf.setframerate(self.TARGET_SR)
         self._file_initialized = True
 
-    def _init_audio_timer(self):
-        """Initialize audio timers on first audio frame (user/tts)."""
-        if self._timer_user is not None and self._timer_tts is not None:
-            return
-        now = time.time()
-        self._timer_user = now
-        self._timer_tts = now
+    def _ensure_timeline_started(self, now_mono: float | None = None) -> None:
+        """Start the session monotonic clock on first audio activity."""
+        if self._origin_mono is None:
+            self._origin_mono = time.monotonic() if now_mono is None else now_mono
 
-    def _init_on_audio(self):
-        """Initialize recording on first audio frame if not yet initialized."""
-        if self._recording_enabled and not self._file_initialized:
-            self._init_file(None)
-        self._init_audio_timer()
+    def _clock_samples_locked(self, now_mono: float | None = None) -> int:
+        """Return elapsed session samples on the monotonic clock."""
+        if self._origin_mono is None:
+            return 0
+        current = time.monotonic() if now_mono is None else now_mono
+        elapsed_sec = max(0.0, current - self._origin_mono)
+        return int(elapsed_sec * self.TARGET_SR)
 
-    def _reset_pending_tts_locked(self) -> None:
-        """Reset pending TTS playback state under ``self._lock``."""
-        self._pending_tts_chunks.clear()
-        self._pending_tts_samples = 0
-        self._estimated_played_samples = 0
-        self._tts_state = "idle"
-        self._last_progress_mono_ts = None
+    def _total_user_samples_locked(self) -> int:
+        """Return the absolute left-channel length in samples."""
+        return self._emitted_user_samples + self._user_buffer.total_samples
 
-    def _advance_estimated_tts_progress_locked(self, now_mono: float) -> None:
-        """Advance estimated TTS playback progress under ``self._lock``."""
-        if self._tts_state != "playing" or self._pending_tts_samples <= 0:
-            self._last_progress_mono_ts = now_mono
-            return
-        if self._last_progress_mono_ts is None:
-            self._last_progress_mono_ts = now_mono
-            return
+    def _total_tts_samples_locked(self) -> int:
+        """Return the absolute right-channel length in samples."""
+        return self._emitted_tts_samples + self._tts_buffer.total_samples
 
-        elapsed_sec = now_mono - self._last_progress_mono_ts
-        self._last_progress_mono_ts = now_mono
-        if elapsed_sec <= 0:
-            return
+    def _clear_tts_playback_locked(self) -> None:
+        """Reset the active TTS wait state."""
+        self._tts_playing_chunk = None
+        self._tts_playing_start_sample = None
+        self._tts_playing_ends_at = None
 
-        added_samples = int(elapsed_sec * self.TARGET_SR)
-        if added_samples <= 0:
-            return
+    def _emit_user_tick_locked(self) -> bool:
+        """Emit one user cadence tick into the left channel."""
+        if self._user_frame_samples <= 0:
+            return False
+        if self._user_queue:
+            self._user_buffer.append_pcm(self._user_queue.popleft())
+        else:
+            self._user_buffer.append_silence(self._user_frame_samples)
+        return True
 
-        remaining_samples = max(
-            0, self._pending_tts_samples - self._estimated_played_samples
-        )
-        self._estimated_played_samples += min(added_samples, remaining_samples)
+    def _advance_user_until_locked(self, now_mono: float) -> None:
+        """Emit every user tick whose scheduled time is due."""
+        while self._user_next_tick_mono is not None and self._user_frame_samples > 0:
+            if self._user_next_tick_mono > now_mono + 1e-6:
+                break
+            if not self._emit_user_tick_locked():
+                break
+            interval_sec = self._user_frame_samples / self.TARGET_SR
+            self._user_next_tick_mono += interval_sec
 
-    def _consume_pending_tts_prefix_locked(self, n_samples: int) -> np.ndarray:
-        """Consume and return a prefix from pending TTS samples under ``self._lock``."""
-        if n_samples <= 0 or self._pending_tts_samples <= 0:
-            self._estimated_played_samples = 0
-            return np.zeros((0,), dtype=np.int16)
+    def _align_user_to_target_locked(
+        self, target_total: int, boundary_mono: Optional[float] = None
+    ) -> None:
+        """Extend the left channel to a target sample position with silence."""
+        if boundary_mono is not None:
+            self._advance_user_until_locked(boundary_mono)
+        missing = max(0, target_total - self._total_user_samples_locked())
+        if missing > 0:
+            self._user_buffer.append_silence(missing)
+        if (
+            boundary_mono is not None
+            and self._user_next_tick_mono is not None
+            and self._user_frame_samples > 0
+        ):
+            interval_sec = self._user_frame_samples / self.TARGET_SR
+            self._user_next_tick_mono = boundary_mono + interval_sec
 
-        remaining = min(n_samples, self._pending_tts_samples)
-        parts: list[np.ndarray] = []
-        while remaining > 0 and self._pending_tts_chunks:
-            chunk = self._pending_tts_chunks[0]
-            if chunk.size <= remaining:
-                parts.append(chunk)
-                self._pending_tts_chunks.popleft()
-                self._pending_tts_samples -= chunk.size
-                remaining -= chunk.size
-                continue
-
-            parts.append(chunk[:remaining].copy())
-            self._pending_tts_chunks[0] = chunk[remaining:].copy()
-            self._pending_tts_samples -= remaining
-            remaining = 0
-
-        consumed_samples = n_samples - remaining
-        self._estimated_played_samples = max(
-            0, self._estimated_played_samples - consumed_samples
-        )
-        if self._pending_tts_samples == 0:
-            self._tts_state = "idle"
-        return (
-            np.concatenate(parts)
-            if parts
-            else np.zeros((0,), dtype=np.int16)
+    def _align_user_to_clock_locked(self, now_mono: float) -> None:
+        """Extend the left channel to the current clock boundary with silence."""
+        self._align_user_to_target_locked(
+            self._clock_samples_locked(now_mono), boundary_mono=now_mono
         )
 
-    # ==================== Event handlers ====================
+    def _truncate_tts_buffer_locked(self, target_total_samples: int) -> None:
+        """Trim the unflushed right channel to an absolute sample position."""
+        keep_samples = max(0, target_total_samples - self._emitted_tts_samples)
+        self._tts_buffer.truncate(keep_samples)
 
-    @Manager.event_handler(SessionConfigReceived, priority=100)
-    async def _on_session_config(self, event: SessionConfigReceived) -> None:
-        """Initialize recording with client-provided path."""
-        if not self._recording_enabled or self._file_initialized:
+    def _append_tts_gap_to_now_locked(self, now_mono: float) -> None:
+        """Fill right-channel silence from the last record point to now."""
+        record_point_mono = self._tts_record_point_mono
+        if record_point_mono is None:
+            record_point_mono = self._origin_mono
+        if record_point_mono is None:
+            self._tts_record_point_mono = now_mono
             return
-        self._init_file(event.recording_path)
 
-    @Manager.event_handler(AudioFrameReceived, priority=50)
-    async def _on_audio_frame(self, event: AudioFrameReceived) -> None:
-        """Append raw user audio to the left channel."""
-        if not self._enabled:
+        gap_samples = max(
+            0,
+            self._clock_samples_locked(now_mono)
+            - self._clock_samples_locked(record_point_mono),
+        )
+        if gap_samples > 0:
+            self._tts_buffer.append_silence(gap_samples)
+        self._tts_record_point_mono = now_mono
+
+    def _start_next_tts_chunk_locked(self, now_mono: float) -> None:
+        """Append the next queued TTS chunk to the right channel."""
+        if not self._tts_queue:
             return
-        self._init_on_audio()
-        try:
-            pcm = event.audio_data or b""
-            if not pcm:
-                return
-            src_sr = event.sample_rate or 16000
-            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
-            await self._append_user_audio(data_i16)
-        except Exception as e:
-            logger.warning("RecordingManager: failed to handle audio frame: %s", e)
+        self._append_tts_gap_to_now_locked(now_mono)
+        chunk = self._tts_queue.popleft()
+        start_sample = self._total_tts_samples_locked()
+        self._tts_buffer.append_pcm(chunk)
+        self._tts_playing_chunk = chunk
+        self._tts_playing_start_sample = start_sample
+        self._tts_playing_ends_at = now_mono + (chunk.size / self.TARGET_SR)
 
-    @Manager.event_handler(TTSStarted, priority=50)
-    async def _on_tts_started(self, event: TTSStarted) -> None:
-        """Clear pending TTS chunks when a new TTS generation starts. Because chunks played now will be from the new generation"""
-        if not self._enabled:
-            return
-        async with self._lock:
-            self._reset_pending_tts_locked()
+    def _pause_or_stop_current_tts_locked(
+        self, now_mono: float, *, keep_remainder: bool
+    ) -> np.ndarray | None:
+        """Cut the active TTS chunk at the current clock position."""
+        target_total = min(
+            self._total_tts_samples_locked(), self._clock_samples_locked(now_mono)
+        )
+        remainder: np.ndarray | None = None
 
-    @Manager.event_handler(TTSChunkGenerated, priority=50)
-    async def _on_tts_chunk_generated(self, event: TTSChunkGenerated) -> None:
-        """Queue generated TTS chunks until playback is confirmed."""
-        if not self._enabled:
-            return
-        try:
-            pcm = event.audio_chunk or b""
-            if not pcm:
-                return
-            src_sr = event.sample_rate or 48000
-            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
-            if data_i16.size <= 0:
-                return
-            now_mono = time.monotonic()
-            async with self._lock:
-                self._advance_estimated_tts_progress_locked(now_mono)
-                self._pending_tts_chunks.append(data_i16.copy())
-                self._pending_tts_samples += data_i16.size
-                if self._tts_state == "idle":
-                    self._tts_state = "playing"
-                if self._last_progress_mono_ts is None:
-                    self._last_progress_mono_ts = now_mono
-        except Exception as e:
-            logger.warning("RecordingManager: failed to queue TTS chunk: %s", e)
+        if (
+            self._tts_playing_chunk is not None
+            and self._tts_playing_start_sample is not None
+        ):
+            played_samples = max(0, target_total - self._tts_playing_start_sample)
+            played_samples = min(played_samples, int(self._tts_playing_chunk.size))
+            target_total = self._tts_playing_start_sample + played_samples
+            if keep_remainder and played_samples < self._tts_playing_chunk.size:
+                remainder = self._tts_playing_chunk[played_samples:].copy()
 
-    @Manager.event_handler(TTSPaused, priority=50)
-    async def _on_tts_paused(self, event: TTSPaused) -> None:
-        """Pause estimated TTS playback progression."""
-        if not self._enabled:
-            return
-        async with self._lock:
-            self._advance_estimated_tts_progress_locked(time.monotonic())
-            self._tts_state = "paused"
+        self._truncate_tts_buffer_locked(target_total)
+        self._clear_tts_playback_locked()
+        return remainder
 
-    @Manager.event_handler(TTSResumed, priority=50)
-    async def _on_tts_resumed(self, event: TTSResumed) -> None:
-        """Resume estimated TTS playback progression."""
-        if not self._enabled:
-            return
-        async with self._lock:
-            self._tts_state = "playing" if self._pending_tts_samples > 0 else "idle"
-            self._last_progress_mono_ts = time.monotonic()
+    def _finalize_tts_to_boundary_locked(self, now_mono: float) -> None:
+        """Cut pending TTS playback to the current boundary and drop future queue items."""
+        self._pause_or_stop_current_tts_locked(now_mono, keep_remainder=False)
+        self._tts_queue.clear()
+        self._tts_paused = False
+        self._tts_stop_allowed = False
+        self._tts_record_point_mono = now_mono
 
-    @Manager.event_handler(TTSChunkPlayed, priority=50)
-    async def _on_tts_chunk_played(self, event: TTSChunkPlayed) -> None:
-        """Pop one TTS chunk from queue and append to the right channel."""
-        if not self._enabled:
-            return
-        self._init_on_audio()
-        try:
-            async with self._lock:
-                self._advance_estimated_tts_progress_locked(time.monotonic())
-                if not self._pending_tts_chunks:
-                    return
-                data_i16 = self._pending_tts_chunks.popleft()
-                self._pending_tts_samples -= data_i16.size
-                self._estimated_played_samples = max(
-                    0, self._estimated_played_samples - data_i16.size
-                )
-                if self._pending_tts_samples == 0:
-                    self._tts_state = "idle"
-            await self._append_tts_audio(data_i16)
-        except Exception as e:
-            logger.warning("RecordingManager: failed to handle TTS chunk played: %s", e)
+    def _prepare_shutdown_locked(self, now_mono: float) -> None:
+        """Fold queued scheduler state into channel buffers before finalization."""
+        if self._user_next_tick_mono is not None or self._user_queue:
+            self._align_user_to_clock_locked(now_mono)
+        while self._user_queue:
+            self._user_buffer.append_pcm(self._user_queue.popleft())
 
-    @Manager.event_handler(TTSStopped, priority=50)
-    async def _on_tts_stopped(self, event: TTSStopped) -> None:
-        """Append the estimated played TTS prefix, then discard the remainder."""
-        if not self._enabled:
-            return
-        self._init_on_audio()
-        try:
-            async with self._lock:
-                self._advance_estimated_tts_progress_locked(time.monotonic())
-                data_i16 = self._consume_pending_tts_prefix_locked(
-                    self._estimated_played_samples
-                )
-                self._reset_pending_tts_locked()
-            await self._append_tts_audio(data_i16)
-        except Exception as e:
-            logger.warning("RecordingManager: failed to handle TTS stopped: %s", e)
-
-    # ==================== Resampling ====================
+        self._finalize_tts_to_boundary_locked(now_mono)
 
     def _resample_to_int16(
         self, pcm_bytes: bytes, src_sr: int, dst_sr: int
     ) -> np.ndarray:
-        """Resample PCM int16 bytes to target sample rate."""
+        """Resample PCM int16 bytes to the target sample rate."""
         if not pcm_bytes:
             return np.zeros((0,), dtype=np.int16)
         data = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32)
         if src_sr == dst_sr or data.size == 0:
             return np.clip(data, -32768, 32767).astype(np.int16)
-        # Linear interpolation resampling
+
         old_n = data.size
         new_n = int(round(old_n * (dst_sr / float(src_sr))))
         if new_n <= 0:
             return np.zeros((0,), dtype=np.int16)
+
         x_old = np.linspace(0.0, 1.0, num=old_n, endpoint=False)
         x_new = np.linspace(0.0, 1.0, num=new_n, endpoint=False)
         resampled = np.interp(x_new, x_old, data)
         return np.clip(resampled, -32768, 32767).astype(np.int16)
 
-    # ==================== Channel append with time-based silence padding ====================
-
-    async def _append_user_audio(self, data_i16: np.ndarray) -> None:
-        """Append user audio to left channel with time-based silence padding."""
-        n = data_i16.size
-        if n <= 0:
-            return
-        audio_duration = n / self.TARGET_SR
-        async with self._lock:
-            now = time.time()
-            # Pad silence when elapsed time since last audio is larger than audio_duration
-            silence_duration = max(0.0, now - audio_duration - self._timer_user)
-            silence_samples = int(silence_duration * self.TARGET_SR)
-            if silence_samples > 0:
-                self._ch_user.extend(b"\x00" * (silence_samples * 2))
-                self._samples_user += silence_samples
-
-            # Append audio chunk
-            self._ch_user.extend(data_i16.tobytes())
-            self._samples_user += n
-
-            # Update timer
-            self._timer_user = self._timer_user + silence_duration + audio_duration
-
-    async def _append_tts_audio(self, data_i16: np.ndarray) -> None:
-        """Append TTS audio to right channel with time-based silence padding."""
-        n = data_i16.size
-        if n <= 0:
-            return
-        audio_duration = n / self.TARGET_SR
-        async with self._lock:
-            now = time.time()
-            # Pad silence when elapsed time since last audio is larger than audio_duration
-            silence_duration = max(0.0, now - audio_duration - self._timer_tts)
-            silence_samples = int(silence_duration * self.TARGET_SR)
-            if silence_samples > 0:
-                self._ch_tts.extend(b"\x00" * (silence_samples * 2))
-                self._samples_tts += silence_samples
-
-            # Append audio chunk
-            self._ch_tts.extend(data_i16.tobytes())
-            self._samples_tts += n
-
-            # Update timer
-            self._timer_tts = self._timer_tts + silence_duration + audio_duration
-
-    # ==================== Periodic flushing ====================
-
-    async def _periodic_flush_loop(self) -> None:
+    async def _user_scheduler_loop(self) -> None:
+        """Consume queued user audio at the latest frame cadence."""
         try:
             while True:
-                await asyncio.sleep(self.FLUSH_INTERVAL_SEC)
+                timeout: float | None = None
+
+                async with self._lock:
+                    now_mono = time.monotonic()
+                    self._advance_user_until_locked(now_mono)
+                    if self._user_next_tick_mono is None or self._user_frame_samples <= 0:
+                        self._user_wakeup.clear()
+                    else:
+                        timeout = max(0.0, self._user_next_tick_mono - now_mono)
+
+                if timeout is None:
+                    await self._user_wakeup.wait()
+                    continue
+
                 try:
-                    await self._flush_outputs()
-                except Exception as e:
-                    logger.warning("RecordingManager: periodic flush error: %s", e)
+                    await asyncio.wait_for(self._user_wakeup.wait(), timeout=timeout)
+                    self._user_wakeup.clear()
+                except asyncio.TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            pass
+
+    async def _tts_scheduler_loop(self) -> None:
+        """Consume queued TTS audio according to the monotonic clock."""
+        try:
+            while True:
+                timeout: float | None = None
+                should_flush = False
+
+                async with self._lock:
+                    while True:
+                        now_mono = time.monotonic()
+
+                        if self._tts_paused:
+                            self._tts_wakeup.clear()
+                            break
+
+                        if (
+                            self._tts_playing_ends_at is not None
+                            and now_mono + 1e-6 >= self._tts_playing_ends_at
+                        ):
+                            self._clear_tts_playback_locked()
+                            self._tts_record_point_mono = now_mono
+                            if not self._tts_queue:
+                                self._align_user_to_target_locked(
+                                    self._total_tts_samples_locked(),
+                                    boundary_mono=now_mono,
+                                )
+                                should_flush = True
+                                self._tts_wakeup.clear()
+                                break
+                            continue
+
+                        if self._tts_playing_ends_at is not None:
+                            timeout = max(0.0, self._tts_playing_ends_at - now_mono)
+                            break
+
+                        if self._tts_queue:
+                            self._ensure_timeline_started(now_mono)
+                            self._start_next_tts_chunk_locked(now_mono)
+                            timeout = max(0.0, self._tts_playing_ends_at - now_mono)
+                            break
+
+                        self._tts_wakeup.clear()
+                        break
+
+                if should_flush:
+                    await self._flush_all_outputs()
+                    continue
+
+                if timeout is None:
+                    await self._tts_wakeup.wait()
+                    continue
+
+                try:
+                    await asyncio.wait_for(self._tts_wakeup.wait(), timeout=timeout)
+                    self._tts_wakeup.clear()
+                except asyncio.TimeoutError:
+                    continue
         except asyncio.CancelledError:
             pass
 
@@ -415,23 +478,18 @@ class RecordingManager(Manager):
     async def _drain_aligned_stereo_chunk(self) -> bytes:
         """Drain the aligned portion shared by both channels as stereo PCM."""
         async with self._lock:
-            n_write = min(self._samples_user, self._samples_tts)
+            n_write = min(self._user_buffer.total_samples, self._tts_buffer.total_samples)
             if n_write <= 0:
                 return b""
 
-            bytes_len = n_write * 2
-            user_bytes = bytes(self._ch_user[:bytes_len])
-            tts_bytes = bytes(self._ch_tts[:bytes_len])
-
-            del self._ch_user[:bytes_len]
-            del self._ch_tts[:bytes_len]
-
-            self._samples_user -= n_write
-            self._samples_tts -= n_write
+            user_bytes = self._user_buffer.consume_prefix(n_write)
+            tts_bytes = self._tts_buffer.consume_prefix(n_write)
+            self._emitted_user_samples += n_write
+            self._emitted_tts_samples += n_write
         return self._interleave_stereo(user_bytes, tts_bytes, n_write)
 
     async def _flush_outputs(self) -> bool:
-        """Flush aligned stereo audio to every enabled sink."""
+        """Flush one aligned stereo chunk to every enabled sink."""
         stereo_chunk = await self._drain_aligned_stereo_chunk()
         if not stereo_chunk:
             return False
@@ -440,6 +498,11 @@ class RecordingManager(Manager):
         if self._send_full_audio_enabled:
             await self._publish_full_audio_chunk(stereo_chunk)
         return True
+
+    async def _flush_all_outputs(self) -> None:
+        """Flush every aligned stereo chunk currently available."""
+        while await self._flush_outputs():
+            pass
 
     async def _write_stereo_chunk(self, stereo_chunk: bytes) -> None:
         """Write a stereo PCM chunk into the WAV file."""
@@ -468,29 +531,32 @@ class RecordingManager(Manager):
             wait_for_completion=True,
         )
 
-    def _reset_buffers(self) -> None:
-        """Reset in-memory audio assembly state."""
-        self._ch_user.clear()
-        self._ch_tts.clear()
-        self._samples_user = 0
-        self._samples_tts = 0
-        self._pending_tts_chunks.clear()
-        self._pending_tts_samples = 0
-        self._estimated_played_samples = 0
-        self._tts_state = "idle"
-        self._last_progress_mono_ts = None
-        self._timer_user = None
-        self._timer_tts = None
+    def _reset_buffers_locked(self) -> None:
+        """Reset in-memory buffers after the final chunk is built."""
+        self._user_buffer.clear()
+        self._tts_buffer.clear()
+        self._emitted_user_samples = 0
+        self._emitted_tts_samples = 0
+        self._user_queue.clear()
+        self._user_frame_samples = 0
+        self._user_next_tick_mono = None
+        self._tts_queue.clear()
+        self._tts_paused = False
+        self._tts_stop_allowed = False
+        self._tts_record_point_mono = None
+        self._origin_mono = None
+        self._clear_tts_playback_locked()
 
     async def _build_final_stereo_chunk(self) -> bytes:
         """Build the final padded stereo chunk from any remaining buffered audio."""
         async with self._lock:
-            n_samples = max(self._samples_user, self._samples_tts)
+            n_samples = max(self._user_buffer.total_samples, self._tts_buffer.total_samples)
             if n_samples <= 0:
-                self._reset_buffers()
+                self._reset_buffers_locked()
                 return b""
-            user = np.frombuffer(bytes(self._ch_user), dtype=np.int16)
-            tts = np.frombuffer(bytes(self._ch_tts), dtype=np.int16)
+
+            user = self._user_buffer.materialize()
+            tts = self._tts_buffer.materialize()
             if user.size < n_samples:
                 user = np.concatenate(
                     [user, np.zeros((n_samples - user.size,), dtype=np.int16)]
@@ -499,30 +565,170 @@ class RecordingManager(Manager):
                 tts = np.concatenate(
                     [tts, np.zeros((n_samples - tts.size,), dtype=np.int16)]
                 )
+
             stereo_chunk = self._interleave_stereo(
                 user.tobytes(), tts.tobytes(), n_samples
             )
-            self._reset_buffers()
+            self._reset_buffers_locked()
             return stereo_chunk
 
-    # ==================== Lifecycle ====================
+    @Manager.event_handler(SessionConfigReceived, priority=100)
+    async def _on_session_config(self, event: SessionConfigReceived) -> None:
+        """Initialize recording with a client-provided path."""
+        if not self._recording_enabled or self._file_initialized:
+            return
+        self._init_file(event.recording_path)
+
+    @Manager.event_handler(AudioFrameReceived, priority=50)
+    async def _on_audio_frame(self, event: AudioFrameReceived) -> None:
+        """Queue user audio for left-channel scheduling."""
+        if not self._enabled:
+            return
+        try:
+            pcm = event.audio_data or b""
+            if not pcm:
+                return
+
+            src_sr = event.sample_rate or 16000
+            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
+            if data_i16.size <= 0:
+                return
+
+            async with self._lock:
+                now_mono = time.monotonic()
+                self._ensure_timeline_started(now_mono)
+                self._advance_user_until_locked(now_mono)
+                self._user_frame_samples = int(data_i16.size)
+                self._user_queue.append(data_i16)
+                if self._user_next_tick_mono is None:
+                    self._user_next_tick_mono = (
+                        now_mono + (self._user_frame_samples / self.TARGET_SR)
+                    )
+                self._user_wakeup.set()
+        except Exception as e:
+            logger.warning("RecordingManager: failed to handle audio frame: %s", e)
+
+    @Manager.event_handler(TTSStarted, priority=50)
+    async def _on_tts_started(self, event: TTSStarted) -> None:
+        """Wake the TTS scheduler when a new generation starts."""
+        if not self._enabled:
+            return
+        self._tts_wakeup.set()
+
+    @Manager.event_handler(TTSChunkGenerated, priority=50)
+    async def _on_tts_chunk_generated(self, event: TTSChunkGenerated) -> None:
+        """Queue generated TTS chunks for right-channel scheduling."""
+        if not self._enabled:
+            return
+        try:
+            pcm = event.audio_chunk or b""
+            if not pcm:
+                return
+
+            src_sr = event.sample_rate or 48000
+            data_i16 = self._resample_to_int16(pcm, src_sr, self.TARGET_SR)
+            if data_i16.size <= 0:
+                return
+
+            async with self._lock:
+                now_mono = time.monotonic()
+                self._ensure_timeline_started(now_mono)
+                self._tts_queue.append(data_i16)
+                self._tts_stop_allowed = True
+                self._tts_wakeup.set()
+        except Exception as e:
+            logger.warning("RecordingManager: failed to queue TTS chunk: %s", e)
+
+    @Manager.event_handler(TTSPaused, priority=50)
+    async def _on_tts_paused(self, event: TTSPaused) -> None:
+        """Pause TTS scheduling and cut the active chunk at the current clock."""
+        if not self._enabled:
+            return
+
+        async with self._lock:
+            if self._tts_paused or not self._tts_stop_allowed:
+                return
+            if self._tts_playing_ends_at is None and not self._tts_queue:
+                return
+
+            now_mono = time.monotonic()
+            remainder = self._pause_or_stop_current_tts_locked(
+                now_mono, keep_remainder=True
+            )
+            if remainder is not None and remainder.size > 0:
+                self._tts_queue.appendleft(remainder)
+            self._tts_paused = True
+            self._tts_record_point_mono = now_mono
+            self._tts_wakeup.set()
+
+    @Manager.event_handler(TTSResumed, priority=50)
+    async def _on_tts_resumed(self, event: TTSResumed) -> None:
+        """Resume TTS scheduling from the paused point."""
+        if not self._enabled:
+            return
+
+        should_flush = False
+        async with self._lock:
+            if not self._tts_paused:
+                return
+
+            now_mono = time.monotonic()
+            self._ensure_timeline_started(now_mono)
+            self._append_tts_gap_to_now_locked(now_mono)
+            self._tts_paused = False
+
+            if self._tts_playing_ends_at is None and not self._tts_queue:
+                self._align_user_to_target_locked(
+                    self._total_tts_samples_locked(), boundary_mono=now_mono
+                )
+                should_flush = True
+
+            self._tts_wakeup.set()
+
+        if should_flush:
+            await self._flush_all_outputs()
+
+    @Manager.event_handler(TTSStopped, priority=50)
+    async def _on_tts_stopped(self, event: TTSStopped) -> None:
+        """Stop TTS scheduling, truncate the active chunk, and flush outputs."""
+        if not self._enabled:
+            return
+        try:
+            async with self._lock:
+                if not self._tts_stop_allowed:
+                    return
+
+                now_mono = time.monotonic()
+                self._finalize_tts_to_boundary_locked(now_mono)
+                self._align_user_to_target_locked(
+                    self._total_tts_samples_locked(), boundary_mono=now_mono
+                )
+                self._tts_wakeup.set()
+            await self._flush_all_outputs()
+        except Exception as e:
+            logger.warning("RecordingManager: failed to handle TTS stopped: %s", e)
 
     async def shutdown(self) -> None:
         """Finalize recording by flushing remaining buffers and closing the file."""
         if not self._enabled:
             return
-        # Stop periodic flush
-        if self._flush_task and not self._flush_task.done():
-            self._flush_task.cancel()
-            try:
-                await self._flush_task
-            except asyncio.CancelledError:
-                pass
-            self._flush_task = None
 
-        # Final flush
+        for task in (self._user_task, self._tts_task):
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        self._user_task = None
+        self._tts_task = None
+
+        async with self._lock:
+            self._prepare_shutdown_locked(time.monotonic())
+
         try:
-            await self._flush_outputs()
+            await self._flush_all_outputs()
         except Exception:
             pass
 
@@ -530,8 +736,9 @@ class RecordingManager(Manager):
         if final_chunk:
             if self._recording_enabled:
                 await self._write_stereo_chunk(final_chunk)
+            if self._send_full_audio_enabled:
+                await self._publish_full_audio_chunk(final_chunk)
 
-        # Close file handle
         try:
             if self._recording_enabled and self._wf is not None:
                 self._wf.close()

--- a/src/xtalk/serving/modules/tts_manager.py
+++ b/src/xtalk/serving/modules/tts_manager.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+from collections import deque
 from typing import Optional, NamedTuple, Any
 
 from ...log_utils import logger
@@ -13,6 +14,7 @@ from ..events import (
     TTSResumed,
     TTSFinished,
     TTSChunkGenerated,
+    TTSChunkPlayed,
     ErrorOccurred,
     TTSVoiceChange,
     TTSEmotionChange,
@@ -44,6 +46,10 @@ class TTSManager(Manager):
 
     # Sentence delimiters for chunking
     SENTENCE_DELIMITERS = {"。", "，", "！", "!", "？", "?", ".", ",", "：", ":"}
+    # Maximum duration of each outbound PCM chunk in milliseconds.
+    TTS_CHUNK_MS = 100
+    # Maximum unacknowledged outbound audio budget in milliseconds.
+    MAX_OUTSTANDING_MS = 300
     # Sentinel for marking end of TTS stream
     _FLUSH_SENTINEL = object()
 
@@ -89,6 +95,9 @@ class TTSManager(Manager):
         self._resume_event = asyncio.Event()
         self._resume_event.set()
         self._last_chunk_sent_for_tts = False
+        self._outstanding_chunk_ms: deque[float] = deque()
+        self._outstanding_total_ms = 0.0
+        self._outstanding_condition = asyncio.Condition()
 
     def _ensure_segments_queue(self) -> asyncio.Queue:
         """Ensure a queue exists for sentence segments."""
@@ -169,6 +178,7 @@ class TTSManager(Manager):
 
         # Stop consumer
         await self._stop_consumer()
+        await self._reset_outstanding_audio()
 
         # Cancel segments producer task
         if self._segments_task and not self._segments_task.done():
@@ -246,6 +256,47 @@ class TTSManager(Manager):
 
         self._resume_event.set()
 
+    async def _reset_outstanding_audio(self) -> None:
+        """Clear all unacknowledged outbound audio tracking state."""
+        async with self._outstanding_condition:
+            self._outstanding_chunk_ms.clear()
+            self._outstanding_total_ms = 0.0
+            self._outstanding_condition.notify_all()
+
+    async def _wait_for_outstanding_budget(self) -> None:
+        """Wait until enough outbound audio budget is available."""
+        async with self._outstanding_condition:
+            while (
+                self._consumer_running
+                and self._outstanding_total_ms >= self.MAX_OUTSTANDING_MS
+            ):
+                await self._outstanding_condition.wait()
+
+    async def _track_outstanding_chunk(self, chunk_ms: float) -> None:
+        """Record a just-sent outbound chunk in the outstanding budget."""
+        async with self._outstanding_condition:
+            self._outstanding_chunk_ms.append(chunk_ms)
+            self._outstanding_total_ms += chunk_ms
+
+    def _chunk_duration_ms(self, audio_chunk: bytes, sample_rate: int) -> float:
+        """Return the PCM chunk duration in milliseconds."""
+        if not audio_chunk or sample_rate <= 0:
+            return 0.0
+        sample_count = len(audio_chunk) / 2
+        return sample_count * 1000.0 / sample_rate
+
+    def _split_audio_chunk(self, audio_chunk: bytes, sample_rate: int) -> list[bytes]:
+        """Split PCM audio into fixed-size chunks for outbound transport."""
+        if not audio_chunk or sample_rate <= 0:
+            return []
+        samples_per_chunk = max(1, round(sample_rate * self.TTS_CHUNK_MS / 1000))
+        bytes_per_chunk = samples_per_chunk * 2
+        return [
+            audio_chunk[offset : offset + bytes_per_chunk]
+            for offset in range(0, len(audio_chunk), bytes_per_chunk)
+            if audio_chunk[offset : offset + bytes_per_chunk]
+        ]
+
     async def _tts_consumer(self) -> None:
         """Consume queued TTS output and publish audio events."""
 
@@ -273,14 +324,24 @@ class TTSManager(Manager):
                                 item.audio_chunk, self.current_speed
                             )
 
-                        # Publish to frontend (chunks processed in FIFO order)
-                        event = TTSChunkGenerated(
-                            session_id=self.session_id,
-                            audio_chunk=processed_audio,
-                            sample_rate=item.sample_rate,
-                        )
-                        # Ensure ordering by waiting for completion
-                        await self.event_bus.publish(event, wait_for_completion=True)
+                        for chunk in self._split_audio_chunk(
+                            processed_audio, item.sample_rate
+                        ):
+                            await self._wait_for_outstanding_budget()
+                            if not self._consumer_running:
+                                break
+
+                            event = TTSChunkGenerated(
+                                session_id=self.session_id,
+                                audio_chunk=chunk,
+                                sample_rate=item.sample_rate,
+                            )
+                            await self.event_bus.publish(
+                                event, wait_for_completion=True
+                            )
+                            await self._track_outstanding_chunk(
+                                self._chunk_duration_ms(chunk, item.sample_rate)
+                            )
 
                     # Mark task as done after processing
                     self.tts_queue.task_done()
@@ -321,6 +382,17 @@ class TTSManager(Manager):
             await self._publish_error("tts_consumer_error", str(e))
         finally:
             self._consumer_running = False
+
+    @Manager.event_handler(TTSChunkPlayed, priority=100)
+    async def _handle_tts_chunk_played(self, event: TTSChunkPlayed) -> None:
+        """Release outstanding outbound budget after frontend playback confirmation."""
+        async with self._outstanding_condition:
+            if self._outstanding_chunk_ms:
+                self._outstanding_total_ms = max(
+                    0.0,
+                    self._outstanding_total_ms - self._outstanding_chunk_ms.popleft(),
+                )
+            self._outstanding_condition.notify_all()
 
     async def _publish_tts_started(self) -> None:
         """Publish TTSStarted event."""

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -137,7 +137,16 @@ class ASR(ABC):
 
 
 class TTS(ABC):
-    """Abstract base class for text-to-speech engines."""
+    """Abstract base class for text-to-speech engines.
+
+    Notes
+    -----
+    ``synthesize`` is the required baseline API for every implementation.
+    Streaming-capable engines should additionally override
+    ``synthesize_stream``; non-streaming engines should inherit the default
+    compatibility wrapper. The inherited streaming helpers do not by
+    themselves declare native streaming capability.
+    """
 
     @abstractmethod
     def synthesize(self, text: str) -> bytes:
@@ -152,6 +161,11 @@ class TTS(ABC):
         -------
         bytes
             PCM 16-bit mono audio bytes at 48 kHz.
+
+        Notes
+        -----
+        Every TTS implementation, including streaming backends, must provide
+        this method.
         """
         pass
 
@@ -169,6 +183,13 @@ class TTS(ABC):
         ------
         bytes
             PCM 16-bit mono audio bytes at 48 kHz.
+
+        Notes
+        -----
+        Override this method only when the backend supports native streaming
+        synthesis. The default implementation yields a single chunk produced
+        by ``synthesize`` for compatibility and should not be treated as a
+        declaration of streaming support.
         """
         yield self.synthesize(text)
 
@@ -186,6 +207,11 @@ class TTS(ABC):
         -------
         bytes
             Synthesized PCM audio bytes.
+
+        Notes
+        -----
+        This method is an optional async optimization. Implementations may
+        inherit the default executor-based wrapper.
         """
         loop = asyncio.get_running_loop()
         func = partial(self.synthesize, text, **kwargs)
@@ -208,6 +234,12 @@ class TTS(ABC):
         ------
         bytes
             Streamed PCM audio chunks.
+
+        Notes
+        -----
+        This method is an optional async optimization for streaming-capable
+        backends. When not overridden, it asynchronously iterates over
+        ``synthesize_stream``.
         """
         loop = asyncio.get_running_loop()
         iterable = self.synthesize_stream(text, **kwargs)


### PR DESCRIPTION
## Summary

This PR refines the server-side audio scheduling path used by streaming TTS sessions and automated recording tests. It makes recording output follow scheduled playback timing more closely, limits outbound TTS buffering, and updates the integration contract for streaming-capable TTS backends.

## What Changed

- Reworked `RecordingManager` to build stereo recordings from scheduled user and TTS timelines instead of raw append-only buffers, including explicit pause, resume, stop, and final flush handling.
- Throttled outbound TTS audio in `TTSManager` by splitting PCM into fixed-size chunks and releasing buffer budget only after `TTSChunkPlayed` acknowledgements arrive from the frontend.
- Let `InputGateway` process text websocket messages asynchronously so binary audio reception is not blocked, and chunked large `full_audio_frame` payloads in `OutputGateway`.
- Hardened `scripts/test.py` by running the embedded FastAPI server in a dedicated process, simplifying idle-completion detection, and preferring server-side recordings when they are available locally.
- Clarified the streaming TTS contract in `src/xtalk/speech/interfaces.py` and the related docs, and pinned `fastapi==0.128.0` in the `example` extra for sample app dependencies.
