### PR TITLE
refactor: Refine turn detection flow and preserve realtime ASR partial prefixes

### DIFF
--- a/docs/api/server/xtalk/model_types.md
+++ b/docs/api/server/xtalk/model_types.md
@@ -1059,7 +1059,7 @@ Return the lock guarding listening state changes.
 _Defined in `xtalk.speech.interfaces`._
 
 ```python
-def detect(self, audio: Optional[bytes] = None, text: Optional[str] = None, speech_pause: Optional[bool] = None) -> TurnDetectionResult | list[TurnDetectionResult]
+def detect(self, audio: Optional[bytes] = None, text: Optional[str] = None, speech_pause: Optional[bool] = None) -> TurnDetectionResult
 ```
 
 Detect conversational turn state from audio and/or text.
@@ -1076,17 +1076,15 @@ Detect conversational turn state from audio and/or text.
 
 ##### Returns
 
-- `TurnDetectionResult | list[TurnDetectionResult]`
-  One or more turn-detection decisions. When multiple results are
-  returned, ``STOP_SPEAKING`` should be processed before
-  ``START_GENERATION``.
+- `TurnDetectionResult`
+  Turn-detection decision for the current input.
 
 #### async_detect
 
 _Defined in `xtalk.speech.interfaces`._
 
 ```python
-async def async_detect(self, audio: Optional[bytes] = None, text: Optional[str] = None, speech_pause: Optional[bool] = None) -> TurnDetectionResult | list[TurnDetectionResult]
+async def async_detect(self, audio: Optional[bytes] = None, text: Optional[str] = None, speech_pause: Optional[bool] = None) -> TurnDetectionResult
 ```
 
 Asynchronously detect conversational turn state.
@@ -1102,8 +1100,8 @@ Asynchronously detect conversational turn state.
 
 ##### Returns
 
-- `TurnDetectionResult | list[TurnDetectionResult]`
-  One or more turn-detection decisions.
+- `TurnDetectionResult`
+  Turn-detection decision for the current input.
 
 #### clone
 

--- a/frontend/src/action-handler-functions/input.ts
+++ b/frontend/src/action-handler-functions/input.ts
@@ -11,6 +11,9 @@ const inputMap: ActionToFunctionMap = {
     "vad_speech_end": async (data, websocket, conversation, outputAudioSession) => {
         onVadSpeechEnd(data, websocket, conversation, outputAudioSession);
     },
+    "finish_asr": async (data, websocket, conversation, outputAudioSession) => {
+        conversation.state.streamState = 'processing';
+    },
     "full_audio_frame": async (data, websocket, conversation, outputAudioSession) => {
         const audioBase64 = typeof data?.audio_base64 === "string" ? data.audio_base64 : "";
         if (!audioBase64) {

--- a/frontend/src/action-handler-functions/utils.ts
+++ b/frontend/src/action-handler-functions/utils.ts
@@ -6,5 +6,5 @@ const onVadSpeechStart: ActionHandlerFunction = async (data, websocket, conversa
 }
 
 const onVadSpeechEnd: ActionHandlerFunction = async (data, websocket, conversation, outputAudioSession) => {
-    conversation.state.streamState = 'processing';
+    conversation.state.streamState = 'idle';
 }

--- a/src/xtalk/serving/modules/output_gateway.py
+++ b/src/xtalk/serving/modules/output_gateway.py
@@ -280,13 +280,13 @@ class OutputGateway(EventListenerMixin):
 
     @EventListenerMixin.event_handler(VADSpeechStart, priority=5)
     async def _send_vad_start_signal(self, event: VADSpeechStart) -> None:
-        if event.origin != "server":
+        if event.origin == "client":
             return
         await self._forward("vad_speech_start", {"origin": event.origin})
 
     @EventListenerMixin.event_handler(VADSpeechEnd, priority=5)
     async def _send_vad_end_signal(self, event: VADSpeechEnd) -> None:
-        if event.origin != "server":
+        if event.origin == "client":
             return
         await self._forward("vad_speech_end", {"origin": event.origin})
 

--- a/src/xtalk/serving/modules/turn_detector_manager.py
+++ b/src/xtalk/serving/modules/turn_detector_manager.py
@@ -27,6 +27,7 @@ from ..events import (
     EnhancedAudioFrameReceived,
     ASRResultPartial,
     VADSpeechStart,
+    VADSpeechEnd,
     TTSChunkGenerated,
     TTSPlaybackFinished,
     TTSStopped,
@@ -34,7 +35,11 @@ from ..events import (
     TurnDetectorStartGeneration,
 )
 from ...pipelines import Pipeline
-from ...speech.interfaces import TurnDetectionAction, TurnDetectionResult
+from ...speech.interfaces import (
+    TurnDetectionAction,
+    TurnDetectionResult,
+    TurnVADResult,
+)
 
 
 class TurnDetectorManager(Manager):
@@ -54,6 +59,9 @@ class TurnDetectorManager(Manager):
 
         # Get turn detector from pipeline
         self.turn_detector = self.pipeline.get_turn_detector_model()
+        self._backend_vad = self.pipeline.get_vad_model()
+        self._proxy_vad_enabled = self._backend_vad is None
+        self._proxy_vad_in_speech = False
 
     # ----------------------------
     # Event handling
@@ -98,10 +106,21 @@ class TurnDetectorManager(Manager):
         try:
             if self.turn_detector is None:
                 return
+            if event.origin == "turn_detector":
+                return
+
+            self._disable_proxy_vad()
             result = await self.turn_detector.async_detect(speech_start=True)
             await self._handle_detection_result(result)
         except Exception as e:
             logger.error("[TurnDetectorManager] VAD start processing failed: %s", e)
+
+    @Manager.event_handler(VADSpeechEnd)
+    async def _on_vad_speech_end(self, event: VADSpeechEnd) -> None:
+        """Track externally supplied VAD end events so proxy mode stays disabled."""
+        if event.origin == "turn_detector":
+            return
+        self._disable_proxy_vad()
 
     @Manager.event_handler(TTSChunkGenerated)
     async def _on_tts_chunk_generated(self, event: TTSChunkGenerated) -> None:
@@ -128,20 +147,50 @@ class TurnDetectorManager(Manager):
         # No lock needed: single bool assignment is atomic (GIL), no compound read-then-write
         self.turn_detector.listening = True
 
-    async def _handle_detection_result(
-        self, result: TurnDetectionResult | list[TurnDetectionResult]
-    ) -> None:
-        """Handle turn detection result and emit appropriate events."""
-        if not isinstance(result, list):
-            result = [result]
-        for item in result:
-            if item.action == TurnDetectionAction.STOP_SPEAKING:
-                evt = TurnDetectorStopSpeaking(session_id=self.session_id)
-                await self.event_bus.publish(evt)
-            elif item.action == TurnDetectionAction.START_GENERATION:
-                evt = TurnDetectorStartGeneration(session_id=self.session_id)
-                await self.event_bus.publish(evt)
+    async def _handle_detection_result(self, result: TurnDetectionResult) -> None:
+        """Handle one turn detection result and emit the corresponding events."""
+        await self._handle_proxy_vad_result(result)
+        if result.action == TurnDetectionAction.STOP_SPEAKING:
+            evt = TurnDetectorStopSpeaking(session_id=self.session_id)
+            await self.event_bus.publish(evt)
+        elif result.action == TurnDetectionAction.START_GENERATION:
+            evt = TurnDetectorStartGeneration(session_id=self.session_id)
+            await self.event_bus.publish(evt)
         # DO_NOTHING requires no action
+
+    def _disable_proxy_vad(self) -> None:
+        """Disable turn-detector VAD proxy mode after observing external VAD."""
+        self._proxy_vad_enabled = False
+
+    async def _handle_proxy_vad_result(self, result: TurnDetectionResult) -> None:
+        """Emit proxied VAD transitions before handling turn-detection actions."""
+        if not self._proxy_vad_enabled or result.vad_result is None:
+            return
+
+        if result.vad_result == TurnVADResult.SPEECH:
+            if self._proxy_vad_in_speech:
+                return
+            self._proxy_vad_in_speech = True
+            await self.event_bus.publish(
+                VADSpeechStart(
+                    session_id=self.session_id,
+                    origin="turn_detector",
+                ),
+                wait_for_completion=True,
+            )
+            return
+
+        if result.vad_result == TurnVADResult.SILENCE:
+            if not self._proxy_vad_in_speech:
+                return
+            self._proxy_vad_in_speech = False
+            await self.event_bus.publish(
+                VADSpeechEnd(
+                    session_id=self.session_id,
+                    origin="turn_detector",
+                ),
+                wait_for_completion=True,
+            )
 
     # ----------------------------
     # Lifecycle

--- a/src/xtalk/speech/asr/qwen3_asr_flash_realtime.py
+++ b/src/xtalk/speech/asr/qwen3_asr_flash_realtime.py
@@ -51,8 +51,9 @@ class _RealtimeASRCallback(OmniRealtimeCallback):
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._final_event = threading.Event()
+        self._fixed_prefix: str = ""
         self._last_partial: str = ""
-        self._accumulated_partial: str = ""
+        self._active_partial: str = ""
         self._final_text: str = ""
         self._session_id: str = ""
 
@@ -98,8 +99,8 @@ class _RealtimeASRCallback(OmniRealtimeCallback):
 
         with self._lock:
             self._last_partial = partial
-            self._accumulated_partial = self._merge_incremental_partial(
-                self._accumulated_partial,
+            self._active_partial = self._merge_incremental_partial(
+                self._active_partial,
                 partial,
             )
 
@@ -107,7 +108,8 @@ class _RealtimeASRCallback(OmniRealtimeCallback):
         final = response.get("transcript") or response.get("text") or ""
         final = str(final).strip()
         with self._lock:
-            self._final_text = final or self._accumulated_partial
+            active_text = final or self._active_partial
+            self._final_text = self._join_segments(self._fixed_prefix, active_text)
             self._final_event.set()
 
     def _merge_incremental_partial(self, accumulated: str, partial: str) -> str:
@@ -154,14 +156,15 @@ class _RealtimeASRCallback(OmniRealtimeCallback):
 
     def clear_turn(self) -> None:
         with self._lock:
+            self._fixed_prefix = ""
             self._last_partial = ""
-            self._accumulated_partial = ""
+            self._active_partial = ""
             self._final_text = ""
         self._final_event.clear()
 
     def get_last_partial(self) -> str:
         with self._lock:
-            return self._accumulated_partial
+            return self._join_segments(self._fixed_prefix, self._active_partial)
 
     def wait_final(self, timeout: float) -> Optional[str]:
         ok = self._final_event.wait(timeout=timeout)
@@ -169,6 +172,31 @@ class _RealtimeASRCallback(OmniRealtimeCallback):
             return None
         with self._lock:
             return self._final_text
+
+    def finalize_segment(self, final_text: str | None = None) -> str:
+        """Fix the current segment into the stable prefix and start a new segment."""
+        with self._lock:
+            active_text = str(final_text).strip() if final_text is not None else ""
+            active_text = active_text or self._active_partial
+            if self._fixed_prefix and active_text.startswith(self._fixed_prefix):
+                active_text = active_text[len(self._fixed_prefix) :].strip()
+            self._fixed_prefix = self._join_segments(self._fixed_prefix, active_text)
+            self._last_partial = ""
+            self._active_partial = ""
+            self._final_text = ""
+            self._final_event.clear()
+            return self._fixed_prefix
+
+    @staticmethod
+    def _join_segments(prefix: str, segment: str) -> str:
+        """Join two transcript segments with minimal whitespace cleanup."""
+        prefix = prefix.strip()
+        segment = segment.strip()
+        if not prefix:
+            return segment
+        if not segment:
+            return prefix
+        return f"{prefix} {segment}"
 
 
 class Qwen3ASRFlashRealtime(ASR):
@@ -239,7 +267,7 @@ class Qwen3ASRFlashRealtime(ASR):
                 self._conv.commit()
 
         final = self._callback.wait_final(timeout=self._config.final_wait_timeout_sec)
-        return final if final is not None else self._callback.get_last_partial()
+        return self._callback.finalize_segment(final)
 
     def stream_chunk_bytes_hint(self) -> int | None:
         return self._config.stream_chunk_bytes_hint

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -59,8 +59,8 @@ class ASR(ABC):
         audio : bytes
             Incremental PCM 16-bit mono audio bytes.
         is_final : bool, optional
-            Whether the caller is forcing a final decode because the user paused
-            or the turn ended.
+            Whether the caller is forcing a temporal final decode because the user paused
+            or the turn ended. Does not mean the ASR state must be reset, but may be used as a hint to optimize decoding.
         chat_history : str | None, optional
             Serialized chat history for the current session, excluding the
             in-progress turn when unavailable.

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -685,6 +685,11 @@ class TurnDetectionSemantic(Enum):
     SHOULD_BACKCHANNEL = "should_backchannel"
 
 
+class TurnVADResult(Enum):
+    SPEECH = 1
+    SILENCE = 2
+
+
 @dataclass(frozen=True)
 class TurnDetectionResult:
     """Decision emitted by a turn detector.
@@ -695,10 +700,13 @@ class TurnDetectionResult:
         Immediate action the service should take.
     semantic : TurnDetectionSemantic
         Semantic interpretation of the current conversational state.
+    vad_result : TurnVADResult | None
+        Optional VAD result; only used when VAD is absent
     """
 
     action: TurnDetectionAction
     semantic: TurnDetectionSemantic
+    vad_result: TurnVADResult | None = None
 
 
 class TurnDetector(ABC):
@@ -753,7 +761,7 @@ class TurnDetector(ABC):
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """Detect conversational turn state from audio and/or text.
 
         Parameters
@@ -771,10 +779,8 @@ class TurnDetector(ABC):
 
         Returns
         -------
-        TurnDetectionResult | list[TurnDetectionResult]
-            One or more turn-detection decisions. When multiple results are
-            returned, ``STOP_SPEAKING`` should be processed before
-            ``START_GENERATION``.
+        TurnDetectionResult
+            Turn-detection decision for the current input.
         """
         pass
 
@@ -784,7 +790,7 @@ class TurnDetector(ABC):
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """Asynchronously detect conversational turn state.
 
         Parameters
@@ -801,8 +807,8 @@ class TurnDetector(ABC):
 
         Returns
         -------
-        TurnDetectionResult | list[TurnDetectionResult]
-            One or more turn-detection decisions.
+        TurnDetectionResult
+            Turn-detection decision for the current input.
         """
         loop = asyncio.get_running_loop()
         func = partial(
@@ -812,9 +818,7 @@ class TurnDetector(ABC):
             speech_start=speech_start,
             speech_pause=speech_pause,
         )
-        result: TurnDetectionResult | list[TurnDetectionResult] = (
-            await loop.run_in_executor(None, func)
-        )
+        result: TurnDetectionResult = await loop.run_in_executor(None, func)
         return result
 
     @abstractmethod

--- a/src/xtalk/speech/turn_detector/llm_turn_detector.py
+++ b/src/xtalk/speech/turn_detector/llm_turn_detector.py
@@ -65,7 +65,7 @@ If you find the input abnormal, for example containing ASR misrecognized charact
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         return asyncio.run(self.async_detect(audio, text, speech_start, speech_pause))
 
     async def async_detect(
@@ -74,7 +74,7 @@ If you find the input abnormal, for example containing ASR misrecognized charact
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         del audio
         if speech_start:
             self._reset_incomplete_state()

--- a/src/xtalk/speech/turn_detector/soulx_duplug.py
+++ b/src/xtalk/speech/turn_detector/soulx_duplug.py
@@ -124,7 +124,7 @@ class SoulxDuplug(TurnDetector):
 
     async def _handle_text_fallback(
         self, text: str, speech_pause: Optional[bool]
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """
         Handle the text-driven fallback path.
 
@@ -162,7 +162,7 @@ class SoulxDuplug(TurnDetector):
     # ----------------------------
     async def _commit_true_speak(
         self,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """Emit the confirmed START_GENERATION result and cancel fallback state."""
         await self._cancel_fallback()
         return TurnDetectionResult(
@@ -172,7 +172,7 @@ class SoulxDuplug(TurnDetector):
 
     def _result_for_listening_state(
         self, state_name: Literal["idle", "nonidle", "speak", "blank"]
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """
         Handle the primary listening-side audio state machine.
 
@@ -208,7 +208,7 @@ class SoulxDuplug(TurnDetector):
 
     async def _handle_audio_primary(
         self, audio: bytes
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         """Handle the primary audio-driven turn detection path."""
         if self._ws is None:
             await self._connect()
@@ -264,7 +264,7 @@ class SoulxDuplug(TurnDetector):
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         return asyncio.run(
             self.async_detect(audio, text, speech_start, speech_pause)
         )
@@ -275,7 +275,7 @@ class SoulxDuplug(TurnDetector):
         text: Optional[str] = None,
         speech_start: bool = False,
         speech_pause: Optional[bool] = None,
-    ) -> TurnDetectionResult | list[TurnDetectionResult]:
+    ) -> TurnDetectionResult:
         del speech_start
         if text is not None:
             return await self._handle_text_fallback(text, speech_pause)


### PR DESCRIPTION
  ## What Changed

  - tightened the turn detector contract so `detect`/`async_detect` now return a single `TurnDetectionResult` instead of a list, and updated the API
  docs to match
  - added optional VAD information to turn detection results and taught `TurnDetectorManager` to proxy VAD start/end events from the turn detector
  only when no backend VAD is configured
  - disabled turn-detector VAD proxying as soon as external VAD events are observed, so backend-provided VAD remains the source of truth when
  available
  - forwarded non-client VAD start/end signals to the frontend, and aligned frontend stream-state transitions so:
    - `vad_speech_end` moves the stream back to `idle`
    - `finish_asr` moves the stream to `processing`
  - clarified that `ASR.stream_infer(..., is_final=True)` represents a temporal final decode hint rather than a required ASR state reset
  - updated the Qwen3 realtime ASR callback to preserve finalized transcript prefixes across temporal-final boundaries, so partial and final text
  stay stable over multi-segment decoding