### PR TITLE
feat: Add frontend audio bridge and bot2bot demo

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ plugins:
             'Sample Config for Fully Local Deployment': 完全本地部署示例配置
             'Text Embedding': 文本嵌入
             'Tool Use': 使用工具
+            Bot2Bot: Bot2Bot
             'Introduce a New Model': 引入新模型
             'Customize the Pipeline': 定制X-Talk逻辑
             Testing: 测试
@@ -66,6 +67,7 @@ nav:
       - 'Sample Config for Fully Local Deployment': tutorial/sample_config_for_fully_local_deployment.md
       - 'Text Embedding': tutorial/text_embedding.md
       - 'Tool Use': tutorial/tool_use.md
+      - Bot2Bot: tutorial/bot2bot.md
       - 'Introduce a New Model': tutorial/introduce_a_new_model.md
       - 'Customize the Pipeline': tutorial/customize_the_pipeline.md
       - Testing: tutorial/testing.md
@@ -76,4 +78,3 @@ nav:
       - 'Client': api/client/globals.md
       - 'Server': api/server/index.md
   - Developer: developer.md
-

--- a/docs/tutorial/bot2bot.md
+++ b/docs/tutorial/bot2bot.md
@@ -1,0 +1,259 @@
+X-Talk can bridge multiple frontend sessions into one shared browser-side audio bus so that bots hear a continuous audio stream instead of only microphone input.
+
+This tutorial documents the current frontend-only bot-to-bot bridge API:
+
+- the shared bus is created with `createAudioBridge()`,
+- each bot session uses `inputConfig.mode = "web_bridge"`,
+- user audio may optionally be captured directly by the bridge,
+- bot output audio is published back into the bridge so other bots can respond.
+
+`createAudioBridge()` is the package-level entrypoint. It detects the current frontend platform and currently resolves to the Web bridge implementation.
+
+## When to use it
+
+Use the web audio bridge when you want one browser page to:
+
+- connect multiple X-Talk sessions at the same time,
+- let bots respond to other bots' spoken output,
+- optionally inject real user microphone audio into the same shared stream,
+- keep the server contract unchanged and do the routing on the frontend.
+
+This API is currently Web-only. It lives under `frontend/src/platforms`.
+
+## Shared stream model
+
+The bridge maintains one continuous PCM stream at `16000` Hz.
+
+- When nobody is speaking, the stream contains silence.
+- When the user or a bot publishes audio, that audio is mixed into the stream.
+- Every bot configured with `mode: "web_bridge"` keeps receiving frames from the same shared stream, except for audio chunks that bot published itself.
+
+This means the bridge does not route bot audio point-to-point. Instead, all publishers write into one shared stream, and all bridge-backed bot sessions read from it, while each bot's own published audio is filtered out from its local input stream.
+
+## Create the bridge
+
+Import the bridge constructor from the client bundle:
+
+```ts
+import { createAudioBridge } from "xtalk-client";
+
+const bridge = createAudioBridge();
+```
+
+The public bridge instance API is:
+
+```ts
+type WebBridgeParticipantId = string;
+
+interface WebAudioBridgeUserInputConfig {
+    sourceId?: WebBridgeParticipantId;
+    sampleRate?: number;
+    enableVAD?: boolean;
+    enableEnhancer?: boolean;
+    vadRedemptionMs?: number;
+}
+
+interface WebAudioBridgePublishOptions {
+    sourceId: WebBridgeParticipantId;
+    sampleRate: number;
+}
+
+interface WebAudioBridge {
+    openUserInput(config?: WebAudioBridgeUserInputConfig): Promise<void>;
+    closeUserInput(): Promise<void>;
+    publishAudio(
+        pcmChunkInt16: ArrayBuffer,
+        options: WebAudioBridgePublishOptions,
+    ): void;
+    publishSpeechStart(sourceId: WebBridgeParticipantId): void;
+    publishSpeechEnd(sourceId: WebBridgeParticipantId): void;
+    close(): Promise<void>;
+}
+```
+
+The concrete type names shown here describe the current Web implementation. The package root only exports `createAudioBridge()`, not these Web-specific types.
+
+## Configure a bot session
+
+Each bot still uses the normal `createSession()` API, but the input side is switched from microphone capture to the shared bridge stream:
+
+```ts
+import { createSession } from "xtalk-client";
+
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+```
+
+The bridge-related input fields are:
+
+- `mode`: set to `"web_bridge"` so the session reads from the shared bridge stream.
+- `participantId`: a frontend-side identifier used by the bridge for source-specific VAD behavior and diagnostics.
+- `bridge`: the `WebAudioBridge` instance to subscribe to.
+- `autoEmitVad`: whether audio published by this bot should also trigger frontend VAD events when re-injected into the shared stream.
+- `vadRedemptionMs`: the speech-end redemption window used when `autoEmitVad` is enabled.
+
+## Publish bot output back into the bridge
+
+When a bot speaks, listen to its output audio and publish those PCM chunks back into the bridge:
+
+```ts
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+```
+
+If two bots both do this, they can respond to each other through the shared stream:
+
+```ts
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+
+const botB = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-b",
+        bridge,
+        autoEmitVad: false,
+    },
+});
+
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+
+botB.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-b",
+        sampleRate,
+    });
+});
+
+await botA.open();
+await botB.open();
+```
+
+With this setup:
+
+- both bots keep receiving the same shared stream except for their own published audio,
+- bot output is written back into that stream,
+- bots can continue replying to other bots' replies.
+
+## Let the bridge capture real user audio
+
+If you want the browser microphone to also feed the shared stream, open user input directly on the bridge:
+
+```ts
+await bridge.openUserInput({
+    sourceId: "user",
+    sampleRate: 16000,
+    enableVAD: true,
+    enableEnhancer: true,
+    vadRedemptionMs: 500,
+});
+```
+
+The meaning of these fields is intentionally aligned with the existing web microphone input config:
+
+- `enableVAD`: whether frontend VAD should emit `speechStart` and `speechEnd` for user audio.
+- `enableEnhancer`: whether frontend enhancement runs before user audio is published.
+- `vadRedemptionMs`: how long silence must last before user speech is considered finished.
+
+If you do not want the bridge to capture the user microphone, do not call `openUserInput()`.
+
+## Full example
+
+The example below starts two bots, publishes both bots' output back into the bridge, and also injects real user microphone audio:
+
+```ts
+import { createSession, createAudioBridge } from "xtalk-client";
+
+const bridge = createAudioBridge();
+
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+
+const botB = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-b",
+        bridge,
+        autoEmitVad: false,
+    },
+});
+
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+
+botB.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-b",
+        sampleRate,
+    });
+});
+
+await botA.open();
+await botB.open();
+
+await bridge.openUserInput({
+    sourceId: "user",
+    sampleRate: 16000,
+    enableVAD: true,
+    enableEnhancer: true,
+    vadRedemptionMs: 500,
+});
+```
+
+## Stop the bridge
+
+When shutting down, close user input first if it is active, then close bot sessions, then close the bridge itself:
+
+```ts
+await bridge.closeUserInput();
+await botA.close();
+await botB.close();
+await bridge.close();
+```
+
+## Current limitations
+
+- The bridge currently exists only for the Web platform.
+- The shared bus is implemented on the frontend and does not change server-side agent configuration.
+- `participantId` is not a server-side speaker id. It is only a frontend bridge identifier.
+- A bot does not hear the audio it just published back into the bridge itself.
+- When several bots publish output back into the same stream, they may continue responding to each other indefinitely until you stop them.

--- a/docs/tutorial/bot2bot.zh.md
+++ b/docs/tutorial/bot2bot.zh.md
@@ -1,0 +1,259 @@
+X-Talk 现在支持在浏览器端把多个前端会话接到同一条共享音频总线上，让 bot 听到的是一条连续音频流，而不只是麦克风输入。
+
+本文档介绍当前这套仅前端实现的 bot2bot bridge API：
+
+- 共享音频总线通过 `createAudioBridge()` 创建；
+- 每个 bot session 使用 `inputConfig.mode = "web_bridge"`；
+- 用户麦克风可以选择由 bridge 直接接入，也可以完全不接入；
+- bot 的输出音频会重新发布回 bridge，从而让其他 bot 继续听到并回复。
+
+`createAudioBridge()` 是包根提供的统一入口。它会自动检测当前前端平台；在现阶段，检测到 Web 时会落到 Web bridge 实现。
+
+## 适用场景
+
+当您希望一个浏览器页面同时做到下面几件事时，可以使用 web audio bridge：
+
+- 同时连接多个 X-Talk session；
+- 让 bot 回应其他 bot 的语音输出；
+- 可选地把真实用户麦克风音频也注入同一条共享流；
+- 保持现有服务端接口不变，把音频编排放在前端完成。
+
+这套 API 目前只支持 Web 平台，实现位于 `frontend/src/platforms`。
+
+## 共享流模型
+
+bridge 内部维护一条 `16000` Hz 的连续 PCM 音频流。
+
+- 没有人说话时，这条流会持续输出静默；
+- 用户或 bot 发布音频时，这些音频会被混入这条共享流；
+- 所有配置为 `mode: "web_bridge"` 的 bot session 都会持续收到来自同一条共享流的音频帧，但不会收到自己刚发布回去的那一路音频。
+
+这意味着 bridge 并不是点对点路由 bot 音频，而是让所有发布者都往一条总线上写，所有 bridge bot 都从这条总线上读，同时每个 bot 会自动过滤掉自己刚发布的音频。
+
+## 创建 bridge
+
+从客户端包中导入 bridge 构造函数：
+
+```ts
+import { createAudioBridge } from "xtalk-client";
+
+const bridge = createAudioBridge();
+```
+
+bridge 实例当前公开的 API 如下：
+
+```ts
+type WebBridgeParticipantId = string;
+
+interface WebAudioBridgeUserInputConfig {
+    sourceId?: WebBridgeParticipantId;
+    sampleRate?: number;
+    enableVAD?: boolean;
+    enableEnhancer?: boolean;
+    vadRedemptionMs?: number;
+}
+
+interface WebAudioBridgePublishOptions {
+    sourceId: WebBridgeParticipantId;
+    sampleRate: number;
+}
+
+interface WebAudioBridge {
+    openUserInput(config?: WebAudioBridgeUserInputConfig): Promise<void>;
+    closeUserInput(): Promise<void>;
+    publishAudio(
+        pcmChunkInt16: ArrayBuffer,
+        options: WebAudioBridgePublishOptions,
+    ): void;
+    publishSpeechStart(sourceId: WebBridgeParticipantId): void;
+    publishSpeechEnd(sourceId: WebBridgeParticipantId): void;
+    close(): Promise<void>;
+}
+```
+
+这里展示的具体类型名描述的是当前 Web 实现；包根现在只导出 `createAudioBridge()`，不再直接导出这些带 `Web` 前缀的类型。
+
+## 配置 bot session
+
+每个 bot 仍然使用普通的 `createSession()` API，只是把输入侧从麦克风切换成 bridge 共享流：
+
+```ts
+import { createSession } from "xtalk-client";
+
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+```
+
+这些 bridge 相关输入字段的含义如下：
+
+- `mode`：设置为 `"web_bridge"`，表示这个 session 不再读取麦克风，而是读取共享 bridge 流；
+- `participantId`：前端 bridge 使用的参与者标识，用于按 source 控制 VAD 行为以及调试；
+- `bridge`：当前 bot 要订阅的 `WebAudioBridge` 实例；
+- `autoEmitVad`：该 bot 输出重新写回共享流时，是否同时广播前端 VAD 信号；
+- `vadRedemptionMs`：启用 `autoEmitVad` 时，语音结束的静默收尾时间。
+
+## 把 bot 输出重新发布回 bridge
+
+当 bot 开始说话时，监听它的输出音频，并把这些 PCM 音频块重新发布回 bridge：
+
+```ts
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+```
+
+如果两个 bot 都这样做，它们就可以通过共享流继续互相回应：
+
+```ts
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+
+const botB = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-b",
+        bridge,
+        autoEmitVad: false,
+    },
+});
+
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+
+botB.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-b",
+        sampleRate,
+    });
+});
+
+await botA.open();
+await botB.open();
+```
+
+在这个配置下：
+
+- 两个 bot 都会持续接收同一条共享音频流，但不包含自己刚发布的音频；
+- bot 输出会被重新写回这条流；
+- bot 可以继续回复其他 bot 的回复。
+
+## 让 bridge 直接接收用户音频
+
+如果您希望浏览器麦克风也进入共享流，可以直接在 bridge 上打开用户输入：
+
+```ts
+await bridge.openUserInput({
+    sourceId: "user",
+    sampleRate: 16000,
+    enableVAD: true,
+    enableEnhancer: true,
+    vadRedemptionMs: 500,
+});
+```
+
+这里这些字段的语义故意与现有 Web 麦克风输入配置保持一致：
+
+- `enableVAD`：是否为用户音频广播前端 `speechStart` 和 `speechEnd`；
+- `enableEnhancer`：发布用户音频前是否先做前端增强；
+- `vadRedemptionMs`：静默持续多久后才把用户语音视为结束。
+
+如果您不希望 bridge 接入用户麦克风，就不要调用 `openUserInput()`。
+
+## 完整示例
+
+下面这个例子同时启动两个 bot，把两个 bot 的输出都发布回 bridge，并把真实用户麦克风音频也接入共享流：
+
+```ts
+import { createSession, createAudioBridge } from "xtalk-client";
+
+const bridge = createAudioBridge();
+
+const botA = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-a",
+        bridge,
+        autoEmitVad: true,
+        vadRedemptionMs: 500,
+    },
+});
+
+const botB = createSession("/ws", {
+    inputConfig: {
+        sampleRate: 16000,
+        mode: "web_bridge",
+        participantId: "bot-b",
+        bridge,
+        autoEmitVad: false,
+    },
+});
+
+botA.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-a",
+        sampleRate,
+    });
+});
+
+botB.onOutputAudioChunk((pcm, sampleRate) => {
+    bridge.publishAudio(pcm, {
+        sourceId: "bot-b",
+        sampleRate,
+    });
+});
+
+await botA.open();
+await botB.open();
+
+await bridge.openUserInput({
+    sourceId: "user",
+    sampleRate: 16000,
+    enableVAD: true,
+    enableEnhancer: true,
+    vadRedemptionMs: 500,
+});
+```
+
+## 停止 bridge
+
+关闭时，建议先关闭用户输入，再关闭 bot session，最后关闭 bridge 本身：
+
+```ts
+await bridge.closeUserInput();
+await botA.close();
+await botB.close();
+await bridge.close();
+```
+
+## 当前限制
+
+- 这套 bridge 目前只支持 Web 平台；
+- 共享音频总线完全在前端实现，不会修改服务端 agent 配置；
+- `participantId` 不是服务端的 speaker id，它只是前端 bridge 的参与者标识；
+- bot 不会听到自己刚刚发布回 bridge 的音频；
+- 当多个 bot 的输出持续写回同一条共享流时，它们可能会一直互相回应，直到您显式停止它们。

--- a/examples/bot2bot/server.py
+++ b/examples/bot2bot/server.py
@@ -172,53 +172,6 @@ def validate_agent_class(agent_class: type[Any]) -> None:
         )
 
 
-def get_template_system_prompt(template_config: dict[str, Any]) -> str:
-    """Extract the template ``system_prompt`` when present.
-
-    Parameters
-    ----------
-    template_config : dict[str, Any]
-        Template config loaded from ``--config``.
-
-    Returns
-    -------
-    str
-        Template prompt string, or an empty string when omitted.
-    """
-
-    llm_agent_config = template_config.get("llm_agent")
-    if not isinstance(llm_agent_config, dict):
-        return ""
-    params = llm_agent_config.get("params")
-    if not isinstance(params, dict):
-        return ""
-    system_prompt = params.get("system_prompt")
-    return system_prompt.strip() if isinstance(system_prompt, str) else ""
-
-
-def build_default_system_prompt(
-    template_system_prompt: str,
-    focus_hint: str,
-) -> str:
-    """Create one default prompt seeded from the template prompt.
-
-    Parameters
-    ----------
-    template_system_prompt : str
-        Prompt defined by the template config.
-    focus_hint : str
-        Additional role hint appended for the starter bot.
-
-    Returns
-    -------
-    str
-        Combined default prompt shown in the frontend.
-    """
-
-    parts = [template_system_prompt, focus_hint]
-    return "\n".join(part for part in parts if part).strip()
-
-
 def parse_bot_drafts(payload: dict[str, Any]) -> list[BotDraft]:
     """Parse and validate a bot list from the frontend payload.
 
@@ -430,11 +383,9 @@ class Bot2BotRuntimeManager:
         *,
         template_config: dict[str, Any],
         agent_type: str,
-        template_system_prompt: str,
     ) -> None:
         self.template_config = template_config
         self.agent_type = agent_type
-        self.template_system_prompt = template_system_prompt
         self.active_run: ActiveRun | None = None
 
     def describe_template(self) -> dict[str, Any]:
@@ -452,18 +403,12 @@ class Bot2BotRuntimeManager:
             "default_bots": [
                 {
                     "name": "Bot A",
-                    "system_prompt": build_default_system_prompt(
-                        self.template_system_prompt,
-                        "你更偏产品和用户体验视角，回应时喜欢抛出新的问题。",
-                    ),
+                    "system_prompt": "",
                     "proactive": True,
                 },
                 {
                     "name": "Bot B",
-                    "system_prompt": build_default_system_prompt(
-                        self.template_system_prompt,
-                        "你更偏工程实现和稳定性视角，回应时喜欢给出具体取舍。",
-                    ),
+                    "system_prompt": "",
                     "proactive": False,
                 },
             ],
@@ -562,11 +507,9 @@ def create_app(config_path: str) -> FastAPI:
     template_config = load_json(config_path)
     agent_class = resolve_agent_class(template_config)
     validate_agent_class(agent_class)
-    template_system_prompt = get_template_system_prompt(template_config)
     manager = Bot2BotRuntimeManager(
         template_config=template_config,
         agent_type=agent_class.__name__,
-        template_system_prompt=template_system_prompt,
     )
 
     app = FastAPI(title="Xtalk Bot2Bot Demo")

--- a/examples/bot2bot/server.py
+++ b/examples/bot2bot/server.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import inspect
+import json
+import mimetypes
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from xtalk import Xtalk
+from xtalk.log_utils import mute_other_logging
+from xtalk.model_loader import import_candidate
+
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("text/css", ".css")
+
+mute_other_logging()
+
+
+@dataclass
+class BotDraft:
+    """Editable bot settings submitted by the demo frontend.
+
+    Parameters
+    ----------
+    name : str
+        Display name shown in the browser timeline.
+    system_prompt : str
+        Per-bot prompt injected into ``llm_agent.params.system_prompt``.
+    proactive : bool
+        Whether the bot should proactively start the conversation.
+    """
+
+    name: str
+    system_prompt: str
+    proactive: bool
+
+
+@dataclass
+class ActiveBotRuntime:
+    """One active bot runtime backed by a dedicated Xtalk sub-application.
+
+    Parameters
+    ----------
+    bot_id : str
+        Stable bot identifier used by the frontend bridge and runtime URLs.
+    name : str
+        Display name returned to the browser.
+    app : FastAPI
+        Sub-application exposing standard Xtalk auth, session, upload, and
+        websocket routes.
+    """
+
+    bot_id: str
+    name: str
+    app: FastAPI
+
+
+@dataclass
+class ActiveRun:
+    """Active bot-to-bot run published through the runtime dispatcher.
+
+    Parameters
+    ----------
+    run_id : str
+        Unique run identifier embedded into runtime URLs.
+    bots : dict[str, ActiveBotRuntime]
+        Bot runtimes keyed by bot id.
+    """
+
+    run_id: str
+    bots: dict[str, ActiveBotRuntime]
+
+
+def load_json(path: str) -> dict[str, Any]:
+    """Load a JSON object from disk.
+
+    Parameters
+    ----------
+    path : str
+        JSON file path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed JSON object.
+    """
+
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def resolve_agent_class(template_config: dict[str, Any]) -> type[Any]:
+    """Resolve the configured LLM agent class from the shared registry.
+
+    Parameters
+    ----------
+    template_config : dict[str, Any]
+        Template server config passed through ``--config``.
+
+    Returns
+    -------
+    type[Any]
+        Resolved agent class.
+
+    Raises
+    ------
+    ValueError
+        Raised when the configured agent class cannot be found.
+    """
+
+    llm_agent_config = template_config.get("llm_agent")
+    if not isinstance(llm_agent_config, dict):
+        raise ValueError("Template config must define llm_agent.")
+    model_type = llm_agent_config.get("type")
+    if not isinstance(model_type, str) or not model_type.strip():
+        raise ValueError("Template config llm_agent.type must be a non-empty string.")
+
+    errors: list[str] = []
+    for spec in Xtalk.MODEL_REGISTRY["llm_agent"]:
+        try:
+            container = import_candidate(spec)
+        except Exception as exc:
+            errors.append(f"{spec!r} import failed: {exc!r}")
+            continue
+
+        agent_class = getattr(container, model_type, None)
+        if isinstance(agent_class, type):
+            return agent_class
+
+    detail = "\n  - " + "\n  - ".join(errors) if errors else ""
+    raise ValueError(
+        f"Configured llm agent class {model_type!r} not found in registry."
+        f"{detail}"
+    )
+
+
+def validate_agent_class(agent_class: type[Any]) -> None:
+    """Ensure the selected agent supports the demo overrides.
+
+    Parameters
+    ----------
+    agent_class : type[Any]
+        Resolved agent class from the configured template.
+
+    Raises
+    ------
+    ValueError
+        Raised when the agent does not accept ``system_prompt`` or
+        ``proactive`` constructor parameters.
+    """
+
+    signature = inspect.signature(agent_class.__init__)
+    missing = [
+        name
+        for name in ("system_prompt", "proactive")
+        if name not in signature.parameters
+    ]
+    if missing:
+        raise ValueError(
+            "The configured llm agent must support the following constructor "
+            f"parameters for bot2bot: {', '.join(missing)}."
+        )
+
+
+def get_template_system_prompt(template_config: dict[str, Any]) -> str:
+    """Extract the template ``system_prompt`` when present.
+
+    Parameters
+    ----------
+    template_config : dict[str, Any]
+        Template config loaded from ``--config``.
+
+    Returns
+    -------
+    str
+        Template prompt string, or an empty string when omitted.
+    """
+
+    llm_agent_config = template_config.get("llm_agent")
+    if not isinstance(llm_agent_config, dict):
+        return ""
+    params = llm_agent_config.get("params")
+    if not isinstance(params, dict):
+        return ""
+    system_prompt = params.get("system_prompt")
+    return system_prompt.strip() if isinstance(system_prompt, str) else ""
+
+
+def build_default_system_prompt(
+    template_system_prompt: str,
+    focus_hint: str,
+) -> str:
+    """Create one default prompt seeded from the template prompt.
+
+    Parameters
+    ----------
+    template_system_prompt : str
+        Prompt defined by the template config.
+    focus_hint : str
+        Additional role hint appended for the starter bot.
+
+    Returns
+    -------
+    str
+        Combined default prompt shown in the frontend.
+    """
+
+    parts = [template_system_prompt, focus_hint]
+    return "\n".join(part for part in parts if part).strip()
+
+
+def parse_bot_drafts(payload: dict[str, Any]) -> list[BotDraft]:
+    """Parse and validate a bot list from the frontend payload.
+
+    Parameters
+    ----------
+    payload : dict[str, Any]
+        JSON payload submitted to the start endpoint.
+
+    Returns
+    -------
+    list[BotDraft]
+        Normalized bot settings.
+
+    Raises
+    ------
+    ValueError
+        Raised when the payload is malformed or violates demo constraints.
+    """
+
+    raw_bots = payload.get("bots")
+    if not isinstance(raw_bots, list):
+        raise ValueError("Payload must contain a bots array.")
+    if len(raw_bots) < 2:
+        raise ValueError("At least two bots are required.")
+
+    bots: list[BotDraft] = []
+    proactive_count = 0
+    for index, raw_bot in enumerate(raw_bots, start=1):
+        if not isinstance(raw_bot, dict):
+            raise ValueError(f"Bot {index} must be an object.")
+        name_value = raw_bot.get("name")
+        system_prompt_value = raw_bot.get("system_prompt")
+        proactive_value = raw_bot.get("proactive")
+
+        name = name_value.strip() if isinstance(name_value, str) else ""
+        system_prompt = (
+            system_prompt_value.strip()
+            if isinstance(system_prompt_value, str)
+            else ""
+        )
+        proactive = bool(proactive_value)
+
+        if not name:
+            raise ValueError(f"Bot {index} name must be non-empty.")
+        if not system_prompt:
+            raise ValueError(f"Bot {index} system prompt must be non-empty.")
+
+        if proactive:
+            proactive_count += 1
+        bots.append(
+            BotDraft(
+                name=name,
+                system_prompt=system_prompt,
+                proactive=proactive,
+            )
+        )
+
+    if proactive_count != 1:
+        raise ValueError("Exactly one bot must set proactive=true.")
+    return bots
+
+
+def build_runtime_paths(run_id: str, bot_id: str) -> dict[str, str]:
+    """Build standard Xtalk route paths for one runtime bot.
+
+    Parameters
+    ----------
+    run_id : str
+        Active run id.
+    bot_id : str
+        Bot identifier inside the run.
+
+    Returns
+    -------
+    dict[str, str]
+        Standard route paths rooted at ``/runtime/{run_id}/{bot_id}``.
+    """
+
+    base_path = f"/runtime/{run_id}/{bot_id}"
+    return {
+        "base_path": base_path,
+        "websocket_path": f"{base_path}/ws",
+        "login_path": f"{base_path}/api/auth/login",
+        "sessions_path": f"{base_path}/api/sessions",
+        "upload_path": f"{base_path}/api/upload",
+    }
+
+
+def build_bot_config(template_config: dict[str, Any], bot: BotDraft) -> dict[str, Any]:
+    """Create one per-bot config by overriding the template agent params.
+
+    Parameters
+    ----------
+    template_config : dict[str, Any]
+        Template config passed through ``--config``.
+    bot : BotDraft
+        Normalized bot settings.
+
+    Returns
+    -------
+    dict[str, Any]
+        Deep-copied config ready for ``Xtalk.from_config()``.
+    """
+
+    config = copy.deepcopy(template_config)
+    llm_agent_config = config.get("llm_agent")
+    if not isinstance(llm_agent_config, dict):
+        raise ValueError("Template config must define llm_agent.")
+
+    llm_agent_params = llm_agent_config.get("params")
+    if not isinstance(llm_agent_params, dict):
+        llm_agent_params = {}
+        llm_agent_config["params"] = llm_agent_params
+
+    llm_agent_params["system_prompt"] = bot.system_prompt
+    llm_agent_params["proactive"] = bot.proactive
+    return config
+
+
+class BotRuntimeDispatcher:
+    """Dispatch ``/runtime/{run_id}/{bot_id}/...`` traffic to active sub-apps.
+
+    Parameters
+    ----------
+    manager : Bot2BotRuntimeManager
+        Runtime manager that resolves the currently active bot sub-app.
+    """
+
+    def __init__(self, manager: "Bot2BotRuntimeManager") -> None:
+        self.manager = manager
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        """Route an incoming HTTP or websocket scope to the active bot app.
+
+        Parameters
+        ----------
+        scope : dict[str, Any]
+            Incoming ASGI scope.
+        receive : Any
+            ASGI receive callable.
+        send : Any
+            ASGI send callable.
+        """
+
+        path = scope.get("path", "/")
+        parts = [segment for segment in path.split("/") if segment]
+        if parts and parts[0] == "runtime":
+            parts = parts[1:]
+        if len(parts) < 3:
+            await self._respond_not_found(scope, receive, send)
+            return
+
+        run_id = parts[0]
+        bot_id = parts[1]
+        child_app = self.manager.resolve_bot_app(run_id=run_id, bot_id=bot_id)
+        if child_app is None:
+            await self._respond_not_found(scope, receive, send)
+            return
+
+        child_path = "/" + "/".join(parts[2:])
+        child_scope = dict(scope)
+        child_scope["path"] = child_path
+        child_scope["root_path"] = f"{scope.get('root_path', '')}/{run_id}/{bot_id}"
+        raw_path = scope.get("raw_path")
+        if isinstance(raw_path, bytes):
+            child_scope["raw_path"] = child_path.encode("utf-8")
+        await child_app(child_scope, receive, send)
+
+    async def _respond_not_found(
+        self,
+        scope: dict[str, Any],
+        receive: Any,
+        send: Any,
+    ) -> None:
+        """Return a simple 404 response for missing runtime paths.
+
+        Parameters
+        ----------
+        scope : dict[str, Any]
+            Incoming ASGI scope.
+        receive : Any
+            ASGI receive callable.
+        send : Any
+            ASGI send callable.
+        """
+
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        response = PlainTextResponse("Runtime not found", status_code=404)
+        await response(scope, receive, send)
+
+
+class Bot2BotRuntimeManager:
+    """Manage one active bot-to-bot run and its per-bot Xtalk sub-apps.
+
+    Parameters
+    ----------
+    template_config : dict[str, Any]
+        Template config loaded from ``--config``.
+    agent_type : str
+        Human-readable configured agent type.
+    template_system_prompt : str
+        Template prompt used to seed frontend defaults.
+    """
+
+    def __init__(
+        self,
+        *,
+        template_config: dict[str, Any],
+        agent_type: str,
+        template_system_prompt: str,
+    ) -> None:
+        self.template_config = template_config
+        self.agent_type = agent_type
+        self.template_system_prompt = template_system_prompt
+        self.active_run: ActiveRun | None = None
+
+    def describe_template(self) -> dict[str, Any]:
+        """Return frontend metadata derived from the template config.
+
+        Returns
+        -------
+        dict[str, Any]
+            Template metadata and starter bot defaults.
+        """
+
+        return {
+            "agent_type": self.agent_type,
+            "supports_proactive": True,
+            "default_bots": [
+                {
+                    "name": "Bot A",
+                    "system_prompt": build_default_system_prompt(
+                        self.template_system_prompt,
+                        "你更偏产品和用户体验视角，回应时喜欢抛出新的问题。",
+                    ),
+                    "proactive": True,
+                },
+                {
+                    "name": "Bot B",
+                    "system_prompt": build_default_system_prompt(
+                        self.template_system_prompt,
+                        "你更偏工程实现和稳定性视角，回应时喜欢给出具体取舍。",
+                    ),
+                    "proactive": False,
+                },
+            ],
+        }
+
+    def start(self, bots: list[BotDraft]) -> dict[str, Any]:
+        """Create a fresh active run from the template config.
+
+        Parameters
+        ----------
+        bots : list[BotDraft]
+            Normalized bot settings submitted by the frontend.
+
+        Returns
+        -------
+        dict[str, Any]
+            Run metadata returned to the browser.
+        """
+
+        self.stop()
+
+        run_id = uuid.uuid4().hex
+        runtimes: dict[str, ActiveBotRuntime] = {}
+        response_bots: list[dict[str, Any]] = []
+
+        for index, bot in enumerate(bots, start=1):
+            bot_id = f"bot-{index}"
+            bot_config = build_bot_config(self.template_config, bot)
+            xtalk_instance = Xtalk.from_config(bot_config)
+            sub_app = FastAPI(title=f"Xtalk Bot2Bot Runtime {bot_id}")
+            xtalk_instance.mount_routes(sub_app)
+
+            runtimes[bot_id] = ActiveBotRuntime(
+                bot_id=bot_id,
+                name=bot.name,
+                app=sub_app,
+            )
+            runtime_paths = build_runtime_paths(run_id, bot_id)
+            response_bots.append(
+                {
+                    "id": bot_id,
+                    "name": bot.name,
+                    "proactive": bot.proactive,
+                    **runtime_paths,
+                }
+            )
+
+        self.active_run = ActiveRun(run_id=run_id, bots=runtimes)
+        return {
+            "run_id": run_id,
+            "bots": response_bots,
+        }
+
+    def stop(self) -> None:
+        """Drop the current active run from the dispatcher."""
+
+        self.active_run = None
+
+    def resolve_bot_app(self, *, run_id: str, bot_id: str) -> FastAPI | None:
+        """Resolve one active bot sub-app for the runtime dispatcher.
+
+        Parameters
+        ----------
+        run_id : str
+            Requested run id from the incoming path.
+        bot_id : str
+            Requested bot id from the incoming path.
+
+        Returns
+        -------
+        FastAPI | None
+            Matching sub-app when the run is active, else ``None``.
+        """
+
+        active_run = self.active_run
+        if active_run is None or active_run.run_id != run_id:
+            return None
+        runtime = active_run.bots.get(bot_id)
+        return runtime.app if runtime is not None else None
+
+
+def create_app(config_path: str) -> FastAPI:
+    """Create the bot-to-bot demo application.
+
+    Parameters
+    ----------
+    config_path : str
+        Template config file passed through ``--config``.
+
+    Returns
+    -------
+    FastAPI
+        Configured demo server.
+    """
+
+    template_config = load_json(config_path)
+    agent_class = resolve_agent_class(template_config)
+    validate_agent_class(agent_class)
+    template_system_prompt = get_template_system_prompt(template_config)
+    manager = Bot2BotRuntimeManager(
+        template_config=template_config,
+        agent_type=agent_class.__name__,
+        template_system_prompt=template_system_prompt,
+    )
+
+    app = FastAPI(title="Xtalk Bot2Bot Demo")
+
+    example_root = Path(__file__).parent
+    repo_root = example_root.parent.parent
+    frontend_dist = repo_root / "frontend" / "dist"
+    templates = Jinja2Templates(directory=str(example_root / "templates"))
+    app.mount(
+        "/static",
+        StaticFiles(directory=str(example_root / "static")),
+        name="static",
+    )
+    if frontend_dist.exists():
+        app.mount("/xtalk", StaticFiles(directory=str(frontend_dist)), name="xtalk")
+
+    app.mount("/runtime", BotRuntimeDispatcher(manager), name="runtime")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def read_root(request: Request) -> HTMLResponse:
+        """Render the bot-to-bot demo page.
+
+        Parameters
+        ----------
+        request : Request
+            Current HTTP request.
+
+        Returns
+        -------
+        HTMLResponse
+            Rendered demo HTML.
+        """
+
+        return templates.TemplateResponse("index.html", {"request": request})
+
+    @app.get("/api/bot2bot/template")
+    async def read_template() -> dict[str, Any]:
+        """Return frontend starter defaults derived from the template config.
+
+        Returns
+        -------
+        dict[str, Any]
+            Frontend defaults and capability metadata.
+        """
+
+        return manager.describe_template()
+
+    @app.post("/api/bot2bot/start")
+    async def start_bot2bot(request: Request) -> dict[str, Any]:
+        """Create one active bot-to-bot run from the submitted bot list.
+
+        Parameters
+        ----------
+        request : Request
+            Incoming HTTP request with the bot payload.
+
+        Returns
+        -------
+        dict[str, Any]
+            Run metadata including one websocket path per bot.
+
+        Raises
+        ------
+        HTTPException
+            Raised when the payload is invalid.
+        """
+
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Payload must be a JSON object.")
+        try:
+            bots = parse_bot_drafts(payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return manager.start(bots)
+
+    @app.post("/api/bot2bot/stop")
+    async def stop_bot2bot() -> dict[str, str]:
+        """Stop the active run.
+
+        Returns
+        -------
+        dict[str, str]
+            Stop status payload.
+        """
+
+        manager.stop()
+        return {"status": "stopped"}
+
+    @app.get("/api/bot2bot/health")
+    async def healthcheck() -> dict[str, str]:
+        """Return a lightweight health payload for the example UI.
+
+        Returns
+        -------
+        dict[str, str]
+            Static health response.
+        """
+
+        return {"status": "ok"}
+
+    return app
+
+
+def main() -> None:
+    """Parse flags and run the demo server."""
+
+    parser = argparse.ArgumentParser(description="Xtalk Bot-to-Bot Demo")
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the template server config JSON, for example server_configs/experimental.json",
+    )
+    parser.add_argument("--port", type=int, default=11996, help="Port to listen on")
+    args = parser.parse_args()
+
+    import uvicorn
+
+    uvicorn.run(create_app(args.config), host="0.0.0.0", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bot2bot/static/css/index.css
+++ b/examples/bot2bot/static/css/index.css
@@ -1,0 +1,355 @@
+:root {
+    --bg: #efe5d4;
+    --bg-deep: #d7c2a5;
+    --panel: rgba(255, 251, 245, 0.86);
+    --panel-strong: #fffaf4;
+    --ink: #231d17;
+    --muted: #6a6056;
+    --line: rgba(35, 29, 23, 0.12);
+    --accent: #bb5a2c;
+    --accent-soft: rgba(187, 90, 44, 0.12);
+    --accent-alt: #156f6b;
+    --shadow: 0 28px 70px rgba(77, 52, 26, 0.14);
+    --radius: 24px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    color: var(--ink);
+    font-family: "IBM Plex Sans", "PingFang SC", "Noto Sans SC", sans-serif;
+    background:
+        radial-gradient(circle at top left, rgba(187, 90, 44, 0.2), transparent 26%),
+        radial-gradient(circle at top right, rgba(21, 111, 107, 0.2), transparent 30%),
+        linear-gradient(155deg, #f7efe2 0%, var(--bg) 40%, var(--bg-deep) 100%);
+}
+
+button,
+input,
+textarea {
+    font: inherit;
+}
+
+code {
+    font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+}
+
+.page-shell {
+    width: min(1320px, calc(100vw - 32px));
+    margin: 0 auto;
+    padding: 32px 0 40px;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.85fr);
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.hero-copy,
+.status-card,
+.panel {
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--panel);
+    backdrop-filter: blur(16px);
+    box-shadow: var(--shadow);
+}
+
+.hero-copy {
+    padding: 28px;
+}
+
+.eyebrow,
+.panel-kicker {
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.hero h1,
+.panel h2 {
+    margin: 8px 0 10px;
+    font-family: "Avenir Next", "Helvetica Neue", sans-serif;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+}
+
+.hero h1 {
+    font-size: clamp(34px, 4vw, 56px);
+}
+
+.hero p {
+    margin: 0;
+    max-width: 720px;
+    line-height: 1.75;
+    color: var(--muted);
+}
+
+.status-card {
+    padding: 24px;
+    display: grid;
+    gap: 12px;
+    align-content: center;
+}
+
+.status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--line);
+}
+
+.status-row:last-child {
+    border-bottom: 0;
+}
+
+.status-label {
+    color: var(--muted);
+}
+
+.status-value {
+    font-weight: 700;
+    text-align: right;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: minmax(420px, 0.95fr) minmax(0, 1.15fr);
+    gap: 20px;
+}
+
+.panel {
+    padding: 24px;
+}
+
+.panel-heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.button-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.primary-btn,
+.ghost-btn,
+.remove-btn {
+    border-radius: 999px;
+    border: 0;
+    padding: 11px 17px;
+    cursor: pointer;
+    transition: transform 120ms ease, opacity 120ms ease, background 120ms ease;
+}
+
+.primary-btn {
+    color: #fff;
+    background: linear-gradient(135deg, var(--accent), #d57a36);
+}
+
+.ghost-btn,
+.remove-btn {
+    color: var(--ink);
+    background: rgba(255, 255, 255, 0.68);
+    border: 1px solid var(--line);
+}
+
+.remove-btn {
+    padding: 8px 14px;
+}
+
+.primary-btn:hover,
+.ghost-btn:hover,
+.remove-btn:hover {
+    transform: translateY(-1px);
+}
+
+.primary-btn:disabled,
+.ghost-btn:disabled,
+.remove-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+    transform: none;
+}
+
+.hint-card {
+    display: grid;
+    gap: 8px;
+    margin-bottom: 16px;
+    padding: 16px 18px;
+    border-radius: 18px;
+    border: 1px solid var(--line);
+    background:
+        linear-gradient(160deg, rgba(255, 255, 255, 0.8), rgba(255, 246, 238, 0.9));
+}
+
+.hint-text {
+    font-weight: 600;
+}
+
+.hint-note {
+    color: var(--muted);
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.bot-list {
+    display: grid;
+    gap: 14px;
+}
+
+.bot-card {
+    display: grid;
+    gap: 14px;
+    padding: 18px;
+    border-radius: 22px;
+    border: 1px solid var(--line);
+    background:
+        radial-gradient(circle at top right, rgba(187, 90, 44, 0.09), transparent 26%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.9));
+}
+
+.bot-card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.bot-card-title {
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    text-transform: uppercase;
+}
+
+.field {
+    display: grid;
+    gap: 8px;
+}
+
+.field span {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--muted);
+}
+
+.field input,
+.field textarea {
+    width: 100%;
+    padding: 14px 15px;
+    border-radius: 16px;
+    border: 1px solid rgba(35, 29, 23, 0.14);
+    background: var(--panel-strong);
+    color: var(--ink);
+    resize: vertical;
+}
+
+.field input:focus,
+.field textarea:focus {
+    outline: 2px solid rgba(187, 90, 44, 0.22);
+    border-color: rgba(187, 90, 44, 0.3);
+}
+
+.checkbox-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--ink);
+    font-weight: 600;
+}
+
+.checkbox-field input {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent-alt);
+}
+
+.turn-counter {
+    align-self: center;
+    padding: 8px 12px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.messages {
+    display: grid;
+    gap: 14px;
+    max-height: calc(100vh - 260px);
+    overflow: auto;
+    padding-right: 4px;
+}
+
+.message-card {
+    border-radius: 22px;
+    padding: 18px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(255, 255, 255, 0.94));
+    border: 1px solid var(--line);
+}
+
+.message-card.is-streaming {
+    box-shadow: inset 0 0 0 1px rgba(21, 111, 107, 0.18);
+}
+
+.message-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+}
+
+.message-name {
+    font-size: 15px;
+    font-weight: 800;
+}
+
+.message-meta {
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.message-text {
+    margin: 0;
+    line-height: 1.8;
+    white-space: pre-wrap;
+}
+
+@media (max-width: 960px) {
+    .hero,
+    .layout {
+        grid-template-columns: 1fr;
+    }
+
+    .page-shell {
+        width: min(100vw, calc(100vw - 24px));
+        padding-top: 20px;
+    }
+
+    .panel-heading {
+        flex-direction: column;
+    }
+
+    .button-row {
+        width: 100%;
+    }
+}

--- a/examples/bot2bot/static/js/index.js
+++ b/examples/bot2bot/static/js/index.js
@@ -1,0 +1,451 @@
+async function loadXtalk() {
+    try {
+        return await import("../../xtalk/index.js");
+    } catch (error) {
+        console.warn("Failed to load local xtalk-client bundle, falling back to CDN.", error);
+        return await import("https://unpkg.com/xtalk-client@latest/dist/index.js");
+    }
+}
+
+const { createSession, createAudioBridge } = await loadXtalk();
+
+const $templateAgent = document.getElementById("template-agent");
+const $templateHint = document.getElementById("template-hint");
+const $connectionStatus = document.getElementById("connection-status");
+const $conversationStatus = document.getElementById("conversation-status");
+const $runStatus = document.getElementById("run-status");
+const $turnCounter = document.getElementById("turn-counter");
+const $botList = document.getElementById("bot-list");
+const $messages = document.getElementById("messages");
+const $btnAddBot = document.getElementById("btn-add-bot");
+const $btnStart = document.getElementById("btn-start");
+const $btnStop = document.getElementById("btn-stop");
+const $botCardTemplate = document.getElementById("bot-card-template");
+
+const state = {
+    loadingTemplate: true,
+    starting: false,
+    stopping: false,
+    running: false,
+    template: null,
+    botDrafts: [],
+    bridge: null,
+    runId: null,
+    botRecords: [],
+    messageNodes: new Map(),
+    finalizedMessageKeys: new Set(),
+};
+
+function cloneBotDraft(source, index) {
+    return {
+        name: source?.name?.trim() || `Bot ${index}`,
+        system_prompt: source?.system_prompt?.trim() || "",
+        proactive: Boolean(source?.proactive),
+    };
+}
+
+function buildNewBotDraft() {
+    const templateBot = state.template?.default_bots?.[state.botDrafts.length % 2] ?? null;
+    const draft = cloneBotDraft(templateBot, state.botDrafts.length + 1);
+    if (state.botDrafts.some((bot) => bot.proactive)) {
+        draft.proactive = false;
+    }
+    return draft;
+}
+
+function setConnectionStatus(text) {
+    $connectionStatus.textContent = text;
+}
+
+function setConversationStatus(text) {
+    $conversationStatus.textContent = text;
+}
+
+function setRunStatus(text) {
+    $runStatus.textContent = text;
+}
+
+function updateButtons() {
+    const disableEditing = state.running || state.starting;
+    $btnAddBot.disabled = disableEditing || state.loadingTemplate;
+    $btnStart.disabled = disableEditing || state.loadingTemplate;
+    $btnStop.disabled = !(state.running || state.stopping);
+}
+
+function updateTurnCounter() {
+    const completedTurns = state.finalizedMessageKeys.size;
+    $turnCounter.textContent = completedTurns > 0 ? `${completedTurns} turns finished` : "No turns yet";
+}
+
+function createMessageCard(botName, messageIndex) {
+    const card = document.createElement("article");
+    card.className = "message-card is-streaming";
+
+    const head = document.createElement("div");
+    head.className = "message-head";
+
+    const name = document.createElement("div");
+    name.className = "message-name";
+    name.textContent = botName;
+
+    const meta = document.createElement("div");
+    meta.className = "message-meta";
+    meta.textContent = `Turn ${messageIndex + 1}`;
+
+    const text = document.createElement("p");
+    text.className = "message-text";
+
+    head.append(name, meta);
+    card.append(head, text);
+    $messages.appendChild(card);
+    $messages.scrollTop = $messages.scrollHeight;
+    return card;
+}
+
+function upsertTimelineMessage(bot, messageIndex, message) {
+    const key = `${bot.id}:${messageIndex}`;
+    let card = state.messageNodes.get(key);
+    if (!card) {
+        card = createMessageCard(bot.name, messageIndex);
+        state.messageNodes.set(key, card);
+    }
+
+    card.querySelector(".message-name").textContent = bot.name;
+    card.querySelector(".message-meta").textContent = `Turn ${messageIndex + 1}`;
+    card.querySelector(".message-text").textContent = message.content || "";
+    card.classList.toggle("is-streaming", !message.final);
+
+    if (message.final) {
+        state.finalizedMessageKeys.add(key);
+    }
+    updateTurnCounter();
+    $messages.scrollTop = $messages.scrollHeight;
+}
+
+function clearTimeline() {
+    state.messageNodes.clear();
+    state.finalizedMessageKeys.clear();
+    $messages.innerHTML = "";
+    updateTurnCounter();
+}
+
+function renderBots() {
+    $botList.innerHTML = "";
+    const disableEditing = state.running || state.starting;
+
+    state.botDrafts.forEach((bot, index) => {
+        const fragment = $botCardTemplate.content.cloneNode(true);
+        const card = fragment.querySelector(".bot-card");
+        const title = fragment.querySelector(".bot-card-title");
+        const removeButton = fragment.querySelector(".remove-btn");
+        const nameInput = fragment.querySelector(".bot-name");
+        const promptInput = fragment.querySelector(".bot-system-prompt");
+        const proactiveInput = fragment.querySelector(".bot-proactive");
+
+        title.textContent = `Bot ${index + 1}`;
+        removeButton.disabled = disableEditing || state.botDrafts.length <= 2;
+        nameInput.value = bot.name;
+        promptInput.value = bot.system_prompt;
+        proactiveInput.checked = bot.proactive;
+
+        nameInput.disabled = disableEditing;
+        promptInput.disabled = disableEditing;
+        proactiveInput.disabled = disableEditing;
+
+        removeButton.addEventListener("click", () => {
+            state.botDrafts.splice(index, 1);
+            if (!state.botDrafts.some((item) => item.proactive) && state.botDrafts[0]) {
+                state.botDrafts[0].proactive = true;
+            }
+            renderBots();
+        });
+        nameInput.addEventListener("input", (event) => {
+            state.botDrafts[index].name = event.target.value;
+        });
+        promptInput.addEventListener("input", (event) => {
+            state.botDrafts[index].system_prompt = event.target.value;
+        });
+        proactiveInput.addEventListener("change", (event) => {
+            const checked = Boolean(event.target.checked);
+            state.botDrafts.forEach((item, itemIndex) => {
+                item.proactive = checked && itemIndex === index;
+            });
+            renderBots();
+        });
+
+        $botList.appendChild(card);
+    });
+}
+
+function buildWebSocketURL(path) {
+    const url = new URL(path, window.location.href);
+    url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    return url;
+}
+
+async function fetchJSON(url, options = {}) {
+    const response = await fetch(url, {
+        headers: {
+            "Content-Type": "application/json",
+            ...(options.headers || {}),
+        },
+        ...options,
+    });
+    if (!response.ok) {
+        let message = `Request failed with status ${response.status}`;
+        try {
+            const payload = await response.json();
+            if (payload?.detail) {
+                message = String(payload.detail);
+            }
+        } catch (_error) {
+        }
+        throw new Error(message);
+    }
+    return await response.json();
+}
+
+function validateBotDrafts() {
+    if (state.botDrafts.length < 2) {
+        throw new Error("At least two bots are required.");
+    }
+    const proactiveCount = state.botDrafts.filter((bot) => bot.proactive).length;
+    if (proactiveCount !== 1) {
+        throw new Error("Exactly one bot must set proactive=true.");
+    }
+
+    state.botDrafts.forEach((bot, index) => {
+        if (!bot.name.trim()) {
+            throw new Error(`Bot ${index + 1} name must be non-empty.`);
+        }
+        if (!bot.system_prompt.trim()) {
+            throw new Error(`Bot ${index + 1} system prompt must be non-empty.`);
+        }
+    });
+}
+
+function refreshRuntimeStatus() {
+    if (!state.running && !state.starting) {
+        setConnectionStatus("Idle");
+        setConversationStatus("Idle");
+        setRunStatus("None");
+        return;
+    }
+
+    if (state.starting) {
+        setConnectionStatus("Connecting");
+        setConversationStatus("Starting");
+        setRunStatus(state.runId ? state.runId.slice(0, 8) : "Preparing");
+        return;
+    }
+
+    const total = state.botRecords.length;
+    const connected = state.botRecords.filter(
+        (record) => record.session.state.connectionState === "connected",
+    ).length;
+    setConnectionStatus(`${connected}/${total} connected`);
+
+    const speakingBot = state.botRecords.find(
+        (record) => record.session.state.streamState === "speaking",
+    );
+    const processingBot = state.botRecords.find(
+        (record) => record.session.state.streamState === "processing",
+    );
+
+    if (speakingBot) {
+        setConversationStatus(`${speakingBot.meta.name} speaking`);
+    } else if (processingBot) {
+        setConversationStatus(`${processingBot.meta.name} processing`);
+    } else {
+        setConversationStatus("Running");
+    }
+    setRunStatus(state.runId ? state.runId.slice(0, 8) : "Active");
+}
+
+async function stopLocalRuntime() {
+    const sessions = state.botRecords.map((record) => record.session);
+    const bridge = state.bridge;
+    const runId = state.runId;
+
+    state.botRecords = [];
+    state.bridge = null;
+    state.runId = null;
+    state.running = false;
+    state.starting = false;
+    state.stopping = false;
+    updateButtons();
+    refreshRuntimeStatus();
+    renderBots();
+
+    for (const session of sessions) {
+        try {
+            await session.close();
+        } catch (_error) {
+        }
+    }
+    if (bridge) {
+        try {
+            await bridge.close();
+        } catch (_error) {
+        }
+    }
+    if (runId) {
+        try {
+            await fetchJSON("/api/bot2bot/stop", {
+                method: "POST",
+                body: JSON.stringify({ run_id: runId }),
+            });
+        } catch (_error) {
+        }
+    }
+}
+
+async function startBot2Bot() {
+    validateBotDrafts();
+
+    if (state.running || state.starting) {
+        return;
+    }
+
+    state.starting = true;
+    updateButtons();
+    clearTimeline();
+    refreshRuntimeStatus();
+
+    try {
+        const payload = {
+            bots: state.botDrafts.map((bot) => ({
+                name: bot.name.trim(),
+                system_prompt: bot.system_prompt.trim(),
+                proactive: bot.proactive,
+            })),
+        };
+        const run = await fetchJSON("/api/bot2bot/start", {
+            method: "POST",
+            body: JSON.stringify(payload),
+        });
+
+        state.runId = run.run_id;
+        state.bridge = createAudioBridge();
+
+        const botRecords = run.bots.map((botMeta) => {
+            const session = createSession(buildWebSocketURL(botMeta.websocket_path), {
+                inputConfig: {
+                    sampleRate: 16000,
+                    mode: "web_bridge",
+                    participantId: botMeta.id,
+                    bridge: state.bridge,
+                    autoEmitVad: true,
+                    vadRedemptionMs: 500,
+                },
+                serviceURLs: {
+                    login: new URL(botMeta.login_path, window.location.href),
+                    sessions: new URL(botMeta.sessions_path, window.location.href),
+                    sessionDetail: (sessionId) =>
+                        new URL(
+                            `${botMeta.sessions_path}/${encodeURIComponent(sessionId)}`,
+                            window.location.href,
+                        ),
+                    upload: new URL(botMeta.upload_path, window.location.href),
+                },
+            });
+
+            session.onOutputAudioChunk((pcmChunkInt16, sampleRate) => {
+                state.bridge?.publishAudio(pcmChunkInt16, {
+                    sourceId: botMeta.id,
+                    sampleRate,
+                });
+            });
+            session.onStateChange((sessionState) => {
+                const assistantMessages = sessionState.messages.filter(
+                    (message) => message.role === "assistant",
+                );
+                assistantMessages.forEach((message, messageIndex) => {
+                    upsertTimelineMessage(botMeta, messageIndex, message);
+                });
+                refreshRuntimeStatus();
+            });
+
+            return {
+                meta: botMeta,
+                session,
+            };
+        });
+
+        state.botRecords = botRecords;
+        renderBots();
+        refreshRuntimeStatus();
+
+        const proactiveRecord = botRecords.find((record) => record.meta.proactive);
+        const passiveRecords = botRecords.filter((record) => !record.meta.proactive);
+
+        await Promise.all(passiveRecords.map((record) => record.session.open()));
+        if (proactiveRecord) {
+            await proactiveRecord.session.open();
+        }
+
+        state.running = true;
+        state.starting = false;
+        updateButtons();
+        refreshRuntimeStatus();
+    } catch (error) {
+        await stopLocalRuntime();
+        throw error;
+    }
+}
+
+async function loadTemplate() {
+    state.loadingTemplate = true;
+    updateButtons();
+    const template = await fetchJSON("/api/bot2bot/template");
+    state.template = template;
+    state.botDrafts = Array.isArray(template.default_bots)
+        ? template.default_bots.map((bot, index) => cloneBotDraft(bot, index + 1))
+        : [cloneBotDraft(null, 1), cloneBotDraft(null, 2)];
+    if (!state.botDrafts.some((bot) => bot.proactive) && state.botDrafts[0]) {
+        state.botDrafts[0].proactive = true;
+    }
+    $templateAgent.textContent = template.agent_type || "Unknown";
+    $templateHint.textContent = `Template agent: ${template.agent_type || "Unknown"}. One Xtalk.from_config instance will be created for each bot when you click Start.`;
+    state.loadingTemplate = false;
+    renderBots();
+    updateButtons();
+}
+
+$btnAddBot.addEventListener("click", () => {
+    state.botDrafts.push(buildNewBotDraft());
+    renderBots();
+});
+
+$btnStart.addEventListener("click", async () => {
+    try {
+        await startBot2Bot();
+    } catch (error) {
+        alert(error?.message || String(error));
+    }
+});
+
+$btnStop.addEventListener("click", async () => {
+    if (!state.running) {
+        return;
+    }
+    state.stopping = true;
+    updateButtons();
+    try {
+        await stopLocalRuntime();
+    } finally {
+        state.stopping = false;
+        updateButtons();
+        refreshRuntimeStatus();
+    }
+});
+
+try {
+    await loadTemplate();
+    refreshRuntimeStatus();
+} catch (error) {
+    console.error("Failed to load bot2bot template metadata.", error);
+    $templateAgent.textContent = "Error";
+    $templateHint.textContent = error?.message || String(error);
+    alert(`Failed to load bot2bot template: ${error?.message || error}`);
+}

--- a/examples/bot2bot/templates/index.html
+++ b/examples/bot2bot/templates/index.html
@@ -14,7 +14,6 @@
             <div class="hero-copy">
                 <div class="eyebrow">Xtalk Example</div>
                 <h1>Bot2Bot Voice Demo</h1>
-                <p>每个 bot 都是一个标准 Xtalk session。页面会在启动时按模板 config 创建多个 runtime，再用共享 WebAudioBridge 把它们桥接成 bot2bot 对话。</p>
             </div>
             <div class="status-card">
                 <div class="status-row">

--- a/examples/bot2bot/templates/index.html
+++ b/examples/bot2bot/templates/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="zh-CN">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Xtalk Bot2Bot Demo</title>
+    <link rel="stylesheet" href="/static/css/index.css" />
+</head>
+
+<body>
+    <div class="page-shell">
+        <header class="hero">
+            <div class="hero-copy">
+                <div class="eyebrow">Xtalk Example</div>
+                <h1>Bot2Bot Voice Demo</h1>
+                <p>每个 bot 都是一个标准 Xtalk session。页面会在启动时按模板 config 创建多个 runtime，再用共享 WebAudioBridge 把它们桥接成 bot2bot 对话。</p>
+            </div>
+            <div class="status-card">
+                <div class="status-row">
+                    <span class="status-label">Agent</span>
+                    <span id="template-agent" class="status-value">Loading</span>
+                </div>
+                <div class="status-row">
+                    <span class="status-label">Connection</span>
+                    <span id="connection-status" class="status-value">Idle</span>
+                </div>
+                <div class="status-row">
+                    <span class="status-label">Conversation</span>
+                    <span id="conversation-status" class="status-value">Idle</span>
+                </div>
+                <div class="status-row">
+                    <span class="status-label">Run</span>
+                    <span id="run-status" class="status-value">None</span>
+                </div>
+            </div>
+        </header>
+
+        <main class="layout">
+            <section class="panel control-panel">
+                <div class="panel-heading">
+                    <div>
+                        <div class="panel-kicker">Setup</div>
+                        <h2>Bot Runtime Drafts</h2>
+                    </div>
+                    <div class="button-row">
+                        <button id="btn-add-bot" class="ghost-btn">Add Bot</button>
+                        <button id="btn-start" class="primary-btn">Start</button>
+                        <button id="btn-stop" class="ghost-btn" disabled>Stop</button>
+                    </div>
+                </div>
+
+                <div class="hint-card">
+                    <div id="template-hint" class="hint-text">Loading template config...</div>
+                    <div class="hint-note">Exactly one bot must set <code>proactive=true</code>. The demo does not open user microphone input by default.</div>
+                </div>
+
+                <div id="bot-list" class="bot-list"></div>
+            </section>
+
+            <section class="panel transcript-panel">
+                <div class="panel-heading">
+                    <div>
+                        <div class="panel-kicker">Live Feed</div>
+                        <h2>Assistant Timeline</h2>
+                    </div>
+                    <div id="turn-counter" class="turn-counter">No turns yet</div>
+                </div>
+                <div id="messages" class="messages"></div>
+            </section>
+        </main>
+    </div>
+
+    <template id="bot-card-template">
+        <article class="bot-card">
+            <div class="bot-card-head">
+                <div class="bot-card-title"></div>
+                <button type="button" class="remove-btn">Remove</button>
+            </div>
+            <label class="field">
+                <span>Name</span>
+                <input class="bot-name" type="text" />
+            </label>
+            <label class="field">
+                <span>System Prompt</span>
+                <textarea class="bot-system-prompt" rows="7"></textarea>
+            </label>
+            <label class="checkbox-field">
+                <input class="bot-proactive" type="checkbox" />
+                <span>Proactive opener</span>
+            </label>
+        </article>
+    </template>
+
+    <script type="module" src="/static/js/index.js"></script>
+</body>
+
+</html>

--- a/frontend/src/bases/audio-session.ts
+++ b/frontend/src/bases/audio-session.ts
@@ -2,7 +2,32 @@ export { BaseInputAudioSession, BaseOutputAudioSession };
 export type { InputAudioSessionConfig, OutputAudioSessionConfig };
 
 interface InputAudioSessionConfig {
+    /**
+     * Target input sample rate forwarded to the session runtime.
+     */
     sampleRate: number;
+    /**
+     * Selects the input source implementation.
+     */
+    mode?: "microphone" | "web_bridge";
+    /**
+     * Participant identifier used by bridge-backed input implementations.
+     */
+    participantId?: string;
+    /**
+     * Bridge instance consumed by bridge-backed input implementations.
+     */
+    bridge?: unknown;
+    /**
+     * Whether the source should auto-broadcast frontend VAD when publishing output
+     * back into a shared bridge stream.
+     */
+    autoEmitVad?: boolean;
+    /**
+     * VAD redemption window used by bridge-backed input sources that emit frontend
+     * VAD automatically.
+     */
+    vadRedemptionMs?: number;
     [key: string]: any;
 }
 abstract class BaseInputAudioSession {

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -5,8 +5,10 @@
  */
 
 import { createSession } from "./session/create";
+import { createAudioBridge } from "./platforms/index";
 
 export { createSession };
+export { createAudioBridge };
 export type {
     Session,
     SessionConfig,

--- a/frontend/src/platforms/index.ts
+++ b/frontend/src/platforms/index.ts
@@ -7,6 +7,11 @@ import { BasePersistenceStore } from "../bases/persistence";
 import { BaseDeferredTaskScheduler } from "../bases/task-scheduler";
 import { BaseWebSocket } from "../bases/websocket";
 import {
+    WebBridgeInputAudioSession,
+    createWebAudioBridge as createWebAudioBridgeInternal,
+} from "./web-audio-bridge";
+import type { WebAudioBridge } from "./web-audio-bridge";
+import {
     WebDeferredTaskScheduler,
     WebEncoding,
     WebHTTPClient,
@@ -19,8 +24,16 @@ import {
 } from "./web";
 
 export {
+    createAudioBridge,
     getPlatformRuntime,
 };
+export type {
+    WebAudioBridge,
+    WebAudioBridgePublishOptions,
+    WebAudioBridgeUserInputConfig,
+    WebBridgeInputAudioSessionConfig,
+    WebBridgeParticipantId,
+} from "./web-audio-bridge";
 
 type PlatformRuntime = {
     createInputAudioSession(config: InputAudioSessionConfig): BaseInputAudioSession;
@@ -54,6 +67,9 @@ function detectPlatform(): Platform {
 
 const WEB_PLATFORM_RUNTIME: PlatformRuntime = {
     createInputAudioSession(config) {
+        if (config.mode === "web_bridge") {
+            return new WebBridgeInputAudioSession(config as any);
+        }
         return new WebInputAudioSession(config);
     },
     createOutputAudioSession(config) {
@@ -91,6 +107,20 @@ function getPlatformRuntime(): PlatformRuntime {
     switch (detectPlatform()) {
         case Platform.Web:
             return WEB_PLATFORM_RUNTIME;
+        default:
+            throw new Error("Unknown platform");
+    }
+}
+
+/**
+ * Create an audio bridge for the detected frontend platform.
+ *
+ * @returns A new platform audio bridge instance.
+ */
+function createAudioBridge(): WebAudioBridge {
+    switch (detectPlatform()) {
+        case Platform.Web:
+            return createWebAudioBridgeInternal();
         default:
             throw new Error("Unknown platform");
     }

--- a/frontend/src/platforms/web-audio-bridge.ts
+++ b/frontend/src/platforms/web-audio-bridge.ts
@@ -1,0 +1,593 @@
+import { BaseInputAudioSession } from "../bases/audio-session";
+import type { InputAudioSessionConfig } from "../bases/audio-session";
+import { WebInputAudioSession } from "./web";
+
+export {
+    WEB_AUDIO_BRIDGE_SAMPLE_RATE,
+    WebBridgeInputAudioSession,
+    createWebAudioBridge,
+};
+export type {
+    WebAudioBridge,
+    WebAudioBridgePublishOptions,
+    WebAudioBridgeUserInputConfig,
+    WebBridgeInputAudioSessionConfig,
+    WebBridgeParticipantId,
+};
+
+/**
+ * Default shared-stream sample rate used by the web audio bridge.
+ */
+const WEB_AUDIO_BRIDGE_SAMPLE_RATE = 16000;
+const BRIDGE_FRAME_SAMPLES = 512;
+const DEFAULT_VAD_REDEMPTION_MS = 500;
+const DEFAULT_USER_SOURCE_ID = "user";
+
+/**
+ * Unique identifier for one participant publishing into or receiving from the
+ * shared web bridge audio stream.
+ */
+type WebBridgeParticipantId = string;
+
+/**
+ * User-input capture options accepted by ``openUserInput()``.
+ */
+interface WebAudioBridgeUserInputConfig {
+    /**
+     * Source identifier used when publishing microphone audio into the bridge.
+     */
+    sourceId?: WebBridgeParticipantId;
+    /**
+     * Requested capture sample rate before bridge normalization.
+     */
+    sampleRate?: number;
+    /**
+     * Whether client-side VAD should emit speech start/end for microphone audio.
+     */
+    enableVAD?: boolean;
+    /**
+     * Whether client-side speech enhancement should run before publishing frames.
+     */
+    enableEnhancer?: boolean;
+    /**
+     * Redemption window used by the client VAD before emitting speech end.
+     */
+    vadRedemptionMs?: number;
+}
+
+/**
+ * Metadata attached to one published bridge audio chunk.
+ */
+interface WebAudioBridgePublishOptions {
+    /**
+     * Source identifier responsible for the published audio.
+     */
+    sourceId: WebBridgeParticipantId;
+    /**
+     * Sample rate of the published PCM payload.
+     */
+    sampleRate: number;
+}
+
+/**
+ * Public web-only bridge API used to feed shared audio into bot sessions.
+ */
+interface WebAudioBridge {
+    /**
+     * Open browser microphone capture and publish user audio into the bridge.
+     *
+     * @param config Optional user-input capture overrides.
+     */
+    openUserInput(config?: WebAudioBridgeUserInputConfig): Promise<void>;
+    /**
+     * Stop browser microphone capture previously opened through the bridge.
+     */
+    closeUserInput(): Promise<void>;
+    /**
+     * Publish one PCM s16le mono chunk into the shared bridge stream.
+     *
+     * @param pcmChunkInt16 PCM chunk to mix into the shared stream.
+     * @param options Source metadata for the chunk.
+     */
+    publishAudio(
+        pcmChunkInt16: ArrayBuffer,
+        options: WebAudioBridgePublishOptions,
+    ): void;
+    /**
+     * Broadcast a speech-start event for one source into the shared stream.
+     *
+     * @param sourceId Source that just became active.
+     */
+    publishSpeechStart(sourceId: WebBridgeParticipantId): void;
+    /**
+     * Broadcast a speech-end event for one source into the shared stream.
+     *
+     * @param sourceId Source that just became inactive.
+     */
+    publishSpeechEnd(sourceId: WebBridgeParticipantId): void;
+    /**
+     * Stop the bridge, microphone capture, and the shared silent-stream loop.
+     */
+    close(): Promise<void>;
+}
+
+/**
+ * Input-session config for sessions that consume the shared web bridge stream.
+ */
+interface WebBridgeInputAudioSessionConfig extends InputAudioSessionConfig {
+    /**
+     * Must be ``"web_bridge"`` to consume shared bridge audio instead of the microphone.
+     */
+    mode: "web_bridge";
+    /**
+     * Unique participant id used for diagnostics and source-specific VAD defaults.
+     */
+    participantId: WebBridgeParticipantId;
+    /**
+     * Shared web bridge that will feed this input session.
+     */
+    bridge: WebAudioBridge;
+    /**
+     * Whether this participant should auto-broadcast VAD when publishing its own output back
+     * into the bridge.
+     */
+    autoEmitVad?: boolean;
+    /**
+     * Redemption window used when auto-broadcasting source-local speech end.
+     */
+    vadRedemptionMs?: number;
+}
+
+type WebAudioBridgeInputTarget = {
+    participantId: WebBridgeParticipantId;
+    sampleRate: number;
+    autoEmitVad: boolean;
+    vadRedemptionMs: number;
+    pushAudioChunk: (pcmChunkInt16: ArrayBuffer) => void | Promise<void>;
+    handleSpeechStart: () => void | Promise<void>;
+    handleSpeechEnd: () => void | Promise<void>;
+};
+
+interface WebAudioBridgeInternal extends WebAudioBridge {
+    registerInputTarget(target: WebAudioBridgeInputTarget): void;
+    unregisterInputTarget(participantId: WebBridgeParticipantId): void;
+}
+
+type SourceRuntimeState = {
+    autoEmitVad: boolean;
+    vadRedemptionMs: number;
+    endTimerId: number | null;
+};
+
+/**
+ * Input session that continuously consumes frames from the shared web audio bridge.
+ */
+class WebBridgeInputAudioSession extends BaseInputAudioSession {
+    private readonly bridge: WebAudioBridgeInternal;
+    private readonly config: WebBridgeInputAudioSessionConfig;
+    private _muted = false;
+    private opened = false;
+
+    constructor(config: WebBridgeInputAudioSessionConfig) {
+        super();
+        this.config = {
+            ...config,
+            autoEmitVad: config.autoEmitVad ?? false,
+            vadRedemptionMs: resolveVadRedemptionMs(config.vadRedemptionMs),
+        };
+        this.bridge = config.bridge as WebAudioBridgeInternal;
+    }
+
+    async open(): Promise<void> {
+        if (this.opened) {
+            throw new Error("Session already started");
+        }
+        this.opened = true;
+        this.bridge.registerInputTarget({
+            participantId: this.config.participantId,
+            sampleRate: this.config.sampleRate,
+            autoEmitVad: Boolean(this.config.autoEmitVad),
+            vadRedemptionMs: resolveVadRedemptionMs(this.config.vadRedemptionMs),
+            pushAudioChunk: (pcmChunkInt16) => {
+                if (this._muted) {
+                    return;
+                }
+                this.frameCallback(pcmChunkInt16);
+            },
+            handleSpeechStart: () => {
+                if (this._muted) {
+                    return;
+                }
+                this.speechStartCallback();
+            },
+            handleSpeechEnd: () => {
+                if (this._muted) {
+                    return;
+                }
+                this.speechEndCallback();
+            },
+        });
+    }
+
+    async close(): Promise<void> {
+        if (!this.opened) {
+            throw new Error("Session not started");
+        }
+        this.opened = false;
+        this.bridge.unregisterInputTarget(this.config.participantId);
+    }
+
+    get muted(): boolean {
+        return this._muted;
+    }
+
+    set muted(value: boolean) {
+        this._muted = value;
+    }
+}
+
+class DefaultWebAudioBridge implements WebAudioBridgeInternal {
+    private readonly bridgeSampleRate = WEB_AUDIO_BRIDGE_SAMPLE_RATE;
+    private readonly frameSamples = BRIDGE_FRAME_SAMPLES;
+    private readonly subscribers = new Map<WebBridgeParticipantId, WebAudioBridgeInputTarget>();
+    private readonly sourceStates = new Map<WebBridgeParticipantId, SourceRuntimeState>();
+    private readonly activeVadSources = new Set<WebBridgeParticipantId>();
+    private readonly sourceBuffers = new Map<WebBridgeParticipantId, number[]>();
+    private dispatchTimerId: number | null = null;
+    private userInputSession: WebInputAudioSession | null = null;
+    private userInputSourceId: WebBridgeParticipantId | null = null;
+
+    registerInputTarget(target: WebAudioBridgeInputTarget): void {
+        this.subscribers.set(target.participantId, target);
+        this.ensureSourceState(target.participantId, {
+            autoEmitVad: target.autoEmitVad,
+            vadRedemptionMs: target.vadRedemptionMs,
+        });
+        if (this.hasAudibleVadForTarget(target.participantId)) {
+            void Promise.resolve(target.handleSpeechStart());
+        }
+        this.ensureDispatchLoop();
+    }
+
+    unregisterInputTarget(participantId: WebBridgeParticipantId): void {
+        this.subscribers.delete(participantId);
+        this.publishSpeechEnd(participantId);
+        this.sourceBuffers.delete(participantId);
+        const sourceState = this.sourceStates.get(participantId);
+        if (sourceState?.endTimerId != null) {
+            window.clearTimeout(sourceState.endTimerId);
+        }
+        this.sourceStates.delete(participantId);
+        this.maybeStopDispatchLoop();
+    }
+
+    async openUserInput(
+        config: WebAudioBridgeUserInputConfig = {},
+    ): Promise<void> {
+        await this.closeUserInput();
+
+        const resolvedConfig = {
+            sourceId: config.sourceId ?? DEFAULT_USER_SOURCE_ID,
+            sampleRate: config.sampleRate ?? this.bridgeSampleRate,
+            enableVAD: config.enableVAD ?? true,
+            enableEnhancer: config.enableEnhancer ?? true,
+            vadRedemptionMs: resolveVadRedemptionMs(config.vadRedemptionMs),
+        };
+
+        const inputSession = new WebInputAudioSession({
+            sampleRate: resolvedConfig.sampleRate,
+            enableVAD: resolvedConfig.enableVAD,
+            enableEnhancer: resolvedConfig.enableEnhancer,
+            vadRedemptionMs: resolvedConfig.vadRedemptionMs,
+        });
+
+        inputSession.onFrame((pcmChunkInt16) => {
+            this.publishAudio(pcmChunkInt16, {
+                sourceId: resolvedConfig.sourceId,
+                sampleRate: resolvedConfig.sampleRate,
+            });
+        });
+        inputSession.onSpeechStart(() => {
+            this.publishSpeechStart(resolvedConfig.sourceId);
+        });
+        inputSession.onSpeechEnd(() => {
+            this.publishSpeechEnd(resolvedConfig.sourceId);
+        });
+
+        await inputSession.open();
+        this.userInputSession = inputSession;
+        this.userInputSourceId = resolvedConfig.sourceId;
+        this.ensureSourceState(resolvedConfig.sourceId, {
+            autoEmitVad: resolvedConfig.enableVAD,
+            vadRedemptionMs: resolvedConfig.vadRedemptionMs,
+        });
+        this.ensureDispatchLoop();
+    }
+
+    async closeUserInput(): Promise<void> {
+        const current = this.userInputSession;
+        const sourceId = this.userInputSourceId;
+        this.userInputSession = null;
+        this.userInputSourceId = null;
+
+        if (current) {
+            try {
+                await current.close();
+            } catch {
+                // Ignore shutdown errors from already-closed microphone sessions.
+            }
+        }
+        if (sourceId) {
+            this.publishSpeechEnd(sourceId);
+            this.sourceBuffers.delete(sourceId);
+        }
+        this.maybeStopDispatchLoop();
+    }
+
+    publishAudio(
+        pcmChunkInt16: ArrayBuffer,
+        options: WebAudioBridgePublishOptions,
+    ): void {
+        const sourceState = this.sourceStates.get(options.sourceId);
+        const float32 = decodePcm16ToFloat32(pcmChunkInt16);
+        const normalized = (
+            options.sampleRate === this.bridgeSampleRate
+                ? float32
+                : resampleFloat32(float32, options.sampleRate, this.bridgeSampleRate)
+        );
+
+        if (normalized.length === 0) {
+            return;
+        }
+
+        mixIntoSourceBuffer(
+            this.sourceBuffers,
+            options.sourceId,
+            normalized,
+        );
+        this.ensureDispatchLoop();
+
+        if (sourceState?.autoEmitVad) {
+            this.publishSpeechStart(options.sourceId);
+            if (sourceState.endTimerId != null) {
+                window.clearTimeout(sourceState.endTimerId);
+            }
+            sourceState.endTimerId = window.setTimeout(() => {
+                sourceState.endTimerId = null;
+                this.publishSpeechEnd(options.sourceId);
+            }, sourceState.vadRedemptionMs);
+        }
+    }
+
+    publishSpeechStart(sourceId: WebBridgeParticipantId): void {
+        const previouslyAudibleTargets = new Set<WebBridgeParticipantId>();
+        for (const target of this.subscribers.values()) {
+            if (this.hasAudibleVadForTarget(target.participantId)) {
+                previouslyAudibleTargets.add(target.participantId);
+            }
+        }
+        this.activeVadSources.add(sourceId);
+        for (const target of this.subscribers.values()) {
+            if (previouslyAudibleTargets.has(target.participantId)) {
+                continue;
+            }
+            if (!this.hasAudibleVadForTarget(target.participantId)) {
+                continue;
+            }
+            void Promise.resolve(target.handleSpeechStart());
+        }
+    }
+
+    publishSpeechEnd(sourceId: WebBridgeParticipantId): void {
+        const sourceState = this.sourceStates.get(sourceId);
+        if (sourceState?.endTimerId != null) {
+            window.clearTimeout(sourceState.endTimerId);
+            sourceState.endTimerId = null;
+        }
+        const previouslyAudibleTargets = new Set<WebBridgeParticipantId>();
+        for (const target of this.subscribers.values()) {
+            if (this.hasAudibleVadForTarget(target.participantId)) {
+                previouslyAudibleTargets.add(target.participantId);
+            }
+        }
+        const wasActive = this.activeVadSources.delete(sourceId);
+        if (!wasActive) {
+            return;
+        }
+        for (const target of this.subscribers.values()) {
+            if (!previouslyAudibleTargets.has(target.participantId)) {
+                continue;
+            }
+            if (this.hasAudibleVadForTarget(target.participantId)) {
+                continue;
+            }
+            void Promise.resolve(target.handleSpeechEnd());
+        }
+    }
+
+    async close(): Promise<void> {
+        await this.closeUserInput();
+        if (this.dispatchTimerId != null) {
+            window.clearInterval(this.dispatchTimerId);
+            this.dispatchTimerId = null;
+        }
+        for (const sourceState of this.sourceStates.values()) {
+            if (sourceState.endTimerId != null) {
+                window.clearTimeout(sourceState.endTimerId);
+            }
+        }
+        this.sourceStates.clear();
+        this.activeVadSources.clear();
+        this.subscribers.clear();
+        this.sourceBuffers.clear();
+    }
+
+    private ensureDispatchLoop(): void {
+        if (this.dispatchTimerId != null) {
+            return;
+        }
+        this.dispatchTimerId = window.setInterval(() => {
+            this.emitNextFrame();
+        }, this.frameSamples / this.bridgeSampleRate * 1000);
+    }
+
+    private maybeStopDispatchLoop(): void {
+        if (this.subscribers.size !== 0 || this.userInputSession !== null) {
+            return;
+        }
+        if (this.dispatchTimerId != null) {
+            window.clearInterval(this.dispatchTimerId);
+            this.dispatchTimerId = null;
+        }
+    }
+
+    private emitNextFrame(): void {
+        if (this.subscribers.size === 0) {
+            return;
+        }
+
+        for (const target of this.subscribers.values()) {
+            const floatFrame = new Float32Array(this.frameSamples);
+            for (const [sourceId, sourceBuffer] of this.sourceBuffers.entries()) {
+                if (sourceId === target.participantId) {
+                    continue;
+                }
+                const available = Math.min(sourceBuffer.length, this.frameSamples);
+                for (let index = 0; index < available; index += 1) {
+                    const mixed = floatFrame[index]! + (sourceBuffer[index] ?? 0);
+                    floatFrame[index] = Math.max(-1, Math.min(1, mixed));
+                }
+            }
+            const targetFrame = (
+                target.sampleRate === this.bridgeSampleRate
+                    ? encodeFloat32ToPcm16(floatFrame)
+                    : encodeFloat32ToPcm16(
+                        resampleFloat32(floatFrame, this.bridgeSampleRate, target.sampleRate),
+                    )
+            );
+            void Promise.resolve(target.pushAudioChunk(targetFrame));
+        }
+        for (const [sourceId, sourceBuffer] of this.sourceBuffers.entries()) {
+            const available = Math.min(sourceBuffer.length, this.frameSamples);
+            if (available > 0) {
+                sourceBuffer.splice(0, available);
+            }
+            if (sourceBuffer.length === 0) {
+                this.sourceBuffers.delete(sourceId);
+            }
+        }
+    }
+
+    private ensureSourceState(
+        sourceId: WebBridgeParticipantId,
+        {
+            autoEmitVad,
+            vadRedemptionMs,
+        }: {
+            autoEmitVad: boolean;
+            vadRedemptionMs: number;
+        },
+    ): SourceRuntimeState {
+        const existing = this.sourceStates.get(sourceId);
+        if (existing) {
+            existing.autoEmitVad = autoEmitVad;
+            existing.vadRedemptionMs = vadRedemptionMs;
+            return existing;
+        }
+        const created: SourceRuntimeState = {
+            autoEmitVad,
+            vadRedemptionMs,
+            endTimerId: null,
+        };
+        this.sourceStates.set(sourceId, created);
+        return created;
+    }
+
+    private hasAudibleVadForTarget(targetParticipantId: WebBridgeParticipantId): boolean {
+        for (const sourceId of this.activeVadSources) {
+            if (sourceId !== targetParticipantId) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * Create a web-only shared audio bridge backed by one continuous PCM stream.
+ *
+ * The bridge always emits a continuous stream to bridge-input sessions; when no
+ * user or bot audio is present the stream consists of silence.
+ *
+ * @returns A new web audio bridge instance.
+ */
+function createWebAudioBridge(): WebAudioBridge {
+    return new DefaultWebAudioBridge();
+}
+
+function resolveVadRedemptionMs(value: number | undefined): number {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        return DEFAULT_VAD_REDEMPTION_MS;
+    }
+    return value;
+}
+
+function mixIntoSourceBuffer(
+    target: Map<WebBridgeParticipantId, number[]>,
+    sourceId: WebBridgeParticipantId,
+    source: Float32Array,
+): void {
+    const sourceBuffer = target.get(sourceId) ?? [];
+    for (let index = 0; index < source.length; index += 1) {
+        sourceBuffer.push(Math.max(-1, Math.min(1, source[index]!)));
+    }
+    target.set(sourceId, sourceBuffer);
+}
+
+function decodePcm16ToFloat32(pcmChunkInt16: ArrayBuffer): Float32Array {
+    const int16 = new Int16Array(pcmChunkInt16);
+    const float32 = new Float32Array(int16.length);
+    for (let index = 0; index < int16.length; index += 1) {
+        float32[index] = int16[index]! / 32768;
+    }
+    return float32;
+}
+
+function encodeFloat32ToPcm16(float32: Float32Array): ArrayBuffer {
+    const int16 = new Int16Array(float32.length);
+    for (let index = 0; index < float32.length; index += 1) {
+        const clamped = Math.max(-1, Math.min(1, float32[index]!));
+        int16[index] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    }
+    return int16.buffer;
+}
+
+function resampleFloat32(
+    input: Float32Array,
+    sourceSampleRate: number,
+    targetSampleRate: number,
+): Float32Array {
+    if (
+        sourceSampleRate === targetSampleRate
+        || input.length === 0
+        || sourceSampleRate <= 0
+        || targetSampleRate <= 0
+    ) {
+        return input;
+    }
+
+    const ratio = sourceSampleRate / targetSampleRate;
+    const outputLength = Math.max(1, Math.floor(input.length / ratio));
+    const output = new Float32Array(outputLength);
+
+    for (let index = 0; index < outputLength; index += 1) {
+        const position = index * ratio;
+        const leftIndex = Math.floor(position);
+        const rightIndex = Math.min(leftIndex + 1, input.length - 1);
+        const fraction = position - leftIndex;
+        const left = input[leftIndex] ?? 0;
+        const right = input[rightIndex] ?? left;
+        output[index] = left + (right - left) * fraction;
+    }
+    return output;
+}

--- a/src/xtalk/llm_agent/experimental.py
+++ b/src/xtalk/llm_agent/experimental.py
@@ -62,7 +62,27 @@ class ExperimentalAgent(Agent):
         backchannel_source_dir: str | Path | None = None,
         tools: list[BaseTool | Callable[[], BaseTool]] | None = None,
         system_prompt: str = "",
+        proactive: bool = True,
     ) -> None:
+        """Initialize the experimental agent.
+
+        Parameters
+        ----------
+        model : BaseChatModel | dict[str, Any]
+            Primary chat model or configuration.
+        backchannel_model : BaseChatModel | dict[str, Any] | None, optional
+            Optional model used to judge backchannel insertion.
+        backchannel_source_dir : str | Path | None, optional
+            Directory containing backchannel assets.
+        tools : list[BaseTool | Callable[[], BaseTool]] | None, optional
+            Optional tool instances or factories.
+        system_prompt : str, optional
+            Additional system prompt appended after the base prompt.
+        proactive : bool, optional
+            Whether the agent should proactively emit the startup greeting on
+            the session loop.
+        """
+
         self.model = model if isinstance(model, BaseChatModel) else ChatOpenAI(**model)
         self.backchannel_model = (
             backchannel_model
@@ -72,6 +92,7 @@ class ExperimentalAgent(Agent):
             else None
         )
         self._additional_system_prompt = system_prompt
+        self.proactive = proactive
         self.system_prompt = self.BASE_SYSTEM_PROMPT + system_prompt
         self._chat_history = ChatHistory(system_prompt=self.system_prompt)
         self.backchannel_source_dir = (
@@ -126,6 +147,7 @@ class ExperimentalAgent(Agent):
             backchannel_source_dir=self.backchannel_source_dir,
             system_prompt=self._additional_system_prompt,
             tools=self._base_tools,
+            proactive=self.proactive,
         )
 
     def restore_history(self, messages: list[dict[str, Any]]) -> None:
@@ -159,7 +181,7 @@ class ExperimentalAgent(Agent):
     async def _loop_runner(self) -> AsyncIterator[AgentOutput]:
         while True:
             # greeting: AI take initiative to call user on session start
-            if len(self.messages) == 1:
+            if self.proactive and len(self.messages) == 1:
                 self._chat_history.append_message(HumanMessage(content="你好。"))
                 collector = TextCollector()
                 async for item in self._stream_and_collect_text(


### PR DESCRIPTION
## Summary
- add a frontend audio bridge API with shared bridge-backed input sessions and proactive greeting control for the experimental agent
- add a bot2bot example app that creates one Xtalk runtime per bot from a template config and bridges them on the frontend
- add English and Chinese bot2bot tutorial docs and wire them into mkdocs navigation

## Testing
- python3 -m py_compile src/xtalk/llm_agent/experimental.py
- python3 -m py_compile examples/bot2bot/server.py
- python3 FastAPI TestClient checks for /api/bot2bot/template, /api/bot2bot/health, invalid /api/bot2bot/start, and mocked runtime start routing
- npm run build in frontend
- node --check examples/bot2bot/static/js/index.js