### PR TITLE
feature: improve ASR/VAD model integration and bot2bot runtime controls

### DIFF
--- a/examples/bot2bot/server.py
+++ b/examples/bot2bot/server.py
@@ -38,11 +38,14 @@ class BotDraft:
         Per-bot prompt injected into ``llm_agent.params.system_prompt``.
     proactive : bool
         Whether the bot should proactively start the conversation.
+    voice : str
+        Optional TTS voice override injected into ``tts.params.voice``.
     """
 
     name: str
     system_prompt: str
     proactive: bool
+    voice: str
 
 
 @dataclass
@@ -144,6 +147,35 @@ def resolve_agent_class(template_config: dict[str, Any]) -> type[Any]:
     )
 
 
+def validate_template_vad_config(template_config: dict[str, Any]) -> None:
+    """Ensure the bot2bot template config defines a backend VAD model.
+
+    Parameters
+    ----------
+    template_config : dict[str, Any]
+        Template server config passed through ``--config``.
+
+    Raises
+    ------
+    ValueError
+        Raised when the template config does not define a valid ``vad`` block.
+    """
+
+    vad_config = template_config.get("vad")
+    if isinstance(vad_config, dict) and vad_config.get("type"):
+        return
+
+    raise ValueError(
+        "Bot2Bot requires backend VAD in the template config. "
+        "Install the dependency with `pip install -e '.[silero-vad]'`, then add "
+        'the following block to your config:\n'
+        '"vad": {\n'
+        '    "type": "SileroVAD",\n'
+        '    "params": {}\n'
+        "}"
+    )
+
+
 def validate_agent_class(agent_class: type[Any]) -> None:
     """Ensure the selected agent supports the demo overrides.
 
@@ -205,6 +237,7 @@ def parse_bot_drafts(payload: dict[str, Any]) -> list[BotDraft]:
         name_value = raw_bot.get("name")
         system_prompt_value = raw_bot.get("system_prompt")
         proactive_value = raw_bot.get("proactive")
+        voice_value = raw_bot.get("voice")
 
         name = name_value.strip() if isinstance(name_value, str) else ""
         system_prompt = (
@@ -213,6 +246,7 @@ def parse_bot_drafts(payload: dict[str, Any]) -> list[BotDraft]:
             else ""
         )
         proactive = bool(proactive_value)
+        voice = voice_value.strip() if isinstance(voice_value, str) else ""
 
         if not name:
             raise ValueError(f"Bot {index} name must be non-empty.")
@@ -226,6 +260,7 @@ def parse_bot_drafts(payload: dict[str, Any]) -> list[BotDraft]:
                 name=name,
                 system_prompt=system_prompt,
                 proactive=proactive,
+                voice=voice,
             )
         )
 
@@ -288,6 +323,19 @@ def build_bot_config(template_config: dict[str, Any], bot: BotDraft) -> dict[str
 
     llm_agent_params["system_prompt"] = bot.system_prompt
     llm_agent_params["proactive"] = bot.proactive
+
+    if bot.voice:
+        tts_config = config.get("tts")
+        if not isinstance(tts_config, dict):
+            tts_config = {}
+            config["tts"] = tts_config
+
+        tts_params = tts_config.get("params")
+        if not isinstance(tts_params, dict):
+            tts_params = {}
+            tts_config["params"] = tts_params
+
+        tts_params["voice"] = bot.voice
     return config
 
 
@@ -405,11 +453,13 @@ class Bot2BotRuntimeManager:
                     "name": "Bot A",
                     "system_prompt": "",
                     "proactive": True,
+                    "voice": "",
                 },
                 {
                     "name": "Bot B",
                     "system_prompt": "",
                     "proactive": False,
+                    "voice": "",
                 },
             ],
         }
@@ -505,6 +555,7 @@ def create_app(config_path: str) -> FastAPI:
     """
 
     template_config = load_json(config_path)
+    validate_template_vad_config(template_config)
     agent_class = resolve_agent_class(template_config)
     validate_agent_class(agent_class)
     manager = Bot2BotRuntimeManager(

--- a/examples/bot2bot/static/js/index.js
+++ b/examples/bot2bot/static/js/index.js
@@ -41,6 +41,7 @@ function cloneBotDraft(source, index) {
         name: source?.name?.trim() || `Bot ${index}`,
         system_prompt: source?.system_prompt?.trim() || "",
         proactive: Boolean(source?.proactive),
+        voice: source?.voice?.trim() || "",
     };
 }
 
@@ -141,16 +142,19 @@ function renderBots() {
         const nameInput = fragment.querySelector(".bot-name");
         const promptInput = fragment.querySelector(".bot-system-prompt");
         const proactiveInput = fragment.querySelector(".bot-proactive");
+        const voiceInput = fragment.querySelector(".bot-voice");
 
         title.textContent = `Bot ${index + 1}`;
         removeButton.disabled = disableEditing || state.botDrafts.length <= 2;
         nameInput.value = bot.name;
         promptInput.value = bot.system_prompt;
         proactiveInput.checked = bot.proactive;
+        voiceInput.value = bot.voice;
 
         nameInput.disabled = disableEditing;
         promptInput.disabled = disableEditing;
         proactiveInput.disabled = disableEditing;
+        voiceInput.disabled = disableEditing;
 
         removeButton.addEventListener("click", () => {
             state.botDrafts.splice(index, 1);
@@ -164,6 +168,9 @@ function renderBots() {
         });
         promptInput.addEventListener("input", (event) => {
             state.botDrafts[index].system_prompt = event.target.value;
+        });
+        voiceInput.addEventListener("input", (event) => {
+            state.botDrafts[index].voice = event.target.value;
         });
         proactiveInput.addEventListener("change", (event) => {
             const checked = Boolean(event.target.checked);
@@ -318,6 +325,7 @@ async function startBot2Bot() {
                 name: bot.name.trim(),
                 system_prompt: bot.system_prompt.trim(),
                 proactive: bot.proactive,
+                voice: bot.voice.trim(),
             })),
         };
         const run = await fetchJSON("/api/bot2bot/start", {
@@ -335,8 +343,6 @@ async function startBot2Bot() {
                     mode: "web_bridge",
                     participantId: botMeta.id,
                     bridge: state.bridge,
-                    autoEmitVad: true,
-                    vadRedemptionMs: 500,
                 },
                 serviceURLs: {
                     login: new URL(botMeta.login_path, window.location.href),

--- a/examples/bot2bot/templates/index.html
+++ b/examples/bot2bot/templates/index.html
@@ -84,6 +84,10 @@
                 <span>System Prompt</span>
                 <textarea class="bot-system-prompt" rows="7"></textarea>
             </label>
+            <label class="field">
+                <span>Voice</span>
+                <input class="bot-voice" type="text" placeholder="Optional TTS voice" />
+            </label>
             <label class="checkbox-field">
                 <input class="bot-proactive" type="checkbox" />
                 <span>Proactive opener</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ edge-tts = [
   "edge-tts"
 ]
 silero-vad = [
-  "torch",
+  "onnxruntime",
 ]
 rubberband = [
   "pyrubberband"

--- a/src/xtalk/pipelines/default.py
+++ b/src/xtalk/pipelines/default.py
@@ -102,7 +102,7 @@ class DefaultPipeline(Pipeline):
         default=None, metadata={"init_key": "caption_rewriter", "clone": False}
     )
     vad_model: Optional[VAD] = field(
-        default=None, metadata={"init_key": "vad", "clone": False}
+        default=None, metadata={"init_key": "vad", "clone": True}
     )
     enhancer_model: Optional[SpeechEnhancer] = field(
         default=None, metadata={"init_key": "speech_enhancer", "clone": True}

--- a/src/xtalk/speech/interfaces.py
+++ b/src/xtalk/speech/interfaces.py
@@ -59,8 +59,12 @@ class ASR(ABC):
         audio : bytes
             Incremental PCM 16-bit mono audio bytes.
         is_final : bool, optional
-            Whether the caller is forcing a temporal final decode because the user paused
-            or the turn ended. Does not mean the ASR state must be reset, but may be used as a hint to optimize decoding.
+            Whether the caller is asking the ASR to treat the current point as
+            a temporary boundary and optionally flush any tail audio that would
+            otherwise remain buffered. This is only a decoding hint. It does
+            not mean the streaming state must be reset, and previously
+            recognized text for the session must be preserved so later audio
+            can continue from the accumulated result.
         chat_history : str | None, optional
             Serialized chat history for the current session, excluding the
             in-progress turn when unavailable.
@@ -84,8 +88,8 @@ class ASR(ABC):
         Returns
         -------
         int | None
-            Recommended byte count for streaming accumulation, or ``None`` when
-            no preference is provided.
+            Recommended byte count for each chunk passed to
+            ``recognize_stream``, or ``None`` when no preference is provided.
         """
         return None
 
@@ -136,7 +140,12 @@ class ASR(ABC):
         audio : bytes
             Incremental PCM 16-bit mono audio bytes.
         is_final : bool, optional
-            Whether the chunk should force a final decode. Internal state like committed text should not be reset, but the implementation may use this as a hint to optimize decoding, like flushing the upstreamASR model itself.
+            Whether the caller is asking the ASR to treat the current point as
+            a temporary boundary and optionally flush any tail audio that would
+            otherwise remain buffered. This is only a decoding hint. It does
+            not mean the streaming state must be reset, and previously
+            recognized text for the session must be preserved so later audio
+            can continue from the accumulated result.
         chat_history : str | None, optional
             Serialized chat history for the current session, excluding the
             in-progress turn when unavailable.

--- a/src/xtalk/speech/vad/silero_vad.py
+++ b/src/xtalk/speech/vad/silero_vad.py
@@ -1,92 +1,262 @@
-"""
-Silero VAD wrapper that mimics webrtcvad.Vad API (`is_speech`).
-It keeps an internal VADIterator so it can be called chunk-by-chunk.
+"""Silero VAD backed by a shared ONNX Runtime session.
+
+Each process creates a single ONNX session that is shared by all
+``SileroVAD`` instances. Every instance keeps its own streaming model state,
+context window, and pending audio buffer so concurrent sessions do not leak
+state into each other.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
 from pathlib import Path
-import shutil
+import sys
 import tempfile
 import threading
 from urllib.request import urlopen
-import zipfile
 
 import numpy as np
-import torch
+import onnxruntime as ort
+
 from ..interfaces import VAD
 
 
-SILERO_VAD_ZIP_URL = (
-    "https://codeload.github.com/snakers4/silero-vad/legacy.zip/refs/heads/master"
+SAMPLE_RATE = 16000
+FRAME_SAMPLES = 512
+CONTEXT_SAMPLES = 64
+
+SILERO_VAD_ONNX_URL = (
+    "https://raw.githubusercontent.com/snakers4/silero-vad/master/src/"
+    "silero_vad/data/silero_vad.onnx"
 )
-SILERO_VAD_REPO_DIRNAME = "snakers4_silero-vad_master"
+_CACHE_SUBDIR = "xtalk/models"
+_CACHE_FILENAME = "silero_vad.onnx"
+
+_MODEL_FILE_LOCK = threading.Lock()
+_SESSION_LOCK = threading.Lock()
+_SHARED_SESSION: ort.InferenceSession | None = None
+_SHARED_MODEL_PATH: str | None = None
 
 
-def _ensure_local_silero_vad_repo() -> Path:
-    hub_dir = Path(torch.hub.get_dir())
-    repo_dir = hub_dir / SILERO_VAD_REPO_DIRNAME
-    if repo_dir.exists():
-        return repo_dir
+def _user_cache_dir() -> Path:
+    """Return the per-user cache directory for xtalk assets."""
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+    elif sys.platform == "darwin":
+        base = str(Path.home() / "Library" / "Caches")
+    else:
+        base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / _CACHE_SUBDIR
 
-    hub_dir.mkdir(parents=True, exist_ok=True)
-    zip_path = hub_dir / "snakers4_silero-vad_master.zip"
-    if not zip_path.exists():
-        with urlopen(SILERO_VAD_ZIP_URL) as response, zip_path.open("wb") as file_obj:
-            shutil.copyfileobj(response, file_obj)
 
-    extract_dir = Path(tempfile.mkdtemp(prefix="silero-vad-", dir=hub_dir))
-    try:
-        with zipfile.ZipFile(zip_path) as archive:
-            archive.extractall(extract_dir)
+def _ensure_cached_model() -> Path:
+    """Download the Silero VAD ONNX model into the user cache if needed."""
+    cache_dir = _user_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    model_path = cache_dir / _CACHE_FILENAME
+    if model_path.exists():
+        return model_path
 
-        extracted_dirs = [path for path in extract_dir.iterdir() if path.is_dir()]
-        if len(extracted_dirs) != 1:
-            raise RuntimeError(
-                f"Expected one extracted directory from Silero VAD archive, got {len(extracted_dirs)}"
-            )
+    with _MODEL_FILE_LOCK:
+        if model_path.exists():
+            return model_path
 
-        extracted_dirs[0].rename(repo_dir)
-    except Exception:
-        if repo_dir.exists():
-            shutil.rmtree(repo_dir)
-        raise
-    finally:
-        shutil.rmtree(extract_dir, ignore_errors=True)
+        temp_path: Path | None = None
+        try:
+            with urlopen(SILERO_VAD_ONNX_URL) as response:
+                with tempfile.NamedTemporaryFile(
+                    dir=cache_dir,
+                    prefix="silero_vad.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as temp_file:
+                    temp_path = Path(temp_file.name)
+                    temp_file.write(response.read())
 
-    return repo_dir
+            assert temp_path is not None
+            temp_path.replace(model_path)
+            return model_path
+        except Exception:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
+            raise
+
+
+def _resolve_model_path(model_path: str | None) -> Path:
+    """Resolve the Silero VAD ONNX model path."""
+    if model_path is not None:
+        resolved = Path(model_path).expanduser().resolve()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Silero VAD model not found: {resolved}")
+        return resolved
+
+    return _ensure_cached_model().resolve()
+
+
+def _create_session(model_path: Path) -> ort.InferenceSession:
+    """Create the shared ONNX Runtime session."""
+    opts = ort.SessionOptions()
+    opts.inter_op_num_threads = 1
+    opts.intra_op_num_threads = 1
+    opts.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+    opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    return ort.InferenceSession(
+        str(model_path),
+        sess_options=opts,
+        providers=["CPUExecutionProvider"],
+    )
+
+
+def _get_shared_session(model_path: str | None) -> tuple[ort.InferenceSession, str]:
+    """Return the process-wide ONNX session for Silero VAD."""
+    global _SHARED_MODEL_PATH, _SHARED_SESSION
+
+    resolved_path = str(_resolve_model_path(model_path))
+    with _SESSION_LOCK:
+        if (
+            _SHARED_SESSION is None
+            or _SHARED_MODEL_PATH is None
+            or _SHARED_MODEL_PATH != resolved_path
+        ):
+            _SHARED_SESSION = _create_session(Path(resolved_path))
+            _SHARED_MODEL_PATH = resolved_path
+        assert _SHARED_SESSION is not None
+        return _SHARED_SESSION, resolved_path
+
+
+@dataclass
+class _SileroStreamState:
+    """Per-instance streaming state for the Silero VAD model."""
+
+    model_state: np.ndarray = field(
+        default_factory=lambda: np.zeros((2, 1, 128), dtype=np.float32)
+    )
+    context: np.ndarray = field(
+        default_factory=lambda: np.zeros((1, CONTEXT_SAMPLES), dtype=np.float32)
+    )
+    pending_audio: np.ndarray = field(
+        default_factory=lambda: np.zeros((0,), dtype=np.float32)
+    )
+
+    def reset(self) -> None:
+        """Reset per-stream model memory and buffered audio."""
+        self.model_state = np.zeros((2, 1, 128), dtype=np.float32)
+        self.context = np.zeros((1, CONTEXT_SAMPLES), dtype=np.float32)
+        self.pending_audio = np.zeros((0,), dtype=np.float32)
 
 
 class SileroVAD(VAD):
-    def __init__(self, threshold: float = 0.5) -> None:
-        repo_dir = _ensure_local_silero_vad_repo()
-        model, _ = torch.hub.load(
-            repo_or_dir=str(repo_dir),
-            model="silero_vad",
-            source="local",
-        )
-        self._model = model
+    """Silero VAD implementation with shared model session and per-instance state."""
 
-        self.threshold = threshold
-        self.window_samples = 512
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        model_path: str | None = None,
+        frame_samples: int = FRAME_SAMPLES,
+        context_samples: int = CONTEXT_SAMPLES,
+    ) -> None:
+        """Initialize the VAD instance.
+
+        Parameters
+        ----------
+        threshold : float, optional
+            Speech probability threshold used to convert the model output into a
+            boolean decision.
+        model_path : str | None, optional
+            Optional path to the Silero VAD ONNX model. When omitted, several
+            common repository-local paths are tried.
+        frame_samples : int, optional
+            Expected frame size in samples for model inference. Current Silero
+            ONNX models typically expect 512 samples at 16 kHz.
+        context_samples : int, optional
+            Number of trailing samples from the previous frame to prepend as
+            model context on the next inference call.
+        """
+        self.threshold = float(threshold)
+        self.frame_samples = int(frame_samples)
+        self.context_samples = int(context_samples)
+        self.session, self.model_path = _get_shared_session(model_path)
         self._inference_lock = threading.Lock()
+        self._state = _SileroStreamState()
+        self._state.context = np.zeros(
+            (1, self.context_samples),
+            dtype=np.float32,
+        )
+
+    def clone(self) -> "SileroVAD":
+        """Clone the VAD while reusing the shared ONNX session."""
+        return SileroVAD(
+            threshold=self.threshold,
+            model_path=self.model_path,
+            frame_samples=self.frame_samples,
+            context_samples=self.context_samples,
+        )
+
+    def reset(self) -> None:
+        """Reset this instance's streaming state."""
+        self._state.reset()
+        if self.context_samples != CONTEXT_SAMPLES:
+            self._state.context = np.zeros(
+                (1, self.context_samples),
+                dtype=np.float32,
+            )
 
     def is_speech(self, frame: bytes) -> bool:
-        # int16 PCM ➜ float32 tensor
-        pcm = np.frombuffer(frame, dtype=np.int16).astype(np.float32) / 32768.0
-        wav = torch.from_numpy(pcm).unsqueeze(0)  # [1, T]
+        """Determine whether the latest complete frame contains speech.
 
-        # Feed window_samples-sized chunks to VADIterator
-        num_samples = self.window_samples
-        prob: float = 0.0  # probability of the last processed chunk
+        Parameters
+        ----------
+        frame : bytes
+            PCM 16-bit mono audio bytes at 16 kHz. Input may contain any number
+            of samples; the instance buffers partial data internally and only
+            runs inference on complete ``frame_samples`` windows.
 
-        # Iterate over the waveform using fixed windows
-        # TODO: Parallelize Silero VAD safely without sharing one JIT model instance across concurrent calls.
+        Returns
+        -------
+        bool
+            ``True`` when the most recent complete frame has speech
+            probability greater than or equal to ``threshold``. If not enough
+            audio is available to form a complete frame, returns ``False``.
+        """
+        if not frame:
+            return False
+
+        audio = np.frombuffer(frame, dtype=np.int16).astype(np.float32) / 32768.0
+        if audio.size == 0:
+            return False
+
+        self._state.pending_audio = np.concatenate([self._state.pending_audio, audio])
+        last_prob: float | None = None
+
+        while self._state.pending_audio.shape[0] >= self.frame_samples:
+            chunk = self._state.pending_audio[: self.frame_samples]
+            self._state.pending_audio = self._state.pending_audio[self.frame_samples :]
+            last_prob = self._infer_one_frame(chunk)
+
+        if last_prob is None:
+            return False
+        return last_prob >= self.threshold
+
+    def _infer_one_frame(self, frame: np.ndarray) -> float:
+        """Run ONNX inference for one complete frame."""
+        if frame.shape[0] != self.frame_samples:
+            raise ValueError(f"frame must have {self.frame_samples} samples")
+
+        x = frame.reshape(1, -1).astype(np.float32, copy=False)
+        x = np.concatenate([self._state.context, x], axis=1)
+        ort_inputs = {
+            "input": x,
+            "state": self._state.model_state,
+            "sr": np.array(SAMPLE_RATE, dtype=np.int64),
+        }
+
         with self._inference_lock:
-            for start in range(0, wav.shape[1], num_samples):
-                chunk = wav[:, start : start + num_samples]
-                if chunk.shape[1] < num_samples:
-                    break
-                # VADIterator returns speech probability for this chunk
-                prob = float(self._model(chunk.squeeze(0), 16000).item())
+            out, new_state = self.session.run(None, ort_inputs)
 
-        # Use the probability of the last full chunk as the speech decision
-        return prob >= self.threshold
+        self._state.model_state = new_state
+        self._state.context = x[:, -self.context_samples :].astype(
+            np.float32,
+            copy=False,
+        )
+        return float(np.asarray(out).squeeze())


### PR DESCRIPTION
## Summary
- clarify ASR streaming interface comments for final flush semantics and chunk size guidance
- refactor Silero VAD to use a shared process-level ONNX session with per-instance stream state and cached model download
- update bot2bot example to require backend VAD config and support per-bot TTS voice overrides from the frontend

## Testing
- python3 -m py_compile src/xtalk/serving/modules/asr_manager.py

## Notes
- install optional VAD dependency with 
- add backend VAD config when using the bot2bot example if it is missing from the template