### PR TITLE
feature: Add TurnSense turn detector support

### DIFF
--- a/docs/docs/supported_models.md
+++ b/docs/docs/supported_models.md
@@ -145,6 +145,19 @@ Turn detectors decide when the user has finished speaking and the system should 
 
 </details>
 
+<details markdown="1">
+<summary>TurnSense</summary>
+
+**Dependency:** `pip install "xtalk[turn-sense] @ git+https://github.com/xcc-zach/xtalk.git@main"`
+
+**Path:** `src/xtalk/speech/turn_detector/turn_sense.py`
+
+[Original Repo](https://github.com/Bairong-Xdynamics/TurnSense)
+
+[X-Talk-adapted service deployment reference](https://github.com/xcc-zach/TurnSense-server)
+
+</details>
+
 ### Speech Enhancement
     
 **Name in config**: `speech_enhancer`

--- a/docs/docs/supported_models.zh.md
+++ b/docs/docs/supported_models.zh.md
@@ -145,6 +145,19 @@ Turn detector 用于判断用户是否已经说完，并决定系统何时开始
 
 </details>
 
+<details markdown="1">
+<summary>TurnSense</summary>
+
+**依赖：** `pip install "xtalk[turn-sense] @ git+https://github.com/xcc-zach/xtalk.git@main"`
+
+**路径：** `src/xtalk/speech/turn_detector/turn_sense.py`
+
+[原仓库](https://github.com/Bairong-Xdynamics/TurnSense)
+
+[适配 X-Talk 的服务部署参考](https://github.com/xcc-zach/TurnSense-server)
+
+</details>
+
 ### 语音增强
 
 **配置中的名称**：`speech_enhancer`

--- a/docs/docs/system_design.zh.md
+++ b/docs/docs/system_design.zh.md
@@ -1,0 +1,13 @@
+# 整体架构
+
+## 前后端分离
+
+前端API在`frontend`下，后端在`src/xtalk`。
+
+前端负责音频与控制信号的收发、以及轻量的语音处理（VAD、语音增强）；后端承载X-Talk的主体逻辑。
+
+## 后端架构
+
+后端组件分为模型与`Manager`两级；模型为外部模型的适配器，例如如果想在X-Talk中使用IndexTTS，就要实现TTS接口定义的适配器，然后外部启动IndexTTS后，通过配置的方式接入；`Manager`为模型调度器，例如ASRManager控制ASR模型开始、暂停、继续、结束识别；`Manager`之间依赖观察者模式通信，力求解耦各个模型的能力，将模型间交互落到事件通信中。
+
+模型接口定义于`src/xtalk/llm_agent/interfaces.py`和`src/xtalk/speech/interfaces.py`；前者为LLM的适配接口：LLM是X-Talk的智能核心，负责综合各种语音模型的信息进行输出；后者包含各类语音模块的适配接口，例如ASR、TTS、VAD，以及一些实验性的适配接口，例如TurnDetector、SpeakerEncoder。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ pyannote = ["pyannote.audio","torchvision"]
 soulx-duplug = [
   "websockets",
 ]
+turn-sense = [
+  "aiohttp",
+]
 example = [
   "pypdf",
   "fastapi==0.128.0",

--- a/server_configs/experimental_telos_turn_sense.json
+++ b/server_configs/experimental_telos_turn_sense.json
@@ -1,0 +1,45 @@
+{
+    "asr": {
+        "type": "TelosDoubaoASR",
+        "params": {
+            "base_url": "https://litellm.telos-agent.com",
+            "api_key": "sk-Ex9stQRB-v6Ez7qgcw8t8g",
+            "model": "volcengine/doubao-asr-flash",
+            "incremental": true
+        }
+    },
+    "llm_agent": {
+        "type": "ExperimentalAgent",
+        "params": {
+            "model": {
+                "base_url": "https://litellm.telos-agent.com/v1",
+                "api_key": "sk-Ex9stQRB-v6Ez7qgcw8t8g",
+                "model": "openai/gpt-5.5",
+                "reasoning": {
+                    "effort": "none"
+                }
+            }
+        }
+    },
+    "tts": {
+        "type": "TelosDoubaoTTS",
+        "params": {
+            "base_url": "https://litellm.telos-agent.com",
+            "api_key": "sk-Ex9stQRB-v6Ez7qgcw8t8g",
+            "model": "volcengine/doubao-tts-2.0"
+        }
+    },
+    "vad": {
+        "type": "SileroVAD",
+        "params": {}
+    },
+    "turn_detector": {
+        "type": "TurnSense",
+        "params": {
+            "base_url": "http://127.0.0.1:8321"
+        }
+    },
+    "service_config": {
+        "recording": true
+    }
+}

--- a/server_configs/experimental_turn_sense.json
+++ b/server_configs/experimental_turn_sense.json
@@ -1,0 +1,42 @@
+{
+    "asr": {
+        "type": "Qwen3ASRFlashRealtime",
+        "params": {
+            "api_key": "sk-f6ce958fa01d4f0583ca27c7e66b96ff"
+        }
+    },
+    "llm_agent": {
+        "type": "ExperimentalAgent",
+        "params": {
+            "model": {
+                "api_key": "sk-f6ce958fa01d4f0583ca27c7e66b96ff",
+                "model": "qwen3.6-plus",
+                "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                "extra_body": {
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            }
+        }
+    },
+    "tts": {
+        "type": "CosyVoice",
+        "params": {
+            "api_key": "sk-f6ce958fa01d4f0583ca27c7e66b96ff"
+        }
+    },
+    "vad": {
+        "type": "SileroVAD",
+        "params": {}
+    },
+    "turn_detector": {
+        "type": "TurnSense",
+        "params": {
+            "base_url": "http://127.0.0.1:8321"
+        }
+    },
+    "service_config": {
+        "recording": true
+    }
+}

--- a/src/xtalk/serving/modules/asr_manager.py
+++ b/src/xtalk/serving/modules/asr_manager.py
@@ -137,6 +137,12 @@ class AudioConsumer:
             logger.warning(f"AudioConsumer ended repeatedly; do early return")
             return
         self._ended = True
+        if self._paused:
+            # Reuse the pause-time recognition result to avoid re-entering ASR
+            # during the pause->finalize handoff.
+            await self._publish_final_from_cached_text()
+            await self._reset_states()
+            return
         await self._stop_consumer()
         audio = await self._audio_queue.get()
         await self._recognize_and_publish(audio, is_asr_end=True, is_final_chunk=True)
@@ -198,13 +204,7 @@ class AudioConsumer:
             return
         if is_asr_end:
             self._recognized_text = recognized_text
-            await self._publish_event(
-                ASRResultFinal(
-                    session_id=self._session_id,
-                    text=recognized_text,
-                    display_text=recognized_text,
-                )
-            )
+            await self._publish_final_text(recognized_text)
         else:
             if recognized_text == self._recognized_text and not is_final_chunk:
                 return
@@ -225,6 +225,22 @@ class AudioConsumer:
 
     async def _publish_event(self, event: BaseEvent):
         await self._event_bus.publish(event)
+
+    async def _publish_final_text(self, text: str) -> None:
+        """Publish one final ASR result."""
+        await self._publish_event(
+            ASRResultFinal(
+                session_id=self._session_id,
+                text=text,
+                display_text=text,
+            )
+        )
+
+    async def _publish_final_from_cached_text(self) -> None:
+        """Publish the cached recognition result as the final ASR result."""
+        if self._is_blank_text(self._recognized_text):
+            return
+        await self._publish_final_text(self._recognized_text)
 
     async def _reset_states(self):
         self._recognized_text = ""

--- a/src/xtalk/speech/turn_detector/__init__.py
+++ b/src/xtalk/speech/turn_detector/__init__.py
@@ -1,4 +1,5 @@
 from .llm_turn_detector import LLMTurnDetector
 from .soulx_duplug import SoulxDuplug
+from .turn_sense import TurnSense
 
-__all__ = ["LLMTurnDetector", "SoulxDuplug"]
+__all__ = ["LLMTurnDetector", "SoulxDuplug", "TurnSense"]

--- a/src/xtalk/speech/turn_detector/turn_sense.py
+++ b/src/xtalk/speech/turn_detector/turn_sense.py
@@ -1,0 +1,382 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import aiohttp
+
+from ..interfaces import (
+    TurnDetectionAction,
+    TurnDetectionResult,
+    TurnDetectionSemantic,
+    TurnDetector,
+)
+
+_IDLE_RESULT = TurnDetectionResult(
+    action=TurnDetectionAction.DO_NOTHING,
+    semantic=TurnDetectionSemantic.IDLE,
+)
+
+
+@dataclass(frozen=True)
+class TurnSenseProbabilities:
+    """Class probabilities returned by the TurnSense HTTP service."""
+
+    complete: float
+    incomplete: float
+    invalid: float
+
+
+@dataclass(frozen=True)
+class TurnSenseInferenceResult:
+    """Structured inference result returned by the TurnSense HTTP service."""
+
+    prediction: Literal["complete", "incomplete", "invalid"]
+    probabilities: TurnSenseProbabilities
+
+
+class TurnSense(TurnDetector):
+    """Turn detector client for the external TurnSense HTTP service."""
+
+    AUDIO_CHANNELS = 1
+    AUDIO_FORMAT = "pcm_s16le"
+    PCM_BYTES_PER_SECOND = 16000 * 2
+    SAMPLE_RATE = 16000
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8000",
+        timeout: float = 10.0,
+        inference_interval_ms: int = 200,
+    ) -> None:
+        """Initialize the TurnSense HTTP client.
+
+        Parameters
+        ----------
+        base_url : str, optional
+            Base URL of the TurnSense HTTP server.
+        timeout : float, optional
+            Request timeout in seconds for inference calls.
+        inference_interval_ms : int, optional
+            Buffered-audio interval in milliseconds between inference requests.
+        """
+        super().__init__()
+        if inference_interval_ms <= 0:
+            raise ValueError("inference_interval_ms must be positive")
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._inference_interval_ms = inference_interval_ms
+        self._infer_bytes_url = f"{self._base_url}/infer/bytes"
+        self._inference_interval_bytes = (
+            self.PCM_BYTES_PER_SECOND * self._inference_interval_ms // 1000
+        )
+        self._state_lock = asyncio.Lock()
+        self._audio_buffer = bytearray()
+        self._speech_started = False
+        self._epoch = 0
+        self._latest_inference_seq = 0
+        self._latest_result_seq = 0
+        self._latest_result: Optional[TurnSenseInferenceResult] = None
+        self._latest_inference_task: Optional[asyncio.Task] = None
+        self._last_requested_num_bytes = 0
+        self._pending_complete_after_interrupt = False
+
+    def _reset_detection_state(self) -> None:
+        """Reset buffered audio and invalidate stale in-flight inference results."""
+        self._epoch += 1
+        self._audio_buffer.clear()
+        self._speech_started = False
+        self._latest_inference_seq = 0
+        self._latest_result_seq = 0
+        self._latest_result = None
+        self._latest_inference_task = None
+        self._last_requested_num_bytes = 0
+
+    def _begin_speech(self) -> None:
+        """Start a new buffered speech segment if one is not already active."""
+        if self._speech_started:
+            return
+        self._reset_detection_state()
+        self._speech_started = True
+
+    async def _run_inference(
+        self, epoch: int, sequence: int, audio: bytes
+    ) -> tuple[int, int, TurnSenseInferenceResult]:
+        """Run one HTTP inference request for a buffered audio snapshot."""
+        result = await self._infer_audio_bytes(audio)
+        return epoch, sequence, result
+
+    def _store_inference_result(self, task: asyncio.Task) -> None:
+        """Keep only the newest completed inference result for the active epoch."""
+        try:
+            epoch, sequence, result = task.result()
+        except Exception:
+            return
+        if epoch != self._epoch or sequence < self._latest_result_seq:
+            return
+        self._latest_result_seq = sequence
+        self._latest_result = result
+
+    def _launch_inference_locked(self) -> Optional[asyncio.Task]:
+        """Launch inference for the latest buffered audio snapshot."""
+        if not self._audio_buffer:
+            return None
+        snapshot = bytes(self._audio_buffer)
+        self._latest_inference_seq += 1
+        task = asyncio.create_task(
+            self._run_inference(
+                self._epoch,
+                self._latest_inference_seq,
+                snapshot,
+            )
+        )
+        task.add_done_callback(self._store_inference_result)
+        self._latest_inference_task = task
+        self._last_requested_num_bytes = len(snapshot)
+        return task
+
+    def _maybe_launch_periodic_inference_locked(self) -> None:
+        """Launch another inference every configured interval of new audio."""
+        if not self._speech_started:
+            return
+        if len(self._audio_buffer) - self._last_requested_num_bytes < (
+            self._inference_interval_bytes
+        ):
+            return
+        self._launch_inference_locked()
+
+    async def _await_latest_inference(self) -> Optional[TurnSenseInferenceResult]:
+        """Wait until the newest scheduled inference result is available."""
+        while True:
+            async with self._state_lock:
+                task = self._latest_inference_task
+                if task is None:
+                    task = self._launch_inference_locked()
+                    if task is None:
+                        return self._latest_result
+                current_task = task
+            try:
+                await current_task
+            except Exception:
+                async with self._state_lock:
+                    if self._latest_inference_task is current_task:
+                        self._latest_inference_task = None
+                raise
+            async with self._state_lock:
+                if self._latest_inference_task is current_task:
+                    self._latest_inference_task = None
+                    return self._latest_result
+
+    def _result_for_pause(
+        self, inference_result: Optional[TurnSenseInferenceResult]
+    ) -> TurnDetectionResult:
+        """Map the newest pause-time inference result to a listening decision."""
+        if inference_result is None:
+            return TurnDetectionResult(
+                action=TurnDetectionAction.DO_NOTHING,
+                semantic=TurnDetectionSemantic.INCOMPLETE,
+            )
+        if inference_result.prediction == TurnDetectionSemantic.COMPLETE.value:
+            self._reset_detection_state()
+            return TurnDetectionResult(
+                action=TurnDetectionAction.START_GENERATION,
+                semantic=TurnDetectionSemantic.COMPLETE,
+            )
+        return TurnDetectionResult(
+            action=TurnDetectionAction.DO_NOTHING,
+            semantic=TurnDetectionSemantic.INCOMPLETE,
+        )
+
+    def _result_for_interrupt(
+        self, inference_result: Optional[TurnSenseInferenceResult]
+    ) -> TurnDetectionResult:
+        """Map the newest streaming inference result to an interruption decision."""
+        if inference_result is None:
+            return _IDLE_RESULT
+        if inference_result.prediction == "invalid":
+            return _IDLE_RESULT
+        if inference_result.prediction == TurnDetectionSemantic.COMPLETE.value:
+            self._pending_complete_after_interrupt = True
+            self._reset_detection_state()
+            return TurnDetectionResult(
+                action=TurnDetectionAction.STOP_SPEAKING,
+                semantic=TurnDetectionSemantic.COMPLETE,
+            )
+        return TurnDetectionResult(
+            action=TurnDetectionAction.STOP_SPEAKING,
+            semantic=TurnDetectionSemantic.INCOMPLETE,
+        )
+
+    async def _infer_audio_bytes(
+        self, audio: bytes, source: Optional[str] = None
+    ) -> TurnSenseInferenceResult:
+        """Send raw PCM audio bytes to the TurnSense HTTP inference endpoint.
+
+        Parameters
+        ----------
+        audio : bytes
+            PCM 16-bit mono 16 kHz audio bytes to post to the TurnSense service.
+        source : str | None, optional
+            Optional source name sent via the ``X-Audio-Source`` header.
+
+        Returns
+        -------
+        TurnSenseInferenceResult
+            Parsed response returned by the TurnSense service.
+        """
+        headers = {
+            "Content-Type": "application/octet-stream",
+            "X-Audio-Source": source or "turn_sense_audio.pcm",
+            "X-Audio-Format": self.AUDIO_FORMAT,
+            "X-Audio-Sample-Rate": str(self.SAMPLE_RATE),
+            "X-Audio-Channels": str(self.AUDIO_CHANNELS),
+        }
+
+        timeout = aiohttp.ClientTimeout(total=self._timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                self._infer_bytes_url,
+                data=audio,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+                payload = await response.json()
+
+        probabilities = payload["probabilities"]
+        return TurnSenseInferenceResult(
+            prediction=payload["prediction"],
+            probabilities=TurnSenseProbabilities(
+                complete=probabilities["complete"],
+                incomplete=probabilities["incomplete"],
+                invalid=probabilities["invalid"],
+            ),
+        )
+
+    def detect(
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        speech_start: bool = False,
+        speech_pause: Optional[bool] = None,
+    ) -> TurnDetectionResult:
+        """Synchronously run turn detection via the async implementation.
+
+        Parameters
+        ----------
+        audio : bytes | None, optional
+            Current PCM 16-bit mono audio frame at 16 kHz.
+        text : str | None, optional
+            ASR text for the current turn.
+        speech_start : bool, optional
+            Whether VAD has just detected the start of speech.
+        speech_pause : bool | None, optional
+            Whether the user appears to have paused speaking.
+
+        Returns
+        -------
+        TurnDetectionResult
+            Synchronous wrapper around ``async_detect``.
+        """
+        return asyncio.run(
+            self.async_detect(
+                audio=audio,
+                text=text,
+                speech_start=speech_start,
+                speech_pause=speech_pause,
+            )
+        )
+
+    async def async_detect(
+        self,
+        audio: Optional[bytes] = None,
+        text: Optional[str] = None,
+        speech_start: bool = False,
+        speech_pause: Optional[bool] = None,
+    ) -> TurnDetectionResult:
+        """Asynchronously detect turn state using the TurnSense HTTP service.
+
+        Parameters
+        ----------
+        audio : bytes | None, optional
+            Current PCM 16-bit mono audio frame at 16 kHz.
+        text : str | None, optional
+            ASR text for the current turn. The current implementation only uses
+            this path as a carrier for ``speech_pause`` events.
+        speech_start : bool, optional
+            Whether VAD has just detected the start of speech.
+        speech_pause : bool | None, optional
+            Whether the user appears to have paused speaking.
+
+        Returns
+        -------
+        TurnDetectionResult
+            Turn-detection decision derived from the latest available TurnSense
+            prediction.
+
+        Notes
+        -----
+        The detector keeps one shared audio buffer for both listening states.
+        When ``listening`` is ``True``, speech starts buffering on
+        ``speech_start=True`` and a new inference is launched every configured
+        interval of newly buffered audio. On ``speech_pause=True``, the
+        detector waits for the newest inference result and starts generation
+        only when that newest result is ``complete``. Otherwise it keeps the
+        buffered audio and returns ``DO_NOTHING`` with ``INCOMPLETE``.
+
+        When ``listening`` is ``False``, the detector still buffers audio from
+        ``speech_start=True`` onward and launches the same periodic inferences.
+        During this state, the newest non-``invalid`` inference result triggers
+        ``STOP_SPEAKING``. If that newest result is ``complete``, the detector
+        stores a one-shot pending completion so that the next call observed in
+        the listening state returns ``START_GENERATION`` with ``COMPLETE``.
+        """
+        del text
+        async with self.listening_lock():
+            listening = self.listening
+
+        async with self._state_lock:
+            if listening and self._pending_complete_after_interrupt:
+                self._pending_complete_after_interrupt = False
+                self._reset_detection_state()
+                return TurnDetectionResult(
+                    action=TurnDetectionAction.START_GENERATION,
+                    semantic=TurnDetectionSemantic.COMPLETE,
+                )
+
+            if speech_start:
+                self._begin_speech()
+
+            if audio is not None and self._speech_started:
+                self._audio_buffer.extend(audio)
+                self._maybe_launch_periodic_inference_locked()
+
+            speech_started = self._speech_started
+            latest_result = self._latest_result
+
+        if listening and speech_pause:
+            if not speech_started:
+                return _IDLE_RESULT
+            return self._result_for_pause(await self._await_latest_inference())
+
+        if not listening and speech_started:
+            return self._result_for_interrupt(latest_result)
+
+        if speech_started:
+            return TurnDetectionResult(
+                action=TurnDetectionAction.DO_NOTHING,
+                semantic=TurnDetectionSemantic.INCOMPLETE,
+            )
+        return _IDLE_RESULT
+
+    def clone(self) -> TurnDetector:
+        """Clone the detector for a new session.
+
+        Returns
+        -------
+        TurnDetector
+            A new ``TurnSense`` instance.
+        """
+        return TurnSense(
+            base_url=self._base_url,
+            timeout=self._timeout,
+            inference_interval_ms=self._inference_interval_ms,
+        )


### PR DESCRIPTION
## Summary
- add a TurnSense-backed turn detector implementation and export it from the turn detector package
- add TurnSense optional dependency and sample server configs for both experimental templates
- reuse the paused ASR recognition result when finalizing a turn to avoid re-entering ASR during pause-to-final handoff
- document TurnSense support and deployment references in the supported models docs

## Testing
- python3 -m py_compile src/xtalk/speech/turn_detector/turn_sense.py
- python3 -m py_compile src/xtalk/serving/modules/asr_manager.py src/xtalk/serving/modules/turn_taking_manager.py
- validate updated JSON config files locally
