### PR TITLE
fix: stabilize backend smoke tests

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1516,9 +1516,11 @@ class CaseRunner:
             else None
         )
         audio_frame_count = int(math.ceil(len(pcm_bytes) / frame_bytes))
-        trailing_frames = (
-            vad_controller.trailing_silence_frames() if vad_controller else 0
-        )
+        if vad_controller is not None:
+            trailing_frames = vad_controller.trailing_silence_frames()
+        else:
+            frame_ms = ClientVADController.FRAME_SAMPLES * 1000.0 / 16000.0
+            trailing_frames = max(1, int(round(self._vad_redemption_ms / frame_ms)) + 1)
         total_frames = audio_frame_count + trailing_frames
         stream_started = asyncio.get_running_loop().time()
         await self._anchors.set("last_user_start", stream_started)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -52,6 +52,8 @@ DEFAULT_TEST_CONFIG = {
     "judge_llm": None,
 }
 DEFAULT_SETTLE_SECONDS = 1.5
+RECORDING_STABLE_SECONDS = 1.0
+RECORDING_STABLE_TIMEOUT_SECONDS = 10.0
 EMBEDDED_SERVER_HOST = "127.0.0.1"
 EMBEDDED_SERVER_PORT = 0
 SERVICE_CONFIG_PATCH = {
@@ -1351,6 +1353,7 @@ class CaseRunner:
             await self._send_scheduled_inputs(websocket, self._scheduled_inputs)
             self._scheduler_done.set()
             await self._wait_until_idle(websocket)
+            await self._wait_for_recording_stable()
         finally:
             await websocket.close()
             if self._receiver_task is not None:
@@ -1615,6 +1618,28 @@ class CaseRunner:
             if self._ws_closed.is_set():
                 return
             await asyncio.sleep(0.1)
+
+    async def _wait_for_recording_stable(self) -> None:
+        """Wait briefly for server-side recording writes to settle."""
+        if not self._temp_recording_path.exists():
+            return
+
+        deadline = time.monotonic() + RECORDING_STABLE_TIMEOUT_SECONDS
+        stable_since = time.monotonic()
+        last_size = self._temp_recording_path.stat().st_size
+
+        while time.monotonic() < deadline:
+            await asyncio.sleep(0.1)
+            try:
+                current_size = self._temp_recording_path.stat().st_size
+            except OSError:
+                return
+            if current_size != last_size:
+                last_size = current_size
+                stable_since = time.monotonic()
+                continue
+            if time.monotonic() - stable_since >= RECORDING_STABLE_SECONDS:
+                return
 
     async def _touch_activity(self) -> None:
         async with self._activity_lock:


### PR DESCRIPTION
## Summary

This PR fixes two issues in the automated backend testing script:

- Adds trailing silence after each generated user clip when backend VAD is used, so the server can emit speech-end events reliably.
- Waits briefly for server-side recording writes to settle before closing the WebSocket, reducing the chance that long TTS responses are truncated in test recordings.

## Root Cause

The test runner previously stopped sending audio immediately after a user clip when client-side VAD was disabled. In backend VAD mode, the server needs enough trailing silence to close the turn. The runner could also close the WebSocket after business-level idle while the recording writer was still catching up.

## Validation

- Ran `python3 -m py_compile scripts/test.py`.
- Generated the smoke dataset with CosyVoice TTS.
- Ran the smoke test with `server_configs/experimental.json`; the WebSocket session reached `tts_finished`, `tts_playback_finished`, and a normal `CLOSE 1000`.
