### PR TITLE
Use WebSocket adapters for SileroVAD and FastEnhancer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,11 +127,13 @@ edge-tts = [
 silero-vad = [
   "numpy",
   "onnxruntime",
+  "websockets",
 ]
 fast-enhancer = [
   "numpy",
   "requests",
   "onnxruntime",
+  "websockets",
 ]
 rubberband = [
   "pyrubberband"

--- a/src/xtalk/models/speech_enhancer/fast_enhancer.py
+++ b/src/xtalk/models/speech_enhancer/fast_enhancer.py
@@ -9,21 +9,68 @@ Implements streaming enhancement based on the FastEnhancer-S ONNX model:
 from __future__ import annotations
 
 import argparse
+import asyncio
+import json
 import os
 import socket
 import sys
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 import numpy as np
-import requests
 
 try:
     import onnxruntime
 except ImportError:  # pragma: no cover - remote mode does not need ONNX Runtime.
     onnxruntime = None  # type: ignore[assignment]
 
+try:
+    import websockets
+except ImportError:  # pragma: no cover - local mode does not need websockets.
+    websockets = None
+
 from .interfaces import SpeechEnhancer
 from ..registry import model
+
+
+_REMOTE_WS_PATH = "/ws/fastenhancer/realtime"
+_REMOTE_TIMEOUT_SECONDS = 10.0
+
+
+def _resolve_remote_enhancer_url(base_url: str) -> tuple[str, str]:
+    """Resolve the remote FastEnhancer base URL and WebSocket URL."""
+    normalized_base_url = base_url.strip().rstrip("/")
+    if not normalized_base_url:
+        raise ValueError("base_url must not be empty")
+
+    parts = urlsplit(normalized_base_url)
+    if parts.scheme in {"http", "https"}:
+        scheme = "ws" if parts.scheme == "http" else "wss"
+    elif parts.scheme in {"ws", "wss"}:
+        scheme = parts.scheme
+    else:
+        raise ValueError("remote FastEnhancer base_url must use http(s) or ws(s)")
+
+    path = parts.path.rstrip("/") or _REMOTE_WS_PATH
+    websocket_url = urlunsplit((scheme, parts.netloc, path, parts.query, ""))
+    return normalized_base_url, websocket_url
+
+
+def _remote_json_payload(message: object) -> dict[str, object]:
+    """Decode one remote FastEnhancer JSON message."""
+    if isinstance(message, bytes):
+        message = message.decode("utf-8")
+    if not isinstance(message, str):
+        raise ValueError(
+            f"remote FastEnhancer returned unsupported message type: {type(message)}"
+        )
+    payload = json.loads(message)
+    if not isinstance(payload, dict):
+        raise ValueError("remote FastEnhancer JSON message must be an object")
+    if payload.get("type") == "error":
+        detail = str(payload.get("message") or payload)
+        raise RuntimeError(f"remote FastEnhancer error: {detail}")
+    return payload
 
 
 @model(aliases=["FastEnhancerS", "speech_enhancer"])
@@ -33,8 +80,7 @@ class FastEnhancer(SpeechEnhancer):
     Notes
     -----
     When ``base_url`` is provided, all other initialization parameters are
-    ignored and audio is enhanced by the FastEnhancer HTTP service at
-    ``POST /v1/enhance/pcm``.
+    ignored and audio is enhanced by a FastEnhancer WebSocket service.
     """
 
     def __init__(
@@ -58,18 +104,28 @@ class FastEnhancer(SpeechEnhancer):
         _shared_session : object | None, optional
             Existing ONNX Runtime session reused by local clones.
         base_url : str | None, optional
-            Base URL of a running FastEnhancer HTTP service. When set,
+            Base URL of a running FastEnhancer WebSocket service. When set,
             ``model_path``, ``n_fft``, ``hop_size``, and ``_shared_session`` are
             ignored and no local ONNX model is loaded.
         """
-        self.base_url = base_url.rstrip("/") if base_url else None
         self.sample_rate = 16000
+        self.n_fft = n_fft
+        self.hop_size = hop_size
+        self.base_url: str | None = None
+        self._remote_enhancer_url: str | None = None
+        self._remote_ws: object | None = None
+        self._remote_loop: asyncio.AbstractEventLoop | None = None
+        self._remote_lock: asyncio.Lock | None = None
+        if base_url is not None:
+            self.base_url, self._remote_enhancer_url = _resolve_remote_enhancer_url(
+                base_url
+            )
+        else:
+            self.base_url = None
         if self.base_url is not None:
             self.model_path = None
             return
 
-        self.n_fft = n_fft
-        self.hop_size = hop_size
         self.model_path = model_path
 
         # Reuse shared session if provided
@@ -152,6 +208,7 @@ class FastEnhancer(SpeechEnhancer):
     def reset(self) -> None:
         """Reset enhancer state."""
         if self.base_url is not None:
+            self._schedule_remote_close()
             return
 
         self._init_cache()
@@ -196,7 +253,7 @@ class FastEnhancer(SpeechEnhancer):
         if not pcm_bytes:
             return b""
         if self.base_url is not None:
-            return self._enhance_remote(pcm_bytes)
+            return self._enhance_remote_sync(pcm_bytes)
 
         # Convert to float32 [-1, 1]
         pcm_int16 = np.frombuffer(pcm_bytes, dtype=np.int16)
@@ -308,19 +365,180 @@ class FastEnhancer(SpeechEnhancer):
         output_int16 = (output_samples * 32768.0).astype(np.int16)
         return output_int16.tobytes()
 
-    def _enhance_remote(self, pcm_bytes: bytes) -> bytes:
-        """Enhance one PCM payload by calling the FastEnhancer HTTP service."""
-        response = requests.post(
-            f"{self.base_url}/v1/enhance/pcm",
-            params={"input_dtype": "int16", "response_format": "pcm"},
-            data=pcm_bytes,
-            headers={"Content-Type": "application/octet-stream"},
-            timeout=30,
+    async def async_enhance(self, audio: bytes) -> bytes:
+        """Asynchronously enhance audio."""
+        if self.base_url is not None:
+            return await self._enhance_remote_async(audio)
+        return await SpeechEnhancer.async_enhance(self, audio)
+
+    async def async_flush(self) -> bytes:
+        """Asynchronously flush buffered remote or local audio."""
+        if self.base_url is not None:
+            return await self._flush_remote()
+        return await SpeechEnhancer.async_flush(self)
+
+    def _enhance_remote_sync(self, pcm_bytes: bytes) -> bytes:
+        """Synchronously enhance PCM through a short-lived WebSocket."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._enhance_remote_once(pcm_bytes))
+        raise RuntimeError(
+            "remote FastEnhancer.enhance() cannot run inside an active event loop; "
+            "use async_enhance() instead"
         )
-        response.raise_for_status()
-        return response.content
 
+    async def _enhance_remote_once(self, pcm_bytes: bytes) -> bytes:
+        """Run one synchronous compatibility request with a temporary connection."""
+        try:
+            return await self._enhance_remote_async(pcm_bytes)
+        finally:
+            await self._close_remote_connection()
 
+    async def _enhance_remote_async(self, pcm_bytes: bytes) -> bytes:
+        """Enhance one PCM frame through the remote FastEnhancer WebSocket."""
+        if self._remote_enhancer_url is None:
+            raise RuntimeError("remote FastEnhancer URL is not configured")
+        if not pcm_bytes:
+            return b""
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote FastEnhancer inference; "
+                "install xtalk[fast-enhancer]"
+            )
+
+        lock = self._get_remote_lock()
+        async with lock:
+            for attempt in range(2):
+                try:
+                    websocket = await self._ensure_remote_connection()
+                    await websocket.send(pcm_bytes)
+                    while True:
+                        message = await asyncio.wait_for(
+                            websocket.recv(),
+                            timeout=_REMOTE_TIMEOUT_SECONDS,
+                        )
+                        if isinstance(message, bytes):
+                            return message
+                        payload = _remote_json_payload(message)
+                        if payload.get("type") == "audio":
+                            audio = payload.get("audio")
+                            if isinstance(audio, str):
+                                import base64
+
+                                return base64.b64decode(audio)
+                            raise ValueError(
+                                "remote FastEnhancer audio message missing base64 audio"
+                            )
+                except Exception:
+                    await self._close_remote_connection()
+                    if attempt == 0:
+                        continue
+                    raise
+            return b""
+
+    async def _flush_remote(self) -> bytes:
+        """Send a best-effort remote flush command and return tail audio."""
+        lock = self._get_remote_lock()
+        async with lock:
+            if self._remote_enhancer_url is None or self._remote_ws is None:
+                return b""
+            chunks: list[bytes] = []
+            try:
+                websocket = await self._ensure_remote_connection()
+                await websocket.send(json.dumps({"type": "flush"}))
+                while True:
+                    message = await asyncio.wait_for(
+                        websocket.recv(),
+                        timeout=_REMOTE_TIMEOUT_SECONDS,
+                    )
+                    if isinstance(message, bytes):
+                        chunks.append(message)
+                        continue
+                    payload = _remote_json_payload(message)
+                    if payload.get("type") == "flush_ack":
+                        return b"".join(chunks)
+            except Exception:
+                await self._close_remote_connection()
+                raise
+
+    def _get_remote_lock(self) -> asyncio.Lock:
+        """Return the remote WebSocket lock for the current event loop."""
+        loop = asyncio.get_running_loop()
+        if self._remote_lock is None or self._remote_loop is not loop:
+            self._remote_loop = loop
+            self._remote_lock = asyncio.Lock()
+            self._remote_ws = None
+        return self._remote_lock
+
+    async def _ensure_remote_connection(self) -> object:
+        """Open and initialize the remote FastEnhancer WebSocket when needed."""
+        if self._remote_enhancer_url is None:
+            raise RuntimeError("remote FastEnhancer URL is not configured")
+        if self._remote_ws is not None:
+            return self._remote_ws
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote FastEnhancer inference; "
+                "install xtalk[fast-enhancer]"
+            )
+
+        try:
+            websocket = await websockets.connect(
+                self._remote_enhancer_url,
+                open_timeout=_REMOTE_TIMEOUT_SECONDS,
+                close_timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            self._remote_ws = websocket
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "start",
+                        "sample_rate": self.sample_rate,
+                        "frame_samples": self.hop_size,
+                        "encoding": "pcm_s16le",
+                        "channels": 1,
+                    }
+                )
+            )
+            message = await asyncio.wait_for(
+                websocket.recv(),
+                timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            payload = _remote_json_payload(message)
+            if payload.get("type") != "start_ack":
+                raise ValueError(
+                    "remote FastEnhancer expected start_ack, "
+                    f"got {payload.get('type')!r}"
+                )
+            return websocket
+        except Exception:
+            await self._close_remote_connection()
+            raise
+
+    async def _close_remote_connection(self) -> None:
+        """Close the active remote FastEnhancer WebSocket connection."""
+        websocket = self._remote_ws
+        self._remote_ws = None
+        if websocket is not None:
+            await websocket.close()
+
+    def _schedule_remote_close(self) -> None:
+        """Best-effort close for the active remote FastEnhancer connection."""
+        websocket = self._remote_ws
+        self._remote_ws = None
+        if websocket is None:
+            return
+        loop = self._remote_loop
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is not None and running_loop is loop:
+            running_loop.create_task(websocket.close())
+            return
+        if loop is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(loop.create_task, websocket.close())
 
 def _is_tcp_port_open(host: str, port: int, timeout: float) -> bool:
     """Return whether a TCP listener accepts connections at host:port."""
@@ -342,7 +560,7 @@ def _build_test_pcm(sample_rate: int, duration_seconds: float) -> bytes:
 def _run_remote_smoke_test() -> int:
     """Run a simple client request against a running FastEnhancer service."""
     parser = argparse.ArgumentParser(
-        description="Smoke test the FastEnhancer HTTP client."
+        description="Smoke test the FastEnhancer WebSocket client."
     )
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
@@ -357,12 +575,12 @@ def _run_remote_smoke_test() -> int:
         )
         return 2
 
-    base_url = f"http://{args.host}:{args.port}"
+    base_url = f"ws://{args.host}:{args.port}{_REMOTE_WS_PATH}"
     enhancer = FastEnhancer(base_url=base_url)
     pcm_bytes = _build_test_pcm(enhancer.sample_rate, args.duration_seconds)
     try:
         enhanced_bytes = enhancer.enhance(pcm_bytes)
-    except requests.RequestException as exc:
+    except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
         print(
             f"FastEnhancer client request failed for {base_url}: {exc}",
             file=sys.stderr,

--- a/src/xtalk/models/speech_enhancer/fast_enhancer.py
+++ b/src/xtalk/models/speech_enhancer/fast_enhancer.py
@@ -35,6 +35,7 @@ from ..registry import model
 
 _REMOTE_WS_PATH = "/ws/fastenhancer/realtime"
 _REMOTE_TIMEOUT_SECONDS = 10.0
+_REMOTE_FRAME_SAMPLES = 512
 
 
 def _resolve_remote_enhancer_url(base_url: str) -> tuple[str, str]:
@@ -113,6 +114,8 @@ class FastEnhancer(SpeechEnhancer):
         self.hop_size = hop_size
         self.base_url: str | None = None
         self._remote_enhancer_url: str | None = None
+        self._remote_frame_samples = _REMOTE_FRAME_SAMPLES
+        self._remote_pending_audio = bytearray()
         self._remote_ws: object | None = None
         self._remote_loop: asyncio.AbstractEventLoop | None = None
         self._remote_lock: asyncio.Lock | None = None
@@ -208,6 +211,7 @@ class FastEnhancer(SpeechEnhancer):
     def reset(self) -> None:
         """Reset enhancer state."""
         if self.base_url is not None:
+            self._remote_pending_audio.clear()
             self._schedule_remote_close()
             return
 
@@ -320,7 +324,7 @@ class FastEnhancer(SpeechEnhancer):
             Remaining enhanced PCM audio bytes.
         """
         if self.base_url is not None:
-            return b""
+            return self._flush_remote_sync()
 
         # Pad silence to process leftover input (similar to official pad-right)
         padding_needed = self.n_fft
@@ -396,7 +400,7 @@ class FastEnhancer(SpeechEnhancer):
             await self._close_remote_connection()
 
     async def _enhance_remote_async(self, pcm_bytes: bytes) -> bytes:
-        """Enhance one PCM frame through the remote FastEnhancer WebSocket."""
+        """Enhance PCM through the remote FastEnhancer WebSocket."""
         if self._remote_enhancer_url is None:
             raise RuntimeError("remote FastEnhancer URL is not configured")
         if not pcm_bytes:
@@ -409,43 +413,44 @@ class FastEnhancer(SpeechEnhancer):
 
         lock = self._get_remote_lock()
         async with lock:
-            for attempt in range(2):
-                try:
-                    websocket = await self._ensure_remote_connection()
-                    await websocket.send(pcm_bytes)
-                    while True:
-                        message = await asyncio.wait_for(
-                            websocket.recv(),
-                            timeout=_REMOTE_TIMEOUT_SECONDS,
-                        )
-                        if isinstance(message, bytes):
-                            return message
-                        payload = _remote_json_payload(message)
-                        if payload.get("type") == "audio":
-                            audio = payload.get("audio")
-                            if isinstance(audio, str):
-                                import base64
+            self._remote_pending_audio.extend(pcm_bytes)
+            frame_bytes = self._remote_frame_samples * 2
+            chunks: list[bytes] = []
+            while len(self._remote_pending_audio) >= frame_bytes:
+                frame = bytes(self._remote_pending_audio[:frame_bytes])
+                output = await self._send_remote_frame_with_retry(frame)
+                del self._remote_pending_audio[:frame_bytes]
+                chunks.append(output)
+            return b"".join(chunks)
 
-                                return base64.b64decode(audio)
-                            raise ValueError(
-                                "remote FastEnhancer audio message missing base64 audio"
-                            )
-                except Exception:
-                    await self._close_remote_connection()
-                    if attempt == 0:
-                        continue
-                    raise
-            return b""
+    def _flush_remote_sync(self) -> bytes:
+        """Synchronously flush remote audio."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._flush_remote())
+        raise RuntimeError(
+            "remote FastEnhancer.flush() cannot run inside an active event loop; "
+            "use async_flush() instead"
+        )
 
     async def _flush_remote(self) -> bytes:
         """Send a best-effort remote flush command and return tail audio."""
         lock = self._get_remote_lock()
         async with lock:
-            if self._remote_enhancer_url is None or self._remote_ws is None:
+            if self._remote_enhancer_url is None:
                 return b""
             chunks: list[bytes] = []
             try:
                 websocket = await self._ensure_remote_connection()
+                if self._remote_pending_audio:
+                    pending_len = len(self._remote_pending_audio)
+                    frame_bytes = self._remote_frame_samples * 2
+                    padding_len = frame_bytes - pending_len
+                    frame = bytes(self._remote_pending_audio) + bytes(padding_len)
+                    output = await self._send_remote_frame(websocket, frame)
+                    chunks.append(output[:pending_len])
+                    self._remote_pending_audio.clear()
                 await websocket.send(json.dumps({"type": "flush"}))
                 while True:
                     message = await asyncio.wait_for(
@@ -461,6 +466,40 @@ class FastEnhancer(SpeechEnhancer):
             except Exception:
                 await self._close_remote_connection()
                 raise
+
+    async def _send_remote_frame_with_retry(self, pcm_bytes: bytes) -> bytes:
+        """Send one complete remote frame and retry once after reconnecting."""
+        for attempt in range(2):
+            try:
+                websocket = await self._ensure_remote_connection()
+                return await self._send_remote_frame(websocket, pcm_bytes)
+            except Exception:
+                await self._close_remote_connection()
+                if attempt == 0:
+                    continue
+                raise
+        return b""
+
+    async def _send_remote_frame(self, websocket: object, pcm_bytes: bytes) -> bytes:
+        """Send one complete remote frame and return enhanced PCM bytes."""
+        await websocket.send(pcm_bytes)
+        while True:
+            message = await asyncio.wait_for(
+                websocket.recv(),
+                timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            if isinstance(message, bytes):
+                return message
+            payload = _remote_json_payload(message)
+            if payload.get("type") == "audio":
+                audio = payload.get("audio")
+                if isinstance(audio, str):
+                    import base64
+
+                    return base64.b64decode(audio)
+                raise ValueError(
+                    "remote FastEnhancer audio message missing base64 audio"
+                )
 
     def _get_remote_lock(self) -> asyncio.Lock:
         """Return the remote WebSocket lock for the current event loop."""
@@ -495,7 +534,7 @@ class FastEnhancer(SpeechEnhancer):
                     {
                         "type": "start",
                         "sample_rate": self.sample_rate,
-                        "frame_samples": self.hop_size,
+                        "frame_samples": self._remote_frame_samples,
                         "encoding": "pcm_s16le",
                         "channels": 1,
                     }

--- a/src/xtalk/models/vad/silero_vad.py
+++ b/src/xtalk/models/vad/silero_vad.py
@@ -9,6 +9,7 @@ state into each other.
 from __future__ import annotations
 
 import argparse
+import asyncio
 from dataclasses import dataclass, field
 import json
 import os
@@ -18,8 +19,8 @@ import sys
 import tempfile
 import threading
 from typing import Any
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import urlopen
 
 import numpy as np
 
@@ -27,6 +28,11 @@ try:
     import onnxruntime as ort
 except ImportError:
     ort = None
+
+try:
+    import websockets
+except ImportError:
+    websockets = None
 
 from .interfaces import VAD
 from ..registry import model
@@ -43,17 +49,7 @@ SILERO_VAD_ONNX_URL = (
 _CACHE_SUBDIR = "xtalk/models"
 _CACHE_FILENAME = "silero_vad.onnx"
 _REMOTE_TIMEOUT_SECONDS = 10.0
-_REMOTE_VAD_QUERY = urlencode(
-    {
-        "sample_rate": SAMPLE_RATE,
-        "encoding": "pcm_s16le",
-        "channels": 1,
-        "min_speech_duration_ms": 0,
-        "min_silence_duration_ms": 0,
-        "speech_pad_ms": 0,
-        "return_seconds": "true",
-    }
-)
+_REMOTE_WS_PATH = "/ws/vad"
 
 _MODEL_FILE_LOCK = threading.Lock()
 _SESSION_LOCK = threading.Lock()
@@ -154,23 +150,50 @@ def _get_shared_session(model_path: str | None) -> tuple[ort.InferenceSession, s
 
 
 def _resolve_remote_vad_url(base_url: str) -> tuple[str, str]:
-    """Resolve the remote Silero VAD base URL and inference URL."""
+    """Resolve the remote Silero VAD base URL and WebSocket URL."""
     normalized_base_url = base_url.strip().rstrip("/")
     if not normalized_base_url:
         raise ValueError("base_url must not be empty")
-    if normalized_base_url.endswith("/v1/vad"):
-        endpoint_url = normalized_base_url
+
+    parts = urlsplit(normalized_base_url)
+    if parts.scheme in {"http", "https"}:
+        scheme = "ws" if parts.scheme == "http" else "wss"
+    elif parts.scheme in {"ws", "wss"}:
+        scheme = parts.scheme
     else:
-        endpoint_url = f"{normalized_base_url}/v1/vad"
-    return normalized_base_url, f"{endpoint_url}?{_REMOTE_VAD_QUERY}"
+        raise ValueError("remote Silero VAD base_url must use http(s) or ws(s)")
+
+    path = parts.path.rstrip("/") or _REMOTE_WS_PATH
+    websocket_url = urlunsplit((scheme, parts.netloc, path, parts.query, ""))
+    return normalized_base_url, websocket_url
 
 
-def _remote_response_has_speech(payload: dict[str, Any]) -> bool:
-    """Return whether a remote Silero VAD response contains speech segments."""
-    segments = payload["segments"]
-    if not isinstance(segments, list):
-        raise ValueError("remote VAD response field 'segments' must be a list")
-    return bool(segments)
+def _remote_json_payload(message: Any) -> dict[str, Any]:
+    """Decode one remote VAD JSON message."""
+    if isinstance(message, bytes):
+        message = message.decode("utf-8")
+    if not isinstance(message, str):
+        raise ValueError(f"remote VAD returned unsupported message type: {type(message)}")
+    payload = json.loads(message)
+    if not isinstance(payload, dict):
+        raise ValueError("remote VAD JSON message must be an object")
+    message_type = payload.get("type")
+    if message_type == "error":
+        detail = str(payload.get("message") or payload)
+        raise RuntimeError(f"remote VAD error: {detail}")
+    return payload
+
+
+def _remote_frame_has_speech(payload: dict[str, Any], threshold: float) -> bool:
+    """Return the boolean speech decision from one remote VAD frame payload."""
+    if payload.get("type") != "frame":
+        raise ValueError(f"remote VAD expected frame message, got {payload.get('type')!r}")
+    if "is_speech" in payload:
+        return bool(payload["is_speech"])
+    speech_prob = payload.get("speech_prob")
+    if isinstance(speech_prob, (int, float)):
+        return float(speech_prob) >= threshold
+    raise ValueError("remote VAD frame missing 'is_speech' or numeric 'speech_prob'")
 
 
 @dataclass
@@ -211,9 +234,9 @@ class SileroVAD(VAD):
         Parameters
         ----------
         base_url : str | None, optional
-            Optional base URL of an external Silero VAD HTTP service. When set,
-            this instance sends frames to ``/v1/vad`` and ignores all local
-            inference parameters.
+            Optional base URL of an external Silero VAD WebSocket service. When
+            set, this instance sends PCM frames over a persistent WebSocket and
+            ignores local inference parameters.
         threshold : float, optional
             Speech probability threshold used to convert the model output into a
             boolean decision.
@@ -227,15 +250,18 @@ class SileroVAD(VAD):
             Number of trailing samples from the previous frame to prepend as
             model context on the next inference call.
         """
+        self.threshold = float(threshold)
+        self.frame_samples = int(frame_samples)
+        self.context_samples = int(context_samples)
         self.base_url: str | None = None
         self._remote_vad_url: str | None = None
+        self._remote_ws: Any | None = None
+        self._remote_loop: asyncio.AbstractEventLoop | None = None
+        self._remote_lock: asyncio.Lock | None = None
         if base_url is not None:
             self.base_url, self._remote_vad_url = _resolve_remote_vad_url(base_url)
             return
 
-        self.threshold = float(threshold)
-        self.frame_samples = int(frame_samples)
-        self.context_samples = int(context_samples)
         self.session, self.model_path = _get_shared_session(model_path)
         self._inference_lock = threading.Lock()
         self._state = _SileroStreamState()
@@ -247,7 +273,11 @@ class SileroVAD(VAD):
     def clone(self) -> "SileroVAD":
         """Clone the VAD while reusing the shared ONNX session."""
         if self.base_url is not None:
-            return SileroVAD(base_url=self.base_url)
+            return SileroVAD(
+                threshold=self.threshold,
+                frame_samples=self.frame_samples,
+                base_url=self.base_url,
+            )
 
         return SileroVAD(
             threshold=self.threshold,
@@ -259,6 +289,7 @@ class SileroVAD(VAD):
     def reset(self) -> None:
         """Reset this instance's streaming state."""
         if self.base_url is not None:
+            self._schedule_remote_close()
             return
 
         self._state.reset()
@@ -289,7 +320,7 @@ class SileroVAD(VAD):
             return False
 
         if self.base_url is not None:
-            return self._is_speech_remote(frame)
+            return self._is_speech_remote_sync(frame)
 
         audio = np.frombuffer(frame, dtype=np.int16).astype(np.float32) / 32768.0
         if audio.size == 0:
@@ -306,6 +337,12 @@ class SileroVAD(VAD):
         if last_prob is None:
             return False
         return last_prob >= self.threshold
+
+    async def async_is_speech(self, frame: bytes) -> bool:
+        """Asynchronously determine whether the latest frame contains speech."""
+        if self.base_url is not None:
+            return await self._is_speech_remote_async(frame)
+        return await VAD.async_is_speech(self, frame)
 
     def _infer_one_frame(self, frame: np.ndarray) -> float:
         """Run ONNX inference for one complete frame."""
@@ -330,22 +367,134 @@ class SileroVAD(VAD):
         )
         return float(np.asarray(out).squeeze())
 
-    def _is_speech_remote(self, frame: bytes) -> bool:
-        """Send a PCM frame to the remote Silero VAD service."""
+    def _is_speech_remote_sync(self, frame: bytes) -> bool:
+        """Synchronously send a PCM frame through a short-lived WebSocket."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._is_speech_remote_once(frame))
+        raise RuntimeError(
+            "remote SileroVAD.is_speech() cannot run inside an active event loop; "
+            "use async_is_speech() instead"
+        )
+
+    async def _is_speech_remote_once(self, frame: bytes) -> bool:
+        """Run one synchronous compatibility request with a temporary connection."""
+        try:
+            return await self._is_speech_remote_async(frame)
+        finally:
+            await self._close_remote_connection()
+
+    async def _is_speech_remote_async(self, frame: bytes) -> bool:
+        """Send a PCM frame to the remote Silero VAD WebSocket service."""
         if self._remote_vad_url is None:
             raise RuntimeError("remote VAD URL is not configured")
+        if not frame:
+            return False
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote Silero VAD inference; "
+                "install xtalk[silero-vad]"
+            )
 
-        request = Request(
-            self._remote_vad_url,
-            data=frame,
-            headers={"Content-Type": "application/octet-stream"},
-            method="POST",
-        )
-        with urlopen(request, timeout=_REMOTE_TIMEOUT_SECONDS) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-        return _remote_response_has_speech(payload)
+        lock = self._get_remote_lock()
+        async with lock:
+            for attempt in range(2):
+                try:
+                    websocket = await self._ensure_remote_connection()
+                    await websocket.send(frame)
+                    while True:
+                        message = await asyncio.wait_for(
+                            websocket.recv(),
+                            timeout=_REMOTE_TIMEOUT_SECONDS,
+                        )
+                        payload = _remote_json_payload(message)
+                        if payload.get("type") == "frame":
+                            return _remote_frame_has_speech(payload, self.threshold)
+                except Exception:
+                    await self._close_remote_connection()
+                    if attempt == 0:
+                        continue
+                    raise
+            return False
 
+    def _get_remote_lock(self) -> asyncio.Lock:
+        """Return the remote WebSocket lock for the current event loop."""
+        loop = asyncio.get_running_loop()
+        if self._remote_lock is None or self._remote_loop is not loop:
+            self._remote_loop = loop
+            self._remote_lock = asyncio.Lock()
+            self._remote_ws = None
+        return self._remote_lock
 
+    async def _ensure_remote_connection(self) -> Any:
+        """Open and initialize the remote VAD WebSocket when needed."""
+        if self._remote_vad_url is None:
+            raise RuntimeError("remote VAD URL is not configured")
+        if self._remote_ws is not None:
+            return self._remote_ws
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote Silero VAD inference; "
+                "install xtalk[silero-vad]"
+            )
+
+        try:
+            websocket = await websockets.connect(
+                self._remote_vad_url,
+                open_timeout=_REMOTE_TIMEOUT_SECONDS,
+                close_timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            self._remote_ws = websocket
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "start",
+                        "sample_rate": SAMPLE_RATE,
+                        "frame_samples": self.frame_samples,
+                        "encoding": "pcm_s16le",
+                        "channels": 1,
+                        "positive_speech_threshold": self.threshold,
+                    }
+                )
+            )
+            message = await asyncio.wait_for(
+                websocket.recv(),
+                timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            payload = _remote_json_payload(message)
+            if payload.get("type") != "start_ack":
+                raise ValueError(
+                    f"remote VAD expected start_ack, got {payload.get('type')!r}"
+                )
+            return websocket
+        except Exception:
+            await self._close_remote_connection()
+            raise
+
+    async def _close_remote_connection(self) -> None:
+        """Close the active remote VAD WebSocket connection."""
+        websocket = self._remote_ws
+        self._remote_ws = None
+        if websocket is not None:
+            await websocket.close()
+
+    def _schedule_remote_close(self) -> None:
+        """Best-effort close for the active remote VAD connection."""
+        websocket = self._remote_ws
+        self._remote_ws = None
+        if websocket is None:
+            return
+        loop = self._remote_loop
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is not None and running_loop is loop:
+            running_loop.create_task(websocket.close())
+            return
+        if loop is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(loop.create_task, websocket.close())
 
 def _is_tcp_port_open(host: str, port: int, timeout: float) -> bool:
     """Return whether a TCP listener accepts connections at host:port."""
@@ -366,7 +515,9 @@ def _build_test_pcm(sample_rate: int, duration_seconds: float) -> bytes:
 
 def _run_remote_smoke_test() -> int:
     """Run a simple client request against a running Silero VAD service."""
-    parser = argparse.ArgumentParser(description="Smoke test the Silero VAD HTTP client.")
+    parser = argparse.ArgumentParser(
+        description="Smoke test the Silero VAD WebSocket client."
+    )
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8001)
     parser.add_argument("--duration-seconds", type=float, default=0.5)
@@ -380,12 +531,12 @@ def _run_remote_smoke_test() -> int:
         )
         return 2
 
-    base_url = f"http://{args.host}:{args.port}"
+    base_url = f"ws://{args.host}:{args.port}{_REMOTE_WS_PATH}"
     vad = SileroVAD(base_url=base_url)
     pcm_bytes = _build_test_pcm(SAMPLE_RATE, args.duration_seconds)
     try:
         is_speech = vad.is_speech(pcm_bytes)
-    except (OSError, TimeoutError, ValueError) as exc:
+    except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
         print(f"Silero VAD client request failed for {base_url}: {exc}", file=sys.stderr)
         return 1
 
@@ -398,4 +549,3 @@ def _run_remote_smoke_test() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(_run_remote_smoke_test())
-


### PR DESCRIPTION

## Summary

This PR updates the remote audio model adapters for SileroVAD and FastEnhancer to use persistent WebSocket streams instead of per-request HTTP calls.

- Add WebSocket remote mode for `SileroVAD`, including URL normalization, start handshake, per-frame binary PCM sends, JSON frame responses, and connection reset handling.
- Add WebSocket remote mode for `FastEnhancer`, including persistent streaming, binary audio responses, remote flush support, and service-compatible 512-sample frame packing.
- Buffer partial FastEnhancer input frames client-side and drain the tail during `flush()` so callers can send arbitrary chunk sizes while the service receives exact 1024-byte frames.
- Add `websockets` to the `silero-vad` and `fast-enhancer` optional dependencies.

## Validation

- `python3 -m py_compile src/xtalk/models/vad/silero_vad.py src/xtalk/models/speech_enhancer/fast_enhancer.py`
- Tested `SileroVAD` against the remote VAD service with `/private/tmp/sample-audio-zh-short-speaker2.mp3`; the adapter connected successfully and returned a single speech run over the expected audio segment.
- Tested `FastEnhancer` against the remote enhancer service with the same sample audio; the adapter connected successfully, accepted uneven caller chunk sizes, flushed the tail frame, and produced output length matching the input length.

## Notes

The current remote services were functional in smoke tests, but their observed throughput was slower than real time in this test environment.
