### PR TITLE
fix: use modern Starlette TemplateResponse signature in sample app

### DIFF
--- a/examples/sample_app/configurable_server.py
+++ b/examples/sample_app/configurable_server.py
@@ -53,7 +53,11 @@ async def get_reference_audios():
 
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    # Use the modern Starlette TemplateResponse(request, name, context) signature.
+    # The old "TemplateResponse(name, context)" form puts ``request`` into the
+    # context dict, and jinja2 tries to hash the cache key as ``(name, context)``
+    # which fails because ``request`` is an unhashable mapping. See issue #62.
+    return templates.TemplateResponse(request, "index.html", {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #62.

## What was wrong

The sample dev server's root handler was calling the deprecated Starlette API:

```python
return templates.TemplateResponse("index.html", {"request": request})
```

This puts `request` inside the context dict that jinja2's `LRUCache` then uses as part of the cache key. Because `request` is an unhashable `starlette.requests.Request` (which inherits from `Mapping`), jinja2 crashes with `TypeError: unhashable type: 'dict'` on every `GET /`, so the sample app's landing page is always a 500.

The same pattern is also on the modern-Starlette deprecation list — the new signature is `TemplateResponse(request, name, context)`, and the old form has been emitting `StarletteDeprecationWarning` since 0.27.

## Fix

Switch to the modern signature so `request` is excluded from the cache key:

```python
return templates.TemplateResponse(request, "index.html", {})
```

The `index.html` template does not reference `request`, so an empty context is fine.

## Tested

Wrote an isolated repro that mounts a `Jinja2Templates` directory and `GET /`s a FastAPI app with the example handler, using both signatures:

- **Old API** (unpatched): `GET /` returns **500** with `TypeError: unhashable type: 'dict'`.
- **New API** (patched): `GET /` returns **200** with the rendered template body.

```bash
=== Test 1: Old API (BUGGY) ===
  Got TypeError: unhashable type: 'dict'
  CONFIRMED: Bug reproduces with old API

=== Test 2: New API (FIXED) ===
  Status: 200
  Content: '<!doctype html><html><body>Hello</body></html>'
  PASS: Fix works correctly
```