### PR TITLE
feature: add PyWebRTC speech enhancer far support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+*.env
 .venv
 env/
 venv/

--- a/docs/docs/speech_enhancer_design.md
+++ b/docs/docs/speech_enhancer_design.md
@@ -1,0 +1,140 @@
+# Speech Enhancer Design
+
+```python
+class SpeechEnhancer(ABC):
+    """Abstract base class for speech enhancement engines."""
+
+    @abstractmethod
+    def enhance(self, audio: bytes, far: bytes) -> bytes:
+        ...
+
+    def flush(self) -> bytes:
+        return b""
+
+    async def async_enhance(
+        self,
+        audio: bytes,
+        far: bytes,
+    ) -> bytes:
+        ...
+
+    async def async_flush(self) -> bytes:
+        ...
+
+    @abstractmethod
+    def reset(self) -> None:
+        ...
+
+    @abstractmethod
+    def clone(self) -> "SpeechEnhancer":
+        ...
+```
+
+## Audio Format
+
+`SpeechEnhancer` input and output use:
+
+- PCM 16-bit
+- Mono
+- 16000 Hz
+- Raw PCM bytes without a WAV header
+
+`audio` is the near-end microphone signal. `far` is the far-end reference signal, usually derived from the TTS audio being played to the user, and is used for acoustic echo cancellation.
+
+The upstream audio pipeline always provides `far` and guarantees that:
+
+- `far` uses the same audio format as `audio`
+- `len(far) == len(audio)`
+- both buffers describe the near-end input and far-end reference for the same time window
+
+## `enhance` and `async_enhance`
+
+The service layer primarily calls `async_enhance`. If the underlying implementation only has a synchronous API, implement `enhance` and reuse the base class thread-pool wrapper for `async_enhance`.
+
+If the underlying implementation is asynchronous or remote, prefer implementing `async_enhance` directly and wrapping it for `enhance`.
+
+```python
+import asyncio
+
+def enhance(self, audio: bytes, far: bytes) -> bytes:
+    return self._run_coro(self.async_enhance(audio, far=far))
+
+def _run_coro(self, coro: "asyncio.Future[bytes]") -> bytes:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+```
+
+## Meaning of `far`
+
+`far` is a required interface argument and enables enhancement engines that need a far-end reference, such as acoustic echo cancellation.
+
+- When nothing is being played, the service layer passes a silent `far` buffer with the same length as `audio`.
+- When TTS is being played, the service layer reads a same-length slice from the TTS reference buffer.
+- If the reference buffer is short, the service layer pads silence on the right and still preserves equal length.
+- FastEnhancer accepts the interface argument but ignores `far` in both local and remote modes.
+- A concrete enhancer implementation that targets an echo-cancellation service may use `far`.
+
+Therefore, implementations may assume that `far` has the same byte length as `audio`. The upstream service pipeline owns this invariant, so concrete enhancers do not need to check it again.
+
+## How the Service Layer Builds the Far-End Reference
+
+`EnhancerManager` consumes `AudioFrameReceived` and publishes `EnhancedAudioFrameReceived`. When a `SpeechEnhancer` model is configured, each user audio frame is processed like this:
+
+```python
+far = far_reference.take(len(audio))
+enhanced = await enhancer.async_enhance(audio, far=far)
+```
+
+The far-end reference comes from `TTSChunkReady`. The service layer copies the TTS chunk that is about to be sent to the client, converts it to the speech-enhancer format, and writes it into a reference buffer.
+
+Current conversion rules:
+
+- Treat input TTS chunks as PCM 16-bit mono
+- Resample from `TTSChunkReady.sample_rate` to 16000 Hz
+- Store the converted audio in a bounded FIFO buffer
+- Keep up to 5 seconds by default, configurable with `far_reference_buffer_seconds`
+
+When user audio arrives, the service layer reads a far-end reference buffer with the same byte length as the current `audio`. If no reference is available, it returns same-length silence.
+
+## Role of `TTSChunkPlayed`
+
+`TTSChunkPlayed` means the frontend has confirmed that a TTS chunk finished playback. The current event does not include a `chunk_id`, client playback timestamp, or sample offset, so it cannot provide sample-level alignment.
+
+The service layer uses it to discard already played reference audio that microphone frames did not consume. This prevents stale TTS audio from being used as `far` when the user waits until TTS playback completes before speaking.
+
+More precise alignment should come from future client-side playback reference feedback or timestamped playback events.
+
+## FastEnhancer Behavior
+
+`FastEnhancer` implements the `SpeechEnhancer` interface but does not use `far`.
+This is true for both local ONNX mode and remote FastEnhancer WebSocket mode.
+Remote FastEnhancer continues to use its legacy binary PCM protocol.
+
+`PyWebRTCAudio` is the concrete adapter for the pywebrtc-audio service. Its
+constructor only accepts `base_url`, and it sends the upstream-provided `audio`
+and `far` to the service's `/v1/stream` JSON WebSocket endpoint.
+
+## `flush`
+
+`flush` / `async_flush` drains tail audio buffered inside the enhancer. The service layer inserts a flush barrier after `VADSpeechEnd` so all earlier audio frames are enhanced and dispatched downstream before the flush runs.
+
+For remote FastEnhancer mode, `flush` sends any locally pending padded audio and then uses the remote FastEnhancer flush command.
+
+## `reset` and `clone`
+
+`reset` should clear the current session's streaming state, such as model caches, input/output buffers, remote connections, and pending audio. It should not reload model weights.
+
+`clone` should create an independent runtime instance for a new session. Clones may share weights, configuration, or read-only resources, but must not share streaming buffers, remote connections, pending audio, or session state.
+
+See [Semantics of `clone()` and `reset()` on Model Objects](model_clone_reset.md).
+
+## Implementation Suggestions
+
+- Keep output length aligned with input `audio` whenever possible, so downstream VAD and ASR timelines do not drift.
+- Do not try to infer TTS alignment inside the model interface; length padding and far selection belong to the service layer.
+- If the implementation requires `far`, it may assume the upstream pipeline already matched its length with `audio`.
+- If the implementation does not support `far`, ignore the argument but do not fail on a silent reference.
+- Remote implementations should clear pending audio on `reset` and connection rebuilds.

--- a/docs/docs/speech_enhancer_design.zh.md
+++ b/docs/docs/speech_enhancer_design.zh.md
@@ -1,0 +1,136 @@
+# 语音增强设计
+
+```python
+class SpeechEnhancer(ABC):
+    """语音增强引擎抽象基类。"""
+
+    @abstractmethod
+    def enhance(self, audio: bytes, far: bytes) -> bytes:
+        ...
+
+    def flush(self) -> bytes:
+        return b""
+
+    async def async_enhance(
+        self,
+        audio: bytes,
+        far: bytes,
+    ) -> bytes:
+        ...
+
+    async def async_flush(self) -> bytes:
+        ...
+
+    @abstractmethod
+    def reset(self) -> None:
+        ...
+
+    @abstractmethod
+    def clone(self) -> "SpeechEnhancer":
+        ...
+```
+
+## 音频格式约定
+
+`SpeechEnhancer` 的输入和输出均使用：
+
+- PCM 16-bit
+- 单声道
+- 16000 Hz
+- 裸 PCM 字节流，不包含 WAV 头
+
+`audio` 表示近端麦克风音频。`far` 表示远端参考音频，通常来自系统正在播放给用户的 TTS 音频，用于声学回声消除。
+
+上游音频管线总是提供 `far`，并保证：
+
+- `far` 与 `audio` 使用相同音频格式
+- `len(far) == len(audio)`
+- 二者描述同一段时间窗口内的近端输入与远端参考
+
+## `enhance` 与 `async_enhance`
+
+服务层实际优先调用 `async_enhance`。如果底层实现只有同步 API，可以实现 `enhance`，并复用基类提供的 `async_enhance` 线程池包装。
+
+如果底层实现本身是异步或远程服务，最佳实践是直接实现 `async_enhance`，再用同步包装实现 `enhance`。
+
+```python
+import asyncio
+
+def enhance(self, audio: bytes, far: bytes) -> bytes:
+    return self._run_coro(self.async_enhance(audio, far=far))
+
+def _run_coro(self, coro: "asyncio.Future[bytes]") -> bytes:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+```
+
+## `far` 的语义
+
+`far` 是必传接口参数，用于支持带远端参考的语音增强或回声消除。
+
+- 没有远端播放时，服务层会传入与 `audio` 等长的静音 `far`。
+- 有 TTS 播放时，服务层会从 TTS 参考缓冲中取出与当前 `audio` 等长的片段。
+- 参考缓冲不足时，服务层会在右侧补静音，仍然保证长度一致。
+- FastEnhancer 会接收接口参数，但本地模式和远程模式都会忽略 `far`。
+- 面向回声消除服务的具体 enhancer 实现可以使用 `far`。
+
+因此，语音增强实现可以安全地假设：`far` 与 `audio` 等长。该约束由上游服务管线负责，具体 enhancer 实现不需要重复检查。
+
+## 服务层如何生成远端参考
+
+`EnhancerManager` 消费 `AudioFrameReceived`，并发布 `EnhancedAudioFrameReceived`。当存在 `SpeechEnhancer` 模型时，它会在处理每个用户音频帧时调用：
+
+```python
+far = far_reference.take(len(audio))
+enhanced = await enhancer.async_enhance(audio, far=far)
+```
+
+远端参考来自 `TTSChunkReady` 事件。服务层会把将要发送给客户端的 TTS chunk 复制一份，转换为语音增强接口要求的格式后写入参考缓冲。
+
+当前转换规则为：
+
+- 输入 TTS chunk 视为 PCM 16-bit 单声道
+- 根据 `TTSChunkReady.sample_rate` 重采样到 16000 Hz
+- 写入一个有限长度的 FIFO 缓冲
+- 默认缓冲上限为 5 秒，可通过 `far_reference_buffer_seconds` 配置
+
+当用户音频到达时，服务层从该缓冲取出与当前 `audio` 等长的远端参考。没有可用参考时返回等长静音。
+
+## `TTSChunkPlayed` 的作用
+
+`TTSChunkPlayed` 表示前端确认某个 TTS chunk 已播放完成。当前事件不携带 `chunk_id`、客户端播放时间戳或样本偏移，因此它不能提供样本级对齐。
+
+服务层将其用于清理已经播放但尚未被麦克风帧消耗的旧参考音频，避免用户等 TTS 播完后再说话时仍然拿旧 TTS 作为 `far`。
+
+更精确的对齐应由未来的客户端播放参考回传或带时间戳的播放事件实现。
+
+## FastEnhancer 行为
+
+`FastEnhancer` 实现 `SpeechEnhancer` 接口，但不使用 `far`。本地 ONNX 模式和远程 FastEnhancer WebSocket 模式都是如此。远程 FastEnhancer 仍然使用旧的二进制 PCM 协议。
+
+`PyWebRTCAudio` 是面向 pywebrtc-audio 服务的具体适配器。它的构造参数仅包含 `base_url`，并把上游提供的 `audio` 和 `far` 发送到服务的 `/v1/stream` JSON WebSocket 接口。
+
+## `flush`
+
+`flush` / `async_flush` 用于排出增强器内部缓冲的尾部音频。服务层会在 `VADSpeechEnd` 后插入 flush barrier，确保所有更早的音频帧先完成增强和下游分发。
+
+对远程 FastEnhancer 模式，`flush` 会发送本地 pending audio 的补齐帧，然后使用远程 FastEnhancer 的 flush 命令。
+
+## `reset` 与 `clone`
+
+`reset` 应清空当前会话的流式状态，例如模型 cache、输入输出缓冲、远程连接和 pending audio，但不应重新加载权重。
+
+`clone` 应为新会话创建独立运行时实例。多个克隆可以共享权重、配置或只读资源，但不能共享流式缓冲、远程连接、pending audio 或会话状态。
+
+请参阅[模型对象的 `clone()` 与 `reset()` 语义](model_clone_reset.zh.md)。
+
+## 实现建议
+
+- 输出长度应尽量与输入 `audio` 长度一致，避免下游 VAD/ASR 时间轴漂移。
+- 不要在模型接口层自行猜测 TTS 对齐；长度补齐和 far 选择由服务层负责。
+- 如果实现需要 `far`，可以假设上游管线已经将其长度与 `audio` 对齐。
+- 如果实现不支持 `far`，可以忽略该参数，但不应因为收到静音 `far` 而失败。
+- 远程实现应在 `reset` 和连接重建时清空 pending audio。

--- a/docs/docs/supported_models.md
+++ b/docs/docs/supported_models.md
@@ -117,3 +117,18 @@ Turn detector is used to determine whether the user has finished speaking and de
 [Original Repository](https://github.com/aask1357/fastenhancer)
 
 </details>
+
+<details markdown="1">
+<summary>PyWebRTCAudio</summary>
+
+**Dependency:** `pip install "xtalk[pywebrtc-audio] @ git+https://github.com/xcc-zach/xtalk.git@main"`
+
+**Path:** [`src/xtalk/models/speech_enhancer/pywebrtc_audio.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/models/speech_enhancer/pywebrtc_audio.py)
+
+**Config params:** only `base_url`.
+
+[Quick Start](https://github.com/xcc-zach/xtalk-pywebrtc-audio)
+
+[Original Repository](https://github.com/strands-labs/pywebrtc-audio)
+
+</details>

--- a/docs/docs/supported_models.zh.md
+++ b/docs/docs/supported_models.zh.md
@@ -117,3 +117,18 @@ Turn detector 用于判断用户是否已经说完，并决定系统何时开始
 [原始仓库](https://github.com/aask1357/fastenhancer)
 
 </details>
+
+<details markdown="1">
+<summary>PyWebRTCAudio</summary>
+
+**依赖：** `pip install "xtalk[pywebrtc-audio] @ git+https://github.com/xcc-zach/xtalk.git@main"`
+
+**路径：** [`src/xtalk/models/speech_enhancer/pywebrtc_audio.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/models/speech_enhancer/pywebrtc_audio.py)
+
+**配置参数：** 仅 `base_url`。
+
+[快速开始](https://github.com/xcc-zach/xtalk-pywebrtc-audio)
+
+[原始仓库](https://github.com/strands-labs/pywebrtc-audio)
+
+</details>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,7 @@ plugins:
             'Service Configuration': 服务配置项
             'ASR Design': ASR设计
             'TTS Design': TTS设计
+            'Speech Enhancer Design': 语音增强设计
             'VAD Design': VAD设计
             'Turn Detector Design': Turn Detector设计
             'Model clone() and reset()': 模型对象的clone()与reset()语义
@@ -83,6 +84,7 @@ nav:
       - 'Service Configuration': docs/service_config.md
       - 'ASR Design': docs/asr_design.md
       - 'TTS Design': docs/tts_design.md
+      - 'Speech Enhancer Design': docs/speech_enhancer_design.md
       - 'VAD Design': docs/vad_design.md
       - 'Turn Detector Design': docs/turn_detector_design.md
       - 'Model clone() and reset()': docs/model_clone_reset.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ fast-enhancer = [
   "onnxruntime",
   "websockets",
 ]
+pywebrtc-audio = [
+  "websockets",
+]
 rubberband = [
   "pyrubberband"
 ]

--- a/src/xtalk/models/speech_enhancer/fast_enhancer.py
+++ b/src/xtalk/models/speech_enhancer/fast_enhancer.py
@@ -241,13 +241,15 @@ class FastEnhancer(SpeechEnhancer):
             _shared_session=self.session,  # Shared ONNX session
         )
 
-    def enhance(self, pcm_bytes: bytes) -> bytes:
+    def enhance(self, pcm_bytes: bytes, far: bytes) -> bytes:
         """Enhance audio frames in streaming mode.
 
         Parameters
         ----------
         pcm_bytes : bytes
             PCM 16-bit mono audio bytes at 16 kHz.
+        far : bytes
+            Ignored by FastEnhancer.
 
         Returns
         -------
@@ -369,11 +371,11 @@ class FastEnhancer(SpeechEnhancer):
         output_int16 = (output_samples * 32768.0).astype(np.int16)
         return output_int16.tobytes()
 
-    async def async_enhance(self, audio: bytes) -> bytes:
+    async def async_enhance(self, audio: bytes, far: bytes) -> bytes:
         """Asynchronously enhance audio."""
         if self.base_url is not None:
             return await self._enhance_remote_async(audio)
-        return await SpeechEnhancer.async_enhance(self, audio)
+        return await SpeechEnhancer.async_enhance(self, audio, far)
 
     async def async_flush(self) -> bytes:
         """Asynchronously flush buffered remote or local audio."""
@@ -618,7 +620,7 @@ def _run_remote_smoke_test() -> int:
     enhancer = FastEnhancer(base_url=base_url)
     pcm_bytes = _build_test_pcm(enhancer.sample_rate, args.duration_seconds)
     try:
-        enhanced_bytes = enhancer.enhance(pcm_bytes)
+        enhanced_bytes = enhancer.enhance(pcm_bytes, bytes(len(pcm_bytes)))
     except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
         print(
             f"FastEnhancer client request failed for {base_url}: {exc}",

--- a/src/xtalk/models/speech_enhancer/interfaces.py
+++ b/src/xtalk/models/speech_enhancer/interfaces.py
@@ -14,13 +14,17 @@ class SpeechEnhancer(ABC):
     """
 
     @abstractmethod
-    def enhance(self, audio: bytes) -> bytes:
+    def enhance(self, audio: bytes, far: bytes) -> bytes:
         """Enhance an audio frame.
 
         Parameters
         ----------
         audio : bytes
             PCM 16-bit mono audio bytes at 16 kHz.
+        far : bytes
+            Far-end reference PCM 16-bit mono audio bytes at 16 kHz. The
+            upstream audio pipeline guarantees that it has the same byte length
+            as ``audio``.
 
         Returns
         -------
@@ -39,13 +43,17 @@ class SpeechEnhancer(ABC):
         """
         return b""
 
-    async def async_enhance(self, audio: bytes) -> bytes:
+    async def async_enhance(self, audio: bytes, far: bytes) -> bytes:
         """Asynchronously enhance audio.
 
         Parameters
         ----------
         audio : bytes
             PCM 16-bit mono audio bytes at 16 kHz.
+        far : bytes
+            Far-end reference PCM 16-bit mono audio bytes at 16 kHz. The
+            upstream audio pipeline guarantees that it has the same byte length
+            as ``audio``.
 
         Returns
         -------
@@ -53,7 +61,7 @@ class SpeechEnhancer(ABC):
             Enhanced PCM audio bytes.
         """
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self.enhance, audio)
+        return await loop.run_in_executor(None, self.enhance, audio, far)
 
     async def async_flush(self) -> bytes:
         """Asynchronously flush buffered audio.

--- a/src/xtalk/models/speech_enhancer/pywebrtc_audio.py
+++ b/src/xtalk/models/speech_enhancer/pywebrtc_audio.py
@@ -1,0 +1,286 @@
+"""Remote speech enhancer backed by the pywebrtc-audio service."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from .interfaces import SpeechEnhancer
+from ..registry import model
+
+
+_STREAM_PATH = "/v1/stream"
+_REMOTE_TIMEOUT_SECONDS = 10.0
+_DEFAULT_STREAM_QUERY: dict[str, str] = {
+    "sample_rate": "16000",
+    "num_channels": "1",
+    "echo_cancellation": "true",
+    "noise_suppression": "true",
+    "high_pass_filter": "false",
+    "auto_gain_control": "false",
+    "dtype": "int16",
+}
+
+try:
+    import websockets
+except ImportError:  # pragma: no cover - optional dependency.
+    websockets = None
+
+
+def _resolve_stream_url(base_url: str) -> tuple[str, str]:
+    """Resolve a pywebrtc-audio base URL into a streaming WebSocket URL.
+
+    Parameters
+    ----------
+    base_url : str
+        HTTP(S) or WS(S) base URL of the pywebrtc-audio service. The URL may
+        already include ``/v1/stream`` and query parameters.
+
+    Returns
+    -------
+    tuple[str, str]
+        Normalized base URL and WebSocket stream URL.
+    """
+    normalized_base_url = base_url.strip().rstrip("/")
+    if not normalized_base_url:
+        raise ValueError("base_url must not be empty")
+
+    parts = urlsplit(normalized_base_url)
+    if parts.scheme in {"http", "https"}:
+        scheme = "ws" if parts.scheme == "http" else "wss"
+    elif parts.scheme in {"ws", "wss"}:
+        scheme = parts.scheme
+    else:
+        raise ValueError("pywebrtc-audio base_url must use http(s) or ws(s)")
+
+    path = parts.path.rstrip("/") or _STREAM_PATH
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    for key, value in _DEFAULT_STREAM_QUERY.items():
+        query.setdefault(key, value)
+
+    stream_url = urlunsplit(
+        (
+            scheme,
+            parts.netloc,
+            path,
+            urlencode(query),
+            "",
+        )
+    )
+    return normalized_base_url, stream_url
+
+
+def _json_payload(message: object) -> dict[str, object]:
+    """Decode one pywebrtc-audio WebSocket JSON message."""
+    if isinstance(message, bytes):
+        message = message.decode("utf-8")
+    if not isinstance(message, str):
+        raise ValueError(
+            f"pywebrtc-audio returned unsupported message type: {type(message)}"
+        )
+    payload = json.loads(message)
+    if not isinstance(payload, dict):
+        raise ValueError("pywebrtc-audio JSON message must be an object")
+    if payload.get("type") == "error":
+        detail = str(payload.get("detail") or payload.get("message") or payload)
+        raise RuntimeError(f"pywebrtc-audio error: {detail}")
+    return payload
+
+
+@model(aliases=["PyWebRTCAudio", "pywebrtc_audio"])
+class PyWebRTCAudio(SpeechEnhancer):
+    """Speech enhancer adapter for a remote pywebrtc-audio service."""
+
+    def __init__(self, base_url: str):
+        """Initialize the remote pywebrtc-audio adapter.
+
+        Parameters
+        ----------
+        base_url : str
+            HTTP(S) or WS(S) base URL of the pywebrtc-audio service.
+        """
+        self.base_url, self._stream_url = _resolve_stream_url(base_url)
+        self._ws: object | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._lock: asyncio.Lock | None = None
+
+    def enhance(self, audio: bytes, far: bytes) -> bytes:
+        """Enhance one PCM frame synchronously.
+
+        Parameters
+        ----------
+        audio : bytes
+            PCM 16-bit mono audio bytes at 16 kHz.
+        far : bytes
+            Far-end reference PCM 16-bit mono audio bytes at 16 kHz.
+
+        Returns
+        -------
+        bytes
+            Enhanced PCM 16-bit mono audio bytes at 16 kHz.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._enhance_once(audio, far))
+        raise RuntimeError(
+            "PyWebRTCAudio.enhance() cannot run inside an active event loop; "
+            "use async_enhance() instead"
+        )
+
+    async def async_enhance(self, audio: bytes, far: bytes) -> bytes:
+        """Enhance one PCM frame asynchronously.
+
+        Parameters
+        ----------
+        audio : bytes
+            PCM 16-bit mono audio bytes at 16 kHz.
+        far : bytes
+            Far-end reference PCM 16-bit mono audio bytes at 16 kHz.
+
+        Returns
+        -------
+        bytes
+            Enhanced PCM 16-bit mono audio bytes at 16 kHz.
+        """
+        if not audio:
+            return b""
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote pywebrtc-audio inference"
+            )
+
+        lock = self._get_lock()
+        async with lock:
+            return await self._send_frame_with_retry(audio, far)
+
+    def flush(self) -> bytes:
+        """Return pending enhanced audio.
+
+        Returns
+        -------
+        bytes
+            Empty bytes because pywebrtc-audio emits one result per request.
+        """
+        return b""
+
+    async def async_flush(self) -> bytes:
+        """Return pending enhanced audio asynchronously.
+
+        Returns
+        -------
+        bytes
+            Empty bytes because pywebrtc-audio emits one result per request.
+        """
+        return b""
+
+    def reset(self) -> None:
+        """Reset the remote stream state."""
+        self._schedule_close()
+
+    def clone(self) -> "PyWebRTCAudio":
+        """Clone the enhancer for a new session.
+
+        Returns
+        -------
+        PyWebRTCAudio
+            Clone with an independent WebSocket connection.
+        """
+        return PyWebRTCAudio(base_url=self.base_url)
+
+    async def _enhance_once(self, audio: bytes, far: bytes) -> bytes:
+        """Enhance one synchronous request using a temporary connection."""
+        try:
+            return await self.async_enhance(audio, far)
+        finally:
+            await self._close_connection()
+
+    async def _send_frame(self, websocket: object, audio: bytes, far: bytes) -> bytes:
+        """Send one JSON process frame and return enhanced PCM bytes."""
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "process",
+                    "audio": base64.b64encode(audio).decode("ascii"),
+                    "far": base64.b64encode(far).decode("ascii"),
+                }
+            )
+        )
+        while True:
+            message = await asyncio.wait_for(
+                websocket.recv(),
+                timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            payload = _json_payload(message)
+            if payload.get("type") == "result":
+                result_audio = payload.get("audio")
+                if isinstance(result_audio, str):
+                    return base64.b64decode(result_audio)
+                raise ValueError("pywebrtc-audio result missing base64 audio")
+
+    async def _send_frame_with_retry(self, audio: bytes, far: bytes) -> bytes:
+        """Send one process frame and retry once after reconnecting."""
+        for attempt in range(2):
+            try:
+                websocket = await self._ensure_connection()
+                return await self._send_frame(websocket, audio, far)
+            except Exception:
+                await self._close_connection()
+                if attempt == 0:
+                    continue
+                raise
+        return b""
+
+    def _get_lock(self) -> asyncio.Lock:
+        """Return the WebSocket lock for the current event loop."""
+        loop = asyncio.get_running_loop()
+        if self._lock is None or self._loop is not loop:
+            self._loop = loop
+            self._lock = asyncio.Lock()
+            self._ws = None
+        return self._lock
+
+    async def _ensure_connection(self) -> object:
+        """Open a pywebrtc-audio WebSocket connection when needed."""
+        if self._ws is not None:
+            return self._ws
+        if websockets is None:
+            raise RuntimeError(
+                "websockets is required for remote pywebrtc-audio inference"
+            )
+        try:
+            self._ws = await websockets.connect(
+                self._stream_url,
+                open_timeout=_REMOTE_TIMEOUT_SECONDS,
+                close_timeout=_REMOTE_TIMEOUT_SECONDS,
+            )
+            return self._ws
+        except Exception:
+            await self._close_connection()
+            raise
+
+    async def _close_connection(self) -> None:
+        """Close the active WebSocket connection."""
+        websocket = self._ws
+        self._ws = None
+        if websocket is not None:
+            await websocket.close()
+
+    def _schedule_close(self) -> None:
+        """Schedule a best-effort close for the active WebSocket connection."""
+        websocket = self._ws
+        self._ws = None
+        if websocket is None:
+            return
+        loop = self._loop
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is not None and running_loop is loop:
+            running_loop.create_task(websocket.close())
+            return
+        if loop is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(loop.create_task, websocket.close())

--- a/src/xtalk/serving/modules/enhancer_manager.py
+++ b/src/xtalk/serving/modules/enhancer_manager.py
@@ -23,8 +23,11 @@ Notes:
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from dataclasses import dataclass
 from typing import Optional, Any
+
+import numpy as np
 
 from ...log_utils import logger
 
@@ -33,9 +36,107 @@ from ..interfaces import Manager
 from ..events import (
     AudioFrameReceived,
     EnhancedAudioFrameReceived,
+    TTSChunkPlayed,
+    TTSChunkReady,
+    TTSPlaybackFinished,
+    TTSStarted,
+    TTSStopped,
     VADSpeechEnd,
 )
 from ...models import Models, SpeechEnhancer
+
+
+_ENHANCER_SAMPLE_RATE = 16000
+
+
+class _FarReferenceBuffer:
+    """Far-end PCM reference buffer aligned against microphone frame consumption."""
+
+    def __init__(self, *, sample_rate: int, max_seconds: float) -> None:
+        self.sample_rate = sample_rate
+        self._max_bytes = max(0, int(sample_rate * max_seconds) * 2)
+        self._buffer = bytearray()
+        self._played_chunk_bytes: deque[int] = deque()
+        self._consumed_since_played_ack = 0
+
+    def append(self, pcm: bytes, *, sample_rate: int) -> None:
+        """Append one TTS PCM chunk after converting it to enhancer format."""
+        reference = self._to_reference_pcm(pcm, sample_rate)
+        if not reference:
+            return
+        self._buffer.extend(reference)
+        self._played_chunk_bytes.append(len(reference))
+        self._trim_to_limit()
+
+    def take(self, byte_count: int) -> bytes:
+        """Take an exact-length far reference frame, padding silence if needed."""
+        if byte_count <= 0:
+            return b""
+        available = min(byte_count, len(self._buffer))
+        chunk = bytes(self._buffer[:available])
+        del self._buffer[:available]
+        self._consumed_since_played_ack += available
+        if available < byte_count:
+            chunk += bytes(byte_count - available)
+        return chunk
+
+    def mark_chunk_played(self) -> None:
+        """Discard playback-confirmed reference that microphone frames did not use."""
+        if not self._played_chunk_bytes:
+            return
+        played_bytes = self._played_chunk_bytes.popleft()
+        if self._consumed_since_played_ack >= played_bytes:
+            self._consumed_since_played_ack -= played_bytes
+            return
+        stale_bytes = played_bytes - self._consumed_since_played_ack
+        del self._buffer[: min(stale_bytes, len(self._buffer))]
+        self._consumed_since_played_ack = 0
+
+    def clear(self) -> None:
+        """Clear all buffered far-end reference audio and playback accounting."""
+        self._buffer.clear()
+        self._played_chunk_bytes.clear()
+        self._consumed_since_played_ack = 0
+
+    def _trim_to_limit(self) -> None:
+        """Trim old reference audio when the buffer grows beyond its limit."""
+        if self._max_bytes <= 0:
+            self.clear()
+            return
+        overflow = len(self._buffer) - self._max_bytes
+        if overflow <= 0:
+            return
+        del self._buffer[:overflow]
+        while overflow > 0 and self._played_chunk_bytes:
+            chunk_bytes = self._played_chunk_bytes[0]
+            if overflow < chunk_bytes:
+                self._played_chunk_bytes[0] = chunk_bytes - overflow
+                overflow = 0
+            else:
+                overflow -= self._played_chunk_bytes.popleft()
+        self._consumed_since_played_ack = min(
+            self._consumed_since_played_ack, len(self._buffer)
+        )
+
+    def _to_reference_pcm(self, pcm: bytes, sample_rate: int) -> bytes:
+        """Convert PCM16 mono bytes to 16 kHz PCM16 mono bytes."""
+        even_length = len(pcm) - (len(pcm) % 2)
+        if even_length <= 0 or sample_rate <= 0:
+            return b""
+        pcm = pcm[:even_length]
+        if sample_rate == self.sample_rate:
+            return pcm
+
+        samples = np.frombuffer(pcm, dtype=np.int16)
+        if samples.size == 0:
+            return b""
+        output_size = max(1, round(samples.size * self.sample_rate / sample_rate))
+        if output_size == samples.size:
+            return pcm
+        x_old = np.linspace(0.0, 1.0, num=samples.size, endpoint=False)
+        x_new = np.linspace(0.0, 1.0, num=output_size, endpoint=False)
+        resampled = np.interp(x_new, x_old, samples.astype(np.float32))
+        return np.clip(resampled, -32768, 32767).astype(np.int16).tobytes()
 
 
 @dataclass(slots=True)
@@ -72,6 +173,13 @@ class EnhancerManager(Manager):
         # Only enable when enhancer model is provided
         self.enhancer = models.get(SpeechEnhancer)
         self._last_sample_rate = 16000
+        far_buffer_seconds = float(
+            self.config.get("far_reference_buffer_seconds", 5.0)
+        )
+        self._far_reference = _FarReferenceBuffer(
+            sample_rate=_ENHANCER_SAMPLE_RATE,
+            max_seconds=far_buffer_seconds,
+        )
         # EnhancerManager is also the serialized handoff for raw audio frames so
         # network jitter does not turn into concurrent downstream audio handling.
         self._audio_queue: asyncio.Queue[_QueuedAudioFrame | _QueuedFlush | None] = (
@@ -102,6 +210,43 @@ class EnhancerManager(Manager):
 
         except Exception as e:
             logger.error("[EnhancerManager] handle frame failed: %s", e)
+
+    @Manager.event_handler(TTSChunkReady, priority=60)
+    async def _on_tts_chunk_ready(self, event: TTSChunkReady) -> None:
+        """Queue outbound TTS audio as far-end echo-cancellation reference."""
+        if self.enhancer is None:
+            return
+        try:
+            self._far_reference.append(
+                event.audio_chunk or b"",
+                sample_rate=event.sample_rate or _ENHANCER_SAMPLE_RATE,
+            )
+        except Exception as e:
+            logger.warning("[EnhancerManager] Far reference append failed: %s", e)
+
+    @Manager.event_handler(TTSChunkPlayed, priority=60)
+    async def _on_tts_chunk_played(self, event: TTSChunkPlayed) -> None:
+        """Advance far-reference playback accounting after frontend confirmation."""
+        del event
+        self._far_reference.mark_chunk_played()
+
+    @Manager.event_handler(TTSPlaybackFinished, priority=60)
+    async def _on_tts_playback_finished(self, event: TTSPlaybackFinished) -> None:
+        """Drop stale far reference when the frontend reports playback completion."""
+        del event
+        self._far_reference.clear()
+
+    @Manager.event_handler(TTSStarted, priority=60)
+    async def _on_tts_started(self, event: TTSStarted) -> None:
+        """Start each TTS response with fresh far-reference state."""
+        del event
+        self._far_reference.clear()
+
+    @Manager.event_handler(TTSStopped, priority=60)
+    async def _on_tts_stopped(self, event: TTSStopped) -> None:
+        """Clear far reference when playback is explicitly stopped."""
+        del event
+        self._far_reference.clear()
 
     @Manager.event_handler(VADSpeechEnd, priority=150)
     async def _on_vad_end(self, event: VADSpeechEnd) -> None:
@@ -161,7 +306,11 @@ class EnhancerManager(Manager):
         # to it strictly in order on a single worker.
         if self.enhancer is not None and item.audio_data:
             try:
-                enhanced_data = await self.enhancer.async_enhance(item.audio_data)
+                far_data = self._far_reference.take(len(item.audio_data))
+                enhanced_data = await self.enhancer.async_enhance(
+                    item.audio_data,
+                    far=far_data,
+                )
             except Exception as e:
                 logger.error("[EnhancerManager] Enhancement failed: %s", e)
 


### PR DESCRIPTION
## Summary

- Add required `far: bytes` input to the speech enhancer interface and propagate a same-length far-end reference stream through `EnhancerManager`.
- Add a `PyWebRTCAudio` speech enhancer adapter backed by the pywebrtc-audio WebSocket service, with `base_url` as its only initialization parameter.
- Keep `FastEnhancer` compatible with the new interface while ignoring `far` as intended.
- Document the speech enhancer far-end reference design in English and Chinese, update supported models, and add the optional `pywebrtc-audio` dependency group.
- Update `.gitignore` so `.env`-style files are ignored globally.

## Details

The enhancer manager now builds a far-end reference from TTS output frames, consumes it alongside microphone audio, pads with silence when no TTS reference is available, and uses `TTSChunkPlayed` acknowledgements to drop stale reference audio. The concrete enhancer implementation can rely on upstream code to provide `audio` and `far` with matching byte lengths.

`PyWebRTCAudio` connects to `/v1/stream`, sends `audio` and `far` as base64 JSON payloads, and decodes enhanced PCM from result messages. The adapter supports both sync and async enhancer entry points and preserves the minimal `base_url` configuration surface.

## Validation

- `git diff --check`
- `python3 -m compileall -q src/xtalk/models/speech_enhancer src/xtalk/serving/modules/enhancer_manager.py`
- Parsed `docs/mkdocs.yml` with PyYAML
- Ran the PyWebRTC adapter against `http://10.30.5.37:8000` using the noisy test audio from `xtalk-fastenhancer`, writing enhanced output to a temp directory

## Notes

This PR targets `dev`. The remote `dev` branch already contains the earlier streaming TTS and VAD reset changes, so this PR focuses on the new speech enhancer far-reference support, PyWebRTC adapter, documentation, dependency metadata, and global env-file ignore rule.