### PR TITLE
feature: add native async tool engine and agent integration

### DIFF
--- a/docs/developer/recipe.md
+++ b/docs/developer/recipe.md
@@ -86,7 +86,17 @@ The `accept` method subscribes to external inputs and starts the related process
 
 The `loop` event is triggered once when the connection is established. It can be used for any proactive logic, or to start an output loop. [`src/xtalk/models/agents/experimental.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/models/agents/experimental.py) uses it to trigger proactive dialogue.
 
-`AgentOutput` can be a string, a tool call, or a tool call result. After a tool call returns, the `Manager` can use it to trigger related logic. For example, in [`src/xtalk/serving/modules/llm_agent_context_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/llm_agent_context_manager.py), the `direct_audio` tool call triggers downstream logic in [`src/xtalk/serving/modules/direct_audio_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/direct_audio_manager.py) to generate directly playable audio events.
+`AgentOutput` can be a string, a tool call, a tool call result, or an
+`AgentTurnBoundary`. After a tool call returns, the `Manager` can use it to
+trigger related logic. For example, in
+[`src/xtalk/serving/modules/llm_agent_context_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/llm_agent_context_manager.py),
+the `direct_audio` tool call triggers downstream logic in
+[`src/xtalk/serving/modules/direct_audio_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/direct_audio_manager.py)
+to generate directly playable audio events.
+
+Finite output streams finish the current response when their iterator ends.
+Long-lived streams started by `loop` should yield `AgentTurnBoundary()` after
+each response to trigger TTS flush and response finish.
 
 From a design perspective, `Agent` is expected to be the main reasoning core of the whole system and to integrate information from other components into output.
 

--- a/docs/developer/recipe.zh.md
+++ b/docs/developer/recipe.zh.md
@@ -73,7 +73,10 @@ async def async_accept(self, context: AgentContext) -> AsyncIterator[AgentOutput
 
 `accept`方法订阅外部输入并启动相关处理逻辑；`AgentContext`来自[`src/xtalk/serving/modules/llm_agent_context_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/llm_agent_context_manager.py)，目前较为稳定的类型有`asr_partial`、`asr_final`、`loop`。其中`loop`在连接建立时触发一次，可以用于处理任何主动触发逻辑，或者是启动输出循环。[`src/xtalk/models/agents/experimental.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/models/agents/experimental.py)用于触发主动对话。
 
-`AgentOutput`为字符串、工具调用或工具调用结果；工具调用返回后可用于`Manager`触发相关逻辑，例如[`src/xtalk/serving/modules/llm_agent_context_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/llm_agent_context_manager.py)中`direct_audio`的工具调用触发下游[`src/xtalk/serving/modules/direct_audio_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/direct_audio_manager.py)生成直接播放音频的事件。
+`AgentOutput`可以是字符串、工具调用、工具调用结果或 `AgentTurnBoundary`。工具调用返回后可用于`Manager`触发相关逻辑，例如[`src/xtalk/serving/modules/llm_agent_context_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/llm_agent_context_manager.py)中`direct_audio`的工具调用触发下游[`src/xtalk/serving/modules/direct_audio_manager.py`](https://github.com/xcc-zach/xtalk/blob/main/src/xtalk/serving/modules/direct_audio_manager.py)生成直接播放音频的事件。
+
+普通输出流结束时会自动结束本轮回复；由 `loop` 启动的长期输出流应在每次回复
+后输出 `AgentTurnBoundary()`，用于触发 TTS flush 和 response finish。
 
 `Agent`从设计哲学上期望成为整个系统的思考核心，负责整合其他块的信息输出。
 

--- a/docs/docs/tool_design.md
+++ b/docs/docs/tool_design.md
@@ -117,6 +117,7 @@ types.
 ```python
 from collections.abc import Iterator
 from dataclasses import dataclass
+import time
 
 from xtalk.models.agents.tools import (
     AsyncTool,
@@ -137,6 +138,8 @@ class SearchInput(ToolInput):
 @dataclass
 class SearchState(ToolState):
     pages_done: int = 0
+    subscribed: bool = False
+    stopped: bool = False
 
 
 class SearchOutput(ToolOutput):
@@ -167,11 +170,54 @@ class SearchTool(AsyncTool):
         global_state: ToolEngineState,
     ) -> Iterator[ToolResult[SearchOutput]]:
         del global_state
+        time.sleep(2)  # Simulate slow retrieval; the async bridge runs this in a thread.
         tool_state.pages_done = 1
         yield Running(content="Searching the first page")
+        time.sleep(2)
         yield Finished(
             content=SearchOutput(content=f"Search complete: {tool_input.query}")
         )
+
+    # Optional hooks for status, stopping, and subscription state.
+    @classmethod
+    def status(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> str:
+        del tool_input, global_state
+        return f"Retrieved {tool_state.pages_done} pages"
+
+    @classmethod
+    def stop(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.stopped = True
+
+    @classmethod
+    def subscribe(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.subscribed = True
+
+    @classmethod
+    def unsubscribe(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.subscribed = False
 ```
 
 `emit_initial()` must return `Running` quickly. The current protocol requires
@@ -327,9 +373,10 @@ the current tool-call chain and a later loop cannot consume the same result.
 When several updates arrive before generation starts, every downstream update
 event is preserved while the model generations are coalesced into one. An
 update arriving during generation triggers another generation afterward.
-User requests use the tool-bound model. Proactive reports triggered by
-background updates use the model without bound tools, preventing it from
-calling internal notification or status tools based on synthetic history.
+User requests use a model that may call tools. Proactive reports triggered by
+background updates still bind every tool schema so the model can interpret
+system ToolCalls in history, but set `tool_choice="none"` to prevent tool calls
+during that generation.
 
 ### Concurrent ASR partials
 

--- a/docs/docs/tool_design.md
+++ b/docs/docs/tool_design.md
@@ -1,28 +1,32 @@
-# Asynchronous Tool Calls
+# Tool Call Design
 
-## Principles
+X-Talk supports three kinds of agent tools: LangChain `BaseTool` instances,
+native synchronous `SyncTool` classes, and `AsyncTool` classes that can keep
+producing updates in the background. `ToolEngine` binds and invokes all three
+kinds while maintaining asynchronous lifecycles and valid message history.
 
-- Asynchronous tools are a superset of synchronous tools; an asynchronous tool becomes a synchronous tool when it only contains the tool execution function.
-- Immediately after an asynchronous call starts, return one result and insert it into the LLM history. This keeps compatibility with LLMs that require a `ToolMessage` immediately after a tool call.
-    - Protocol-level invalid cases: an `AIMessage` with non-empty `tool_calls` is not followed by a `ToolMessage`; or no previous `AIMessage.tool_calls` contains the id referenced by a `ToolMessage`.
-- The LLM can query the latest tool result.
-- The LLM can stop a tool call.
-- The LLM can subscribe to or unsubscribe from a tool call. When subscribed, the tool reports the latest result back to the LLM.
-- Tool results are divided into running results and finished results.
+## Goals
 
-## Interface Design
+- A synchronous tool returns one final result.
+- An asynchronous tool immediately returns `Running`, so the agent is not
+  blocked and models that require a matching `ToolMessage` directly after
+  `AIMessage(tool_calls=...)` remain protocol compliant.
+- An asynchronous tool may emit progress updates and must end with `Finished`.
+- The LLM can query, subscribe to, unsubscribe from, or stop an asynchronous
+  call.
+- Every call ID is unique within one `ToolEngine`.
+- Tool results are inserted into history as valid ToolCall/ToolMessage pairs.
 
-### Tool
+The implementation lives in
+[`src/xtalk/models/agents/tools/core.py`](../../src/xtalk/models/agents/tools/core.py).
+Public types are exported from `xtalk.models.agents.tools`.
+
+## Core data types
 
 ```python
-import asyncio
-import types
-from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Generic, Optional, TypeAlias, TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import Any
 
-from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel
 
 
@@ -41,258 +45,93 @@ class ToolState:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-TI = TypeVar("TI", bound=ToolInput)
-TS = TypeVar("TS", bound=ToolState)
-TO = TypeVar("TO", bound=ToolOutput)
-
-
 @dataclass(frozen=True)
 class Running:
     content: str
 
 
 @dataclass(frozen=True)
-class Finished(Generic[TO]):
-    content: TO
-
-
-ToolResult: TypeAlias = Running | Finished[TO]
-ToolEngineState: TypeAlias = Any
-
-
-_SENTINEL = object()
-
-
-def _next_or_sentinel(iterator: Iterator[str]) -> str | object:
-    try:
-        return next(iterator)
-    except StopIteration:
-        return _SENTINEL
-
-
-class AsyncTool(ABC):
-    name: ClassVar[Optional[str]] # Use the tool class name when omitted.
-    subscribe_by_default: ClassVar[bool] = False
-    input_type: ClassVar[type[ToolInput]]
-    state_type: ClassVar[type[ToolState]]
-    output_type: ClassVar[type[ToolOutput]]
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls.input_type, cls.state_type, cls.output_type = (
-            cls._infer_types_from_method_annotations()
-        )
-
-    @classmethod
-    def _infer_types_from_method_annotations(
-        cls,
-    ) -> tuple[type[ToolInput], type[ToolState], type[ToolOutput]]:
-        input_type: type[ToolInput] | None = None
-        state_type: type[ToolState] | None = None
-        output_type: type[ToolOutput] | None = None
-
-        for method_name in (
-            "emit_initial",
-            "aemit_initial",
-            "emit_updates",
-            "aemit_updates",
-            "status",
-            "stop",
-            "subscribe",
-            "unsubscribe",
-        ):
-            raw_method = cls.__dict__.get(method_name)
-            if raw_method is None:
-                continue
-            method = raw_method.__func__ if isinstance(raw_method, classmethod) else raw_method
-            hints = get_type_hints(method)
-
-            if input_type is None and "tool_input" in hints:
-                input_type = cls._validate_input_type(hints["tool_input"])
-            if state_type is None and "tool_state" in hints:
-                state_type = cls._validate_state_type(hints["tool_state"])
-            if output_type is None and "return" in hints:
-                output_type = cls._infer_output_type(hints["return"])
-
-        if input_type is None:
-            raise TypeError(f"{cls.__name__} must annotate tool_input")
-        if state_type is None:
-            raise TypeError(f"{cls.__name__} must annotate tool_state")
-        if output_type is None:
-            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
-        return input_type, state_type, output_type
-
-    @staticmethod
-    def _validate_input_type(value: Any) -> type[ToolInput]:
-        if isinstance(value, type) and issubclass(value, ToolInput):
-            return value
-        raise TypeError("tool_input must be annotated as a ToolInput subclass")
-
-    @staticmethod
-    def _validate_state_type(value: Any) -> type[ToolState]:
-        if isinstance(value, type) and issubclass(value, ToolState):
-            return value
-        raise TypeError("tool_state must be annotated as a ToolState subclass")
-
-    @classmethod
-    def _infer_output_type(cls, annotation: Any) -> type[ToolOutput] | None:
-        origin = get_origin(annotation)
-        args = get_args(annotation)
-
-        if isinstance(annotation, type) and issubclass(annotation, ToolOutput):
-            return annotation
-        if origin in {Running, Finished} and args:
-            output_type = args[0]
-            if isinstance(output_type, type) and issubclass(output_type, ToolOutput):
-                return output_type
-        if origin in {Iterator, AsyncIterator} and args:
-            return cls._infer_output_type(args[0])
-        if origin in {Union, types.UnionType}:
-            for arg in args:
-                output_type = cls._infer_output_type(arg)
-                if output_type is not None:
-                    return output_type
-        return None
-
-    @classmethod
-    @abstractmethod
-    def emit_initial(cls, tool_call_id: str, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> Running:
-        # An asynchronous tool must immediately return one message when called.
-        # This satisfies LLMs that require a ToolMessage immediately after a tool call.
-        # Runtime checks should require the returned Running string to include
-        # tool_call_id, so async_tool_updated can distinguish tool calls.
-        pass
-
-    @classmethod
-    async def aemit_initial(
-        cls, tool_call_id: str, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> Running:
-        # By default, run the synchronous emit_initial in a thread pool.
-        # Asynchronous tools may override this method.
-        return await asyncio.to_thread(cls.emit_initial, tool_input, tool_state, global_state)
-
-    @classmethod
-    @abstractmethod
-    def emit_updates(
-        cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> Iterator[ToolResult[ToolOutput]]:
-        # Actively yield intermediate results.
-        pass
-
-    @classmethod
-    async def aemit_updates(
-        cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> AsyncIterator[ToolResult[ToolOutput]]:
-        # By default, run next() for the synchronous emit_updates iterator in a
-        # thread pool to avoid blocking the event loop.
-        iterator = cls.emit_updates(tool_input, tool_state, global_state)
-        while True:
-            item = await asyncio.to_thread(_next_or_sentinel, iterator)
-            if item is _SENTINEL:
-                break
-            yield item
-
-    @classmethod
-    def status(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> str:
-        # Returned when the LLM queries the tool.
-        return ""
-
-    @classmethod
-    async def astatus(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> str:
-        return await asyncio.to_thread(cls.status, tool_input, tool_state, global_state)
-
-    @classmethod
-    def stop(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # Stop the tool call.
-        pass
-
-    @classmethod
-    async def astop(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.stop, tool_input, tool_state, global_state)
-
-    @classmethod
-    def subscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # Additional logic when update listening is enabled.
-        pass
-
-    @classmethod
-    async def asubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.subscribe, tool_input, tool_state, global_state)
-
-    @classmethod
-    def unsubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # Additional logic when update listening is disabled.
-        pass
-
-    @classmethod
-    async def aunsubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.unsubscribe, tool_input, tool_state, global_state)
-
-
-class SyncTool(ABC):
-    name: ClassVar[Optional[str]] # Use the tool class name when omitted.
-    input_type: ClassVar[type[ToolInput]]
-    output_type: ClassVar[type[ToolOutput]]
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls.input_type, cls.output_type = (
-            cls._infer_types_from_method_annotations()
-        )
-
-    @classmethod
-    def _infer_types_from_method_annotations(
-        cls,
-    ) -> tuple[type[ToolInput], type[ToolOutput]]:
-        raw_method = cls.__dict__.get("invoke")
-        if raw_method is None:
-            raise TypeError(f"{cls.__name__} must define invoke")
-
-        method = raw_method.__func__ if isinstance(raw_method, classmethod) else raw_method
-        hints = get_type_hints(method)
-
-        if "tool_input" not in hints:
-            raise TypeError(f"{cls.__name__} must annotate tool_input")
-        if "return" not in hints:
-            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
-
-        return (
-            cls._validate_input_type(hints["tool_input"]),
-            cls._validate_output_type(hints["return"]),
-        )
-
-    @staticmethod
-    def _validate_input_type(value: Any) -> type[ToolInput]:
-        if isinstance(value, type) and issubclass(value, ToolInput):
-            return value
-        raise TypeError("tool_input must be annotated as a ToolInput subclass")
-
-    @staticmethod
-    def _validate_output_type(value: Any) -> type[ToolOutput]:
-        if isinstance(value, type) and issubclass(value, ToolOutput):
-            return value
-        raise TypeError("return must be annotated as a ToolOutput subclass")
-
-    @classmethod
-    @abstractmethod
-    def invoke(
-        cls, tool_input: ToolInput, global_state: ToolEngineState
-    ) -> ToolOutput:
-        pass
-
-    @classmethod
-    async def ainvoke(
-        cls, tool_input: ToolInput, global_state: ToolEngineState
-    ) -> ToolOutput:
-        return await asyncio.to_thread(cls.invoke, tool_input, global_state)
+class Finished:
+    content: ToolOutput
 ```
 
-Subclasses automatically infer `input_type`, `state_type`, and `output_type` from method parameter and return annotations:
+Their responsibilities are:
+
+- `ToolInput`: structured LLM-generated input validated by Pydantic.
+- `ToolOutput`: structured final output, serialized to JSON by default.
+- `ToolState`: mutable state owned by one asynchronous call.
+- `Running`: textual state emitted before the asynchronous call finishes.
+- `Finished`: the final structured result.
+
+`ToolEngineState` is the session-level shared object passed to native tools. It
+currently has type `Any`. `ToolEngine` retains the supplied object by reference;
+it does not make a shallow or deep copy.
+
+## Creating a synchronous tool
+
+Inherit from `SyncTool` and implement a fully annotated `invoke()` method:
 
 ```python
+from xtalk.models.agents.tools import (
+    SyncTool,
+    ToolEngineState,
+    ToolInput,
+    ToolOutput,
+)
+
+
+class AddInput(ToolInput):
+    left: int
+    right: int
+
+
+class AddOutput(ToolOutput):
+    value: int
+
+
+class AddTool(SyncTool):
+    name = "add"
+
+    @classmethod
+    def invoke(
+        cls,
+        tool_input: AddInput,
+        global_state: ToolEngineState,
+    ) -> AddOutput:
+        del global_state
+        return AddOutput(value=tool_input.left + tool_input.right)
+```
+
+The framework infers `input_type` and `output_type` from the annotations.
+`ainvoke()` uses `asyncio.to_thread()` by default so the synchronous
+implementation does not block the event loop.
+
+When `name` is omitted, the class name is exposed to the LLM.
+
+## Creating an asynchronous tool
+
+Inherit from `AsyncTool` and implement at least `emit_initial()` and
+`emit_updates()`. Their annotations determine the input, state, and output
+types.
+
+```python
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from xtalk.models.agents.tools import (
+    AsyncTool,
+    Finished,
+    Running,
+    ToolEngineState,
+    ToolInput,
+    ToolOutput,
+    ToolResult,
+    ToolState,
+)
+
+
 class SearchInput(ToolInput):
     query: str
-    limit: int = 5
 
 
 @dataclass
@@ -306,15 +145,19 @@ class SearchOutput(ToolOutput):
 
 class SearchTool(AsyncTool):
     name = "search"
+    subscribe_by_default = False
 
     @classmethod
     def emit_initial(
         cls,
+        tool_call_id: str,
         tool_input: SearchInput,
         tool_state: SearchState,
         global_state: ToolEngineState,
     ) -> Running:
-        return Running(f"Starting search: {tool_input.query}")
+        del tool_input, global_state
+        tool_state.call_id = tool_call_id
+        return Running(content=f"Search started; call ID: {tool_call_id}")
 
     @classmethod
     def emit_updates(
@@ -323,421 +166,203 @@ class SearchTool(AsyncTool):
         tool_state: SearchState,
         global_state: ToolEngineState,
     ) -> Iterator[ToolResult[SearchOutput]]:
-        yield Running("Searching")
-        yield Finished(SearchOutput(content="Search complete"))
-
-
-class SyncSearchTool(SyncTool):
-    name = "sync_search"
-
-    @classmethod
-    def invoke(
-        cls,
-        tool_input: SearchInput,
-        global_state: ToolEngineState,
-    ) -> SearchOutput:
-        return SearchOutput(content=f"Search complete: {tool_input.query}")
+        del global_state
+        tool_state.pages_done = 1
+        yield Running(content="Searching the first page")
+        yield Finished(
+            content=SearchOutput(content=f"Search complete: {tool_input.query}")
+        )
 ```
 
-### Synchronous and Asynchronous Compatibility
+`emit_initial()` must return `Running` quickly. The current protocol requires
+its `content` to contain `tool_call_id`. `emit_updates()` may emit multiple
+`Running` values, but it must end with one `Finished`; ending without
+`Finished` is a runtime error.
+
+Default `aemit_initial()` and `aemit_updates()` methods bridge synchronous
+implementations through worker threads. A tool backed by an async SDK may
+override the corresponding `a*` methods.
+
+### Optional lifecycle hooks
+
+`AsyncTool` also provides synchronous and asynchronous hook pairs:
+
+- `status()` / `astatus()`: return the current human-readable status.
+- `stop()` / `astop()`: stop external work and release resources.
+- `subscribe()` / `asubscribe()`: run extra work when progress is subscribed.
+- `unsubscribe()` / `aunsubscribe()`: run extra work when it is unsubscribed.
+
+## State and concurrency
+
+`ToolState` belongs to one call. Store progress, external task handles, and
+call-level locks there whenever possible. Different calls do not share a
+`ToolState` instance.
+
+`ToolEngineState` is shared at session scope. ToolEngine coordinates
+synchronous calls and short lifecycle hooks, but it does **not** hold a global
+lock for the entire `aemit_updates()` wait. An asynchronous update may wait on
+network I/O, a queue, or an external event; holding the lock would prevent
+`status` and `stop` from running.
+
+If `aemit_updates()` mutates shared state, the tool must use short critical
+sections, its own `asyncio.Lock`, or a thread-safe data structure. Do not keep a
+shared-state lock across a network request or a complete update stream.
+
+## ToolEngine
+
+The supported union is:
 
 ```python
 Tool = BaseTool | type[SyncTool] | type[AsyncTool]
 ```
 
-- `BaseTool`: external LangChain tools. Kept compatible, but not guaranteed to access `ToolEngineState`.
-- `SyncTool`: native XTalk synchronous tools. Can access `ToolEngineState`.
-- `AsyncTool`: native XTalk asynchronous tools. Can access `ToolEngineState`.
-
-### ToolEngine
-
-- Keep tools available across `Agent.clone`.
-- Bind additional tools to the model when asynchronous tools exist.
-- Manage tool subscription state.
-- Feed back `ToolMessage` values actively triggered by tools.
-    - Control the timing of asynchronous tool calls: when an asynchronous tool is triggered, first call `aemit_initial` to generate the `ToolMessage` that must be immediately written back, then start tool execution and consume `aemit_updates` according to subscription state.
+Create an engine and bind its schemas:
 
 ```python
-@dataclass
-class ToolRun:
-    result: ToolResult
+from langchain_core.messages import ToolCall
+from xtalk.models.agents.tools import ToolEngine
 
-@dataclass
-class AsyncToolRun(ToolRun):
-    task: asyncio.Task[Any]
-    tool_class: type[AsyncTool]
-    tool_input: ToolInput
-    tool_state: ToolState
-    subscribed: bool
-    running: bool
-
-class ToolEngine:
-    def __init__(self, tools: list[Tool], state: ToolEngineState):
-        # Copy tools into self.tools; copy state into self.state.
-        # Initialize self._id_to_tool_runs: dict[str, ToolRun].
-        # If asynchronous tools exist, append self._create_assist_tools to self.tools.
-        # TODO
-        pass
-
-    def bind(self, model: ChatOpenAI) -> ChatOpenAI:
-        # Bind tools to the model and return the bound model.
-        # TODO
-        pass
-    def on_async_tool_update(self, cb: Callable[[ToolCall, ToolMessage], None]):
-        # Trigger cb when an asynchronous tool actively emits a ToolMessage and
-        # the tool call is subscribed.
-        # self._async_tool_update_callback = cb
-        # Recommended client callback: call append_tool_message and trigger
-        # generation afterward. If the last message before append is an
-        # unfinished HumanMessage, do not generate yet.
-        # Partial HumanMessage values should also stay in history. Use a bool
-        # variable to mark whether the user has finished speaking. If a partial
-        # message is interrupted by inserted AI/tool messages, and a later ASR
-        # partial starts with the previous partial, append a new HumanMessage
-        # containing only the suffix not covered by the prefix; otherwise append
-        # the full new partial.
-        # TODO
-
-        pass
-    async def ainvoke(self, tool_call: ToolCall) -> ToolMessage:
-        # Trigger a tool and produce a ToolMessage. Synchronous tools directly
-        # produce the result; asynchronous tools produce emit_initial.
-        # Synchronous tool calls store Result in self._id_to_tool_runs.
-        # Asynchronous tool calls use AsyncToolRun with extra required fields:
-        # task continuously yields from aemit_updates and calls
-        # self._async_tool_update_callback. Subscribed tool calls call the
-        # callback for both Running and Finished yields; unsubscribed tool calls
-        # call the callback only for Finished. Remember to lock global_state.
-        # TODO
-
-        pass
-    def invoke(self, tool_call: ToolCall) -> ToolMessage:
-        # TODO
-
-        pass
-    @staticmethod
-    def extract_tool_calls(gathered: AIMessageChunk) -> list[ToolCall]:
-        # TODO
-
-        pass
-    # Methods coupled to message-list handling: ------
-    async def ainvoke_and_append(self, tool_call: ToolCall, messages: list[BaseMessage]):
-        # Call ainvoke and then append_tool_message.
-        # TODO
-
-        pass
-    def invoke_and_append(self, tool_call: ToolCall, messages: list[BaseMessage]):
-        # Call invoke and then append_tool_message.
-        # TODO
-
-        pass
-    @staticmethod
-    def append_tool_message(tool_call: ToolCall, tool_message: ToolMessage, list[BaseMessage]):
-        # First call _append_tool_call, then decide the next step based on the
-        # ToolCall it returns.
-        # For forwarded synchronous tool calls: append tool_message to messages.
-        # For async_tool_updated calls: use tool_message.content to create and
-        # append a ToolMessage matching async_tool_updated output.
-        # TODO
-
-        pass
-    @staticmethod
-    def _append_tool_call(tool_call: ToolCall, messages: list[BaseMessage]) -> ToolCall:
-        # Append tool_call without duplication to the last AIMessage.tool_calls,
-        # or create an empty AIMessage(tool_calls=tool_calls).
-        # For a synchronous tool_call, append the tool_call itself.
-        # For an asynchronous tool_call, append a tool_call whose name is
-        # async_tool_updated, whose id is the original tool_call id plus a
-        # distinguishing suffix, and whose args are
-        # {"source_call_id": original tool_call id}.
-        # Return the actual appended tool call.
-        # TODO
-
-        pass
-    # ------
-    def _create_assist_tools(self):
-        return [
-            self._create_async_tool_updated_tool(),
-            self._create_id_to_async_tool_status_tool(),
-            self._create_subscribe_tool(),
-            self._create_unsubscribe_tool(),
-            self._create_stop_tool(),
-        ]
-
-    def _create_async_tool_updated_tool(self) -> BaseTool:
-        @tool("async_tool_updated")
-        def async_tool_updated(
-            source_call_id: str,
-        ) -> str:
-            """Some tool calls return a tool_call id. These tools are asynchronous tools. An asynchronous tool continuously produces new output through this tool: this tool takes the tool_call id returned when the asynchronous tool was called, and outputs the new result for that asynchronous tool. This tool is called by the system; you must not call it proactively. If the conversation history contains a tool message whose result has not yet been reported to the user, your next response must mention this tool result. If there is also a newer user message, respond to both: first briefly report the tool update, then respond to the user message.
-
-            Args:
-                source_call_id: The tool_call id of the asynchronous tool call.
-            """
-            # When ToolMessage is created in the system, it contains
-            # {"running": bool, "tool_output": str}.
-            return "This tool cannot be called proactively."
-
-        return async_tool_updated
-
-    def _create_id_to_async_tool_status_tool(self) -> BaseTool:
-        @tool("id_to_async_tool_status")
-        async def id_to_async_tool_status(source_call_id: str) -> str:
-            """Query the latest running status of an asynchronous tool call.
-
-            Args:
-                source_call_id: The tool_call id of the asynchronous tool call.
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"Async tool call {source_call_id} does not exist"
-            tool_status = await run.tool_class.astatus(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return {
-                "running": run.running
-                "status": tool_status
-            }
-
-        return id_to_async_tool_status
-
-    def _create_subscribe_tool(self) -> BaseTool:
-        @tool("subscribe_async_tool")
-        async def subscribe_async_tool(source_call_id: str) -> str:
-            """Subscribe to subsequent active updates from an asynchronous tool call. Subscribed asynchronous tools return intermediate outputs through async_tool_updated.
-
-            Args:
-                source_call_id: The original tool_call id of the asynchronous tool call.
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"Async tool call {source_call_id} does not exist"
-            run.subscribed = True
-            await run.tool_class.asubscribe(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return f"Subscribed to asynchronous tool {source_call_id}"
-
-        return subscribe_async_tool
-
-    def _create_unsubscribe_tool(self) -> BaseTool:
-        @tool("unsubscribe_async_tool")
-        async def unsubscribe_async_tool(source_call_id: str) -> str:
-            """Unsubscribe from subsequent active updates from an asynchronous tool call. Unsubscribed asynchronous tools only return their final result through async_tool_updated.
-
-            Args:
-                source_call_id: The original tool_call id of the asynchronous tool call.
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"Async tool call {source_call_id} does not exist"
-            run.subscribed = False
-            await run.tool_class.aunsubscribe(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return f"Unsubscribed from asynchronous tool {source_call_id}"
-
-        return unsubscribe_async_tool
-
-    def _create_stop_tool(self) -> BaseTool:
-        @tool("stop_async_tool")
-        async def stop_async_tool(source_call_id: str) -> str:
-            """Stop an asynchronous tool call that is still running.
-
-            Args:
-                source_call_id: The original tool_call id of the asynchronous tool call.
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"Async tool call {source_call_id} does not exist"
-            await run.tool_class.astop(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            run.task.cancel()
-            return f"Stopped asynchronous tool {source_call_id}"
-
-        return stop_async_tool
-```
-
-# Implementation
-
-### Implementation Location
-
-Place `Tool`, `ToolEngine`, and related types in `src/xtalk/models/agents/tools/core.py`, and export the required types from `src/xtalk/models/agents/tools/__init__.py` (types used for creating new tools and types used by agents). Also migrate required content from `src/xtalk/models/agents/tools/utils.py` into `core.py`. Then update `src/xtalk/models/agents/experimental.py` according to `### How an LLM Agent Uses ToolEngine`.
-
-### How an LLM Agent Uses ToolEngine
-
-#### # __init__
-
-```python
-self._base_tools = tools
-self.tool_engine = ToolEngine(
-    tools=tools or [],
+engine = ToolEngine(
+    tools=[AddTool, SearchTool],
     state={},
 )
-self.model_with_tools = self.tool_engine.bind(self.model)
+model_with_tools = engine.bind(model)
 
-self._human_input_finished = True
-self._last_partial_human_text = ""
-self._active_partial_human_index: int | None = None
-self._active_partial_human_prefix = ""
-
-self._async_tool_update_queue: asyncio.Queue[AgentOutput] = asyncio.Queue()
-self.tool_engine.on_async_tool_update(self._on_async_tool_update)
-```
-
-#### # _stream_messages
-
-```python
-async def _stream_messages(self) -> AsyncIterator[AgentOutput]:
-    while True:
-        gathered = None
-
-        async for chunk in self.model_with_tools.astream(self.messages):
-            text = self.content_to_text(chunk.content)
-            if text:
-                yield text
-            gathered = chunk if gathered is None else gathered + chunk
-
-        tool_calls = ToolEngine.extract_tool_calls(gathered)
-        if not tool_calls:
-            return
-
-        for tool_call in tool_calls:
-            yield tool_call
-
-            tool_message = await self.tool_engine.ainvoke_and_append(
-                tool_call,
-                self._chat_history.messages,
-            )
-
-            yield build_tool_call_result(
-                tool_call=tool_call,
-                result_content=str(tool_message.content),
-            )
-```
-
-#### # async tool update callback
-
-```python
-def _on_async_tool_update(
-    self,
-    tool_call: ToolCall,
-    tool_message: ToolMessage,
-) -> None:
-    ToolEngine.append_tool_message(
-        tool_call,
-        tool_message,
-        self._chat_history.messages,
+message = await engine.ainvoke(
+    ToolCall(
+        id="call-add-1",
+        name="add",
+        args={"left": 2, "right": 3},
     )
-
-    if not self._human_input_finished:
-        return
-
-    self._async_tool_update_queue.put_nowait(
-        build_tool_call_result(
-            tool_call=tool_call,
-            result_content=str(tool_message.content),
-        )
-    )
+)
 ```
 
-#### # _loop_runner
+`bind()` exposes schemas to the model. A native tool must still execute through
+ToolEngine and cannot invoke the schema wrapper directly.
+
+### Invocation semantics
+
+- `BaseTool`: call LangChain `ainvoke()` and store a textual result.
+- `SyncTool`: validate input, await the final output, and return ToolMessage.
+- `AsyncTool`: validate input, call `aemit_initial()`, store `AsyncToolRun`,
+  start a background update task, and immediately return the initial
+  ToolMessage.
+
+`invoke()` is limited to `BaseTool` and `SyncTool` in synchronous contexts. Use
+`await ainvoke()` when an event loop is already running. `AsyncTool` always
+requires `await ainvoke()` on a persistent event loop so its updates can
+continue after the initial result.
+
+Each call ID is reserved before execution. Concurrent reuse or reuse after a
+call has completed raises `ValueError`.
+
+### Asynchronous run records
+
+`AsyncToolRun` stores:
+
+- the latest `Running` or `Finished`;
+- the tool class, validated input, and call state;
+- `subscribed` and `running` flags;
+- the background `task`;
+- a lifecycle lock and any background exception.
+
+Background exceptions are stored on the run and retrieved to avoid unhandled
+Task warnings.
+
+## Assistant tools
+
+When at least one `AsyncTool` exists, ToolEngine registers five assistant
+tools:
+
+- `async_tool_updated`: system-only update; its callable schema is hidden from
+  the LLM.
+- `id_to_async_tool_status`: query running state, tool status, and errors.
+- `subscribe_async_tool`: subscribe and return the latest known result.
+- `unsubscribe_async_tool`: suppress progress; the final result is still sent.
+- `stop_async_tool`: call `astop()` and cancel the background task.
+
+The latter four control tools are bound to the model. `async_tool_updated`
+remains a ToolCall/ToolMessage protocol name only, preventing the model from
+mistaking an internal notification for a callable tool.
+Status queries are only for explicit user requests and must not be polled.
+After subscribing, the model should stop calling tools and wait for proactive
+system updates.
+
+With `subscribe_by_default=True`, the subscription hook runs before the update
+task starts. Unsubscribed calls proactively report only `Finished`; subscribed
+calls report both `Running` and `Finished`.
+
+## Message history protocol
+
+Every ToolMessage requires a preceding AI ToolCall with the same ID.
+`append_tool_message()` and `ainvoke_and_append()` preserve this constraint and
+reject:
+
+- empty call IDs;
+- mismatched ToolCall and ToolMessage IDs;
+- duplicate ToolMessages for one ID;
+- one ID reused with a different name or arguments.
+
+An asynchronous update uses a new `async_tool_updated` ToolCall whose arguments
+contain the original `source_call_id`. Its message content has this form:
+
+```json
+{
+  "running": true,
+  "tool_output": "Searching the first page"
+}
+```
+
+The final update sets `running` to `false` and stores the result of
+`ToolOutput.to_content()` in `tool_output`.
+
+## ExperimentalAgent integration
+
+`ExperimentalAgent` creates one ToolEngine per session, binds the model, and
+registers an asynchronous update callback. When no model generation is active,
+the callback appends a valid ToolCall/ToolMessage pair and wakes the session
+loop. Updates arriving during generation are deferred until it finishes, so
+the current tool-call chain and a later loop cannot consume the same result.
+
+When several updates arrive before generation starts, every downstream update
+event is preserved while the model generations are coalesced into one. An
+update arriving during generation triggers another generation afterward.
+User requests use the tool-bound model. Proactive reports triggered by
+background updates use the model without bound tools, preventing it from
+calling internal notification or status tools based on synthetic history.
+
+### Concurrent ASR partials
+
+ASR partials are stored as HumanMessages. If a tool update interrupts an
+unfinished user message, later partials behave as follows:
+
+- if the previous partial is a prefix, append only the new suffix;
+- otherwise append the complete replacement text;
+- if final ASR equals the latest partial, do not append an empty HumanMessage;
+- always clear the final-generation flag after completion, failure, or
+  cancellation.
+
+While the user is still speaking, an asynchronous update is written to history
+without immediately starting model generation. After final ASR, the model sees
+both the tool update and the complete user input.
+
+## Shutdown
+
+Session shutdown must call:
 
 ```python
-async def _loop_runner(self) -> AsyncIterator[AgentOutput]:
-    while True:
-        if self.proactive and len(self.messages) == 1:
-            self._chat_history.append_message(HumanMessage(content="Hello."))
-            async for item in self._stream_greeting():
-                yield item
-            break
-
-        try:
-            item = await asyncio.wait_for(
-                self._async_tool_update_queue.get(),
-                timeout=0.2,
-            )
-            yield item
-        except asyncio.TimeoutError:
-            pass
+await engine.shutdown()
 ```
 
-#### # deal with human message
+`shutdown()` rejects new calls, invokes `astop()` for active asynchronous
+tools, cancels their background tasks, and waits for task completion. Repeated
+shutdown calls are safe.
 
-```python
-def _append_or_update_partial_human_message(
-    self,
-    text: str,
-    *,
-    final: bool,
-) -> None:
-    if not text:
-        return
+## Current limitations
 
-    messages = self._chat_history.messages
-    active_message_is_last = (
-        self._active_partial_human_index is not None
-        and self._active_partial_human_index == len(messages) - 1
-        and isinstance(messages[-1], HumanMessage)
-    )
-
-    if active_message_is_last:
-        if text.startswith(self._active_partial_human_prefix):
-            messages[-1].content = text[len(self._active_partial_human_prefix):]
-        else:
-            messages[-1].content = text
-            self._active_partial_human_prefix = ""
-    else:
-        if self._last_partial_human_text and text.startswith(
-            self._last_partial_human_text
-        ):
-            content = text[len(self._last_partial_human_text):]
-            self._active_partial_human_prefix = self._last_partial_human_text
-        else:
-            content = text
-            self._active_partial_human_prefix = ""
-
-        self._chat_history.append_message(HumanMessage(content=content))
-        self._active_partial_human_index = len(messages) - 1
-
-    self._last_partial_human_text = text
-    self._human_input_finished = final
-
-    if final:
-        self._active_partial_human_index = None
-        self._active_partial_human_prefix = ""
-        self._last_partial_human_text = ""
-
-
-async def _handle_asr_partial(self, asr_text: str) -> AsyncIterator[AgentOutput]:
-    self._append_or_update_partial_human_message(asr_text, final=False)
-
-    if self.backchannel_model is None or self.backchannel_source_dir is None:
-        return
-
-    ...
-
-
-async def _handle_asr_final(self, asr_text: str) -> AsyncIterator[AgentOutput]:
-    self._append_or_update_partial_human_message(asr_text, final=True)
-
-    async for item in self._stream_messages():
-        yield item
-
-    self._already_backchanneled_text = ""
-    self._turn_already_to_backchannel_response = {}
-```
-
-
-## Future Extensions
-
-- The LLM can update a tool's running state ("secondary input").
+- The LLM cannot yet provide a second input to a running tool.
+- Applications and tools must agree on the concurrency policy of
+  `ToolEngineState`.
+- Real models may interpret tool descriptions and proactive updates
+  differently, so optional end-to-end integration tests should complement unit
+  tests.

--- a/docs/docs/tool_design.zh.md
+++ b/docs/docs/tool_design.zh.md
@@ -1,28 +1,29 @@
-# 异步工具调用
+# 工具调用设计
 
-## 原则
+X-Talk 支持三类 Agent 工具：LangChain `BaseTool`、X-Talk 原生同步工具
+`SyncTool`，以及可在后台持续产生更新的 `AsyncTool`。`ToolEngine` 负责统一
+绑定和调用这些工具，并维护异步调用的生命周期与消息历史协议。
 
-- 是同步工具的超集；异步工具仅包含工具执行函数时变为同步工具
-- 异步调用后立刻返回一条结果塞入LLM历史以兼容部分LLM tool call后紧跟ToolMessage的要求
-    - 协议层不通过的情况： AIMessage(tool_calls不为空)后不接ToolMessage；ToolMessage前文所有AIMessage的tool_calls中没有对应id
-- LLM可向工具查询最新结果
-- LLM可关闭工具调用
-- LLM可订阅/取消订阅工具调用；订阅时工具会将最新结果反馈给LLM
-- 工具分为执行中和结束的结果返回
+## 设计目标
 
-## 接口设计
+- 同步工具只返回一次最终结果。
+- 异步工具启动后立即返回一条 `Running`，避免阻塞 Agent，并满足
+  `AIMessage(tool_calls=...)` 后必须出现匹配 `ToolMessage` 的模型协议。
+- 异步工具可以产生过程更新，并最终产生一个 `Finished`。
+- LLM 可以查询、订阅、取消订阅或停止异步工具。
+- 每个工具调用 ID 在同一个 `ToolEngine` 中唯一。
+- 工具结果进入消息历史时始终保持合法的 ToolCall/ToolMessage 配对。
 
-### Tool
+实现位于
+[`src/xtalk/models/agents/tools/core.py`](../../src/xtalk/models/agents/tools/core.py)，
+公共类型从 `xtalk.models.agents.tools` 导出。
+
+## 核心数据类型
 
 ```python
-import asyncio
-import types
-from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Generic, Optional, TypeAlias, TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import Any
 
-from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel
 
 
@@ -41,254 +42,90 @@ class ToolState:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-TI = TypeVar("TI", bound=ToolInput)
-TS = TypeVar("TS", bound=ToolState)
-TO = TypeVar("TO", bound=ToolOutput)
-
-
 @dataclass(frozen=True)
 class Running:
     content: str
 
 
 @dataclass(frozen=True)
-class Finished(Generic[TO]):
-    content: TO
-
-
-ToolResult: TypeAlias = Running | Finished[TO]
-ToolEngineState: TypeAlias = Any
-
-
-_SENTINEL = object()
-
-
-def _next_or_sentinel(iterator: Iterator[str]) -> str | object:
-    try:
-        return next(iterator)
-    except StopIteration:
-        return _SENTINEL
-
-
-class AsyncTool(ABC):
-    name: ClassVar[Optional[str]] # 不设置时使用工具类名
-    subscribe_by_default: ClassVar[bool] = False
-    input_type: ClassVar[type[ToolInput]]
-    state_type: ClassVar[type[ToolState]]
-    output_type: ClassVar[type[ToolOutput]]
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls.input_type, cls.state_type, cls.output_type = (
-            cls._infer_types_from_method_annotations()
-        )
-
-    @classmethod
-    def _infer_types_from_method_annotations(
-        cls,
-    ) -> tuple[type[ToolInput], type[ToolState], type[ToolOutput]]:
-        input_type: type[ToolInput] | None = None
-        state_type: type[ToolState] | None = None
-        output_type: type[ToolOutput] | None = None
-
-        for method_name in (
-            "emit_initial",
-            "aemit_initial",
-            "emit_updates",
-            "aemit_updates",
-            "status",
-            "stop",
-            "subscribe",
-            "unsubscribe",
-        ):
-            raw_method = cls.__dict__.get(method_name)
-            if raw_method is None:
-                continue
-            method = raw_method.__func__ if isinstance(raw_method, classmethod) else raw_method
-            hints = get_type_hints(method)
-
-            if input_type is None and "tool_input" in hints:
-                input_type = cls._validate_input_type(hints["tool_input"])
-            if state_type is None and "tool_state" in hints:
-                state_type = cls._validate_state_type(hints["tool_state"])
-            if output_type is None and "return" in hints:
-                output_type = cls._infer_output_type(hints["return"])
-
-        if input_type is None:
-            raise TypeError(f"{cls.__name__} must annotate tool_input")
-        if state_type is None:
-            raise TypeError(f"{cls.__name__} must annotate tool_state")
-        if output_type is None:
-            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
-        return input_type, state_type, output_type
-
-    @staticmethod
-    def _validate_input_type(value: Any) -> type[ToolInput]:
-        if isinstance(value, type) and issubclass(value, ToolInput):
-            return value
-        raise TypeError("tool_input must be annotated as a ToolInput subclass")
-
-    @staticmethod
-    def _validate_state_type(value: Any) -> type[ToolState]:
-        if isinstance(value, type) and issubclass(value, ToolState):
-            return value
-        raise TypeError("tool_state must be annotated as a ToolState subclass")
-
-    @classmethod
-    def _infer_output_type(cls, annotation: Any) -> type[ToolOutput] | None:
-        origin = get_origin(annotation)
-        args = get_args(annotation)
-
-        if isinstance(annotation, type) and issubclass(annotation, ToolOutput):
-            return annotation
-        if origin in {Running, Finished} and args:
-            output_type = args[0]
-            if isinstance(output_type, type) and issubclass(output_type, ToolOutput):
-                return output_type
-        if origin in {Iterator, AsyncIterator} and args:
-            return cls._infer_output_type(args[0])
-        if origin in {Union, types.UnionType}:
-            for arg in args:
-                output_type = cls._infer_output_type(arg)
-                if output_type is not None:
-                    return output_type
-        return None
-
-    @classmethod
-    @abstractmethod
-    def emit_initial(cls, tool_call_id: str, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> Running:
-        # 异步工具被调用时必须立刻返回一条信息以满足”异步调用后立刻返回一条结果塞入LLM历史以兼容部分LLM tool call后紧跟ToolMessage的要求“
-        # 运行时强制检查返回的Running str中带有tool_call_id，以供async_tool_updated工具区分
-        pass
-
-    @classmethod
-    async def aemit_initial(
-        cls, tool_call_id: str, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> Running:
-        # 默认将同步emit_initial放入线程池执行；异步工具可覆写此方法
-        return await asyncio.to_thread(cls.emit_initial, tool_input, tool_state, global_state)
-
-    @classmethod
-    @abstractmethod
-    def emit_updates(
-        cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> Iterator[ToolResult[ToolOutput]]:
-        # 主动yield中间结果
-        pass
-
-    @classmethod
-    async def aemit_updates(
-        cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState
-    ) -> AsyncIterator[ToolResult[ToolOutput]]:
-        # 默认将同步emit_updates的next放入线程池，避免阻塞event loop
-        iterator = cls.emit_updates(tool_input, tool_state, global_state)
-        while True:
-            item = await asyncio.to_thread(_next_or_sentinel, iterator)
-            if item is _SENTINEL:
-                break
-            yield item
-
-    @classmethod
-    def status(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> str:
-        # LLM查询时返回
-        return ""
-
-    @classmethod
-    async def astatus(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> str:
-        return await asyncio.to_thread(cls.status, tool_input, tool_state, global_state)
-
-    @classmethod
-    def stop(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # 终止工具调用
-        pass
-
-    @classmethod
-    async def astop(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.stop, tool_input, tool_state, global_state)
-
-    @classmethod
-    def subscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # 启用emit监听时的额外逻辑
-        pass
-
-    @classmethod
-    async def asubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.subscribe, tool_input, tool_state, global_state)
-
-    @classmethod
-    def unsubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        # 关闭emit监听时的额外逻辑
-        pass
-
-    @classmethod
-    async def aunsubscribe(cls, tool_input: ToolInput, tool_state: ToolState, global_state: ToolEngineState) -> None:
-        await asyncio.to_thread(cls.unsubscribe, tool_input, tool_state, global_state)
-
-
-class SyncTool(ABC):
-    name: ClassVar[Optional[str]] # 不设置时使用工具类名
-    input_type: ClassVar[type[ToolInput]]
-    output_type: ClassVar[type[ToolOutput]]
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls.input_type, cls.output_type = (
-            cls._infer_types_from_method_annotations()
-        )
-
-    @classmethod
-    def _infer_types_from_method_annotations(
-        cls,
-    ) -> tuple[type[ToolInput], type[ToolOutput]]:
-        raw_method = cls.__dict__.get("invoke")
-        if raw_method is None:
-            raise TypeError(f"{cls.__name__} must define invoke")
-
-        method = raw_method.__func__ if isinstance(raw_method, classmethod) else raw_method
-        hints = get_type_hints(method)
-
-        if "tool_input" not in hints:
-            raise TypeError(f"{cls.__name__} must annotate tool_input")
-        if "return" not in hints:
-            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
-
-        return (
-            cls._validate_input_type(hints["tool_input"]),
-            cls._validate_output_type(hints["return"]),
-        )
-
-    @staticmethod
-    def _validate_input_type(value: Any) -> type[ToolInput]:
-        if isinstance(value, type) and issubclass(value, ToolInput):
-            return value
-        raise TypeError("tool_input must be annotated as a ToolInput subclass")
-
-    @staticmethod
-    def _validate_output_type(value: Any) -> type[ToolOutput]:
-        if isinstance(value, type) and issubclass(value, ToolOutput):
-            return value
-        raise TypeError("return must be annotated as a ToolOutput subclass")
-
-    @classmethod
-    @abstractmethod
-    def invoke(
-        cls, tool_input: ToolInput, global_state: ToolEngineState
-    ) -> ToolOutput:
-        pass
-
-    @classmethod
-    async def ainvoke(
-        cls, tool_input: ToolInput, global_state: ToolEngineState
-    ) -> ToolOutput:
-        return await asyncio.to_thread(cls.invoke, tool_input, global_state)
+class Finished:
+    content: ToolOutput
 ```
 
-子类通过方法参数与返回值注解自动推断`input_type`、`state_type`和`output_type`：
+这些类型的职责如下：
+
+- `ToolInput`：由 LLM 生成并经 Pydantic 校验的结构化输入。
+- `ToolOutput`：工具的结构化最终输出；默认以 JSON 写入 ToolMessage。
+- `ToolState`：一次异步调用独享的可变状态。
+- `Running`：异步工具尚未结束时的文本状态。
+- `Finished`：异步工具的最终结构化结果。
+
+`ToolEngineState` 是传给原生工具的会话级共享对象，目前类型为 `Any`。
+`ToolEngine` 保留传入对象的引用，不对其进行浅复制或深复制。
+
+## 创建同步工具
+
+同步工具继承 `SyncTool`，并实现带完整类型注解的 `invoke()`：
 
 ```python
+from xtalk.models.agents.tools import (
+    SyncTool,
+    ToolEngineState,
+    ToolInput,
+    ToolOutput,
+)
+
+
+class AddInput(ToolInput):
+    left: int
+    right: int
+
+
+class AddOutput(ToolOutput):
+    value: int
+
+
+class AddTool(SyncTool):
+    name = "add"
+
+    @classmethod
+    def invoke(
+        cls,
+        tool_input: AddInput,
+        global_state: ToolEngineState,
+    ) -> AddOutput:
+        del global_state
+        return AddOutput(value=tool_input.left + tool_input.right)
+```
+
+框架从 `invoke()` 的注解自动推断 `input_type` 和 `output_type`。`ainvoke()`
+默认通过 `asyncio.to_thread()` 执行同步实现，避免阻塞事件循环。
+
+没有设置 `name` 时，工具类名会成为对 LLM 暴露的名称。
+
+## 创建异步工具
+
+异步工具继承 `AsyncTool`，至少实现 `emit_initial()` 和
+`emit_updates()`。框架从生命周期方法的注解推断输入、状态和输出类型。
+
+```python
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from xtalk.models.agents.tools import (
+    AsyncTool,
+    Finished,
+    Running,
+    ToolEngineState,
+    ToolInput,
+    ToolOutput,
+    ToolResult,
+    ToolState,
+)
+
+
 class SearchInput(ToolInput):
     query: str
-    limit: int = 5
 
 
 @dataclass
@@ -302,15 +139,19 @@ class SearchOutput(ToolOutput):
 
 class SearchTool(AsyncTool):
     name = "search"
+    subscribe_by_default = False
 
     @classmethod
     def emit_initial(
         cls,
+        tool_call_id: str,
         tool_input: SearchInput,
         tool_state: SearchState,
         global_state: ToolEngineState,
     ) -> Running:
-        return Running(f"开始搜索：{tool_input.query}")
+        del tool_input, global_state
+        tool_state.call_id = tool_call_id
+        return Running(content=f"搜索任务已启动，调用编号：{tool_call_id}")
 
     @classmethod
     def emit_updates(
@@ -319,399 +160,182 @@ class SearchTool(AsyncTool):
         tool_state: SearchState,
         global_state: ToolEngineState,
     ) -> Iterator[ToolResult[SearchOutput]]:
-        yield Running("正在检索")
-        yield Finished(SearchOutput(content="搜索完成"))
-
-
-class SyncSearchTool(SyncTool):
-    name = "sync_search"
-
-    @classmethod
-    def invoke(
-        cls,
-        tool_input: SearchInput,
-        global_state: ToolEngineState,
-    ) -> SearchOutput:
-        return SearchOutput(content=f"搜索完成：{tool_input.query}")
+        del global_state
+        tool_state.pages_done = 1
+        yield Running(content="正在检索第一页")
+        yield Finished(
+            content=SearchOutput(content=f"搜索完成：{tool_input.query}")
+        )
 ```
 
-### 同步异步兼容
+`emit_initial()` 必须快速返回 `Running`，且当前协议要求 `content` 包含
+`tool_call_id`。`emit_updates()` 可以产生多个 `Running`，但必须以一个
+`Finished` 结束；未产生 `Finished` 就结束会被视为运行错误。
+
+默认的 `aemit_initial()` 和 `aemit_updates()` 会在线程中桥接同步实现。底层
+SDK 原生支持 async 时，可以覆写对应的 `a*` 方法。
+
+### 可选生命周期Hook
+
+`AsyncTool` 还提供下列同步/异步Hook：
+
+- `status()` / `astatus()`：返回当前可读状态。
+- `stop()` / `astop()`：终止外部任务并释放资源。
+- `subscribe()` / `asubscribe()`：开始订阅过程更新时执行额外逻辑。
+- `unsubscribe()` / `aunsubscribe()`：取消订阅时执行额外逻辑。
+
+## 状态与并发约束
+
+`ToolState` 属于单次调用，应优先把进度、外部任务句柄和调用级锁放在这里。
+不同调用不会共享同一个 `ToolState`。
+
+`ToolEngineState` 是多个工具共享的会话级对象。同步调用和短生命周期Hook由
+ToolEngine 协调，但 ToolEngine **不会** 在整个 `aemit_updates()` 等待期间
+持有全局锁。异步更新可能长时间等待网络、队列或外部事件；长期持锁会导致
+`status` 和 `stop` 无法执行。
+
+如果 `aemit_updates()` 会修改共享状态，工具实现必须使用短临界区、自己的
+`asyncio.Lock`，或线程安全的数据结构。不要把一次网络请求或一次完整更新流
+包在共享状态锁内。
+
+## ToolEngine
+
+支持的工具联合类型为：
 
 ```python
 Tool = BaseTool | type[SyncTool] | type[AsyncTool]
 ```
 
-- BaseTool：外部 LangChain 工具，保持兼容，不承诺能访问 ToolEngineState
-- SyncTool：XTalk 原生同步工具，可访问 ToolEngineState
-- AsyncTool：XTalk 原生异步工具，可访问 ToolEngineState
-
-### ToolEngine
-
-- 保证Tools跨Agent clone
-- 将含有异步工具时额外绑定的工具绑定到model
-- 负责管理工具订阅状态
-- 反馈Tool主动触发的ToolMessage
-    - 控制异步工具的调用时机：触发异步工具时先调用`aemit_initial`生成必须立即回填的`ToolMessage`，随后启动工具执行并按订阅状态消费`aemit_updates`
+创建并绑定工具：
 
 ```python
-@dataclass
-class ToolRun:
-    result: ToolResult
+from langchain_core.messages import ToolCall
+from xtalk.models.agents.tools import ToolEngine
 
-@dataclass
-class AsyncToolRun(ToolRun):
-    task: asyncio.Task[Any]
-    tool_class: type[AsyncTool]
-    tool_input: ToolInput
-    tool_state: ToolState
-    subscribed: bool
-    running: bool
-
-class ToolEngine:
-    def __init__(self, tools: list[Tool], state: ToolEngineState):
-        # 复制一份tools挂载到self.tools；复制一份state挂载到self.state
-        # 初始化id到工具运行的字典self._id_to_tool_runs: dict[str, ToolRun]
-        # 若工具中有异步工具，self.tools额外添加工具self._create_assist_tools
-        # TODO
-        pass
-
-    def bind(self, model: ChatOpenAI) -> ChatOpenAI:
-        # 把tools绑定到model并返回绑定后的model
-        # TODO
-        pass
-    def on_async_tool_update(self, cb: Callable[[ToolCall, ToolMessage], None]):
-        # 异步工具主动发ToolMessage且被订阅时触发cb
-        # self._async_tool_update_callback = cb
-        # 客户端推荐挂载的cb:调用append_tool_message后触发生成/如果append前最后一条是未完的HumanMessage则先不生成
-        # partial HumanMessage也要在历史中;用一个bool变量标记是否说完;partial消息被插入的AI+工具消息打断后,后续来的asr partial更新如果以前一段partial为前缀则新增的HumanMessage仅包含不在前缀中的后缀,否则包含完整的新的partial
-        # TODO
-
-        pass
-    async def ainvoke(self, tool_call: ToolCall) -> ToolMessage:
-        # 触发工具并产生ToolMessage(同步工具直接产出，异步工具emit_initial产出)
-        # 同步工具调用把Result填到self._id_to_tool_runs；异步工具用AsyncToolRun额外所需参数：
-        # task为不断从aemit_updates中yield并调用self._async_tool_update_callback（被订阅的工具调用会把Running和Finished的yield都调用callback，未被订阅的工具调用只会把Finished调用callback)，并注意锁住global_state
-        # TODO
-
-        pass
-    def invoke(self, tool_call: ToolCall) -> ToolMessage:
-        # TODO
-
-        pass
-    @staticmethod
-    def extract_tool_calls(gathered: AIMessageChunk) -> list[ToolCall]:
-        # TODO
-
-        pass
-    # 耦合messages的处理逻辑的方法：------
-    async def ainvoke_and_append(self, tool_call: ToolCall, messages: list[BaseMessage]):
-        # ainvoke并调用append_tool_message
-        # TODO
-
-        pass
-    def invoke_and_append(self, tool_call: ToolCall, messages: list[BaseMessage]):
-        # invoke并调用append_tool_message
-        # TODO
-
-        pass
-    @staticmethod
-    def append_tool_message(tool_call: ToolCall, tool_message: ToolMessage, list[BaseMessage]):
-        # 先调用_append_tool_call，然后根据其返回ToolCall决定下一步
-        # 为透传的同步工具调用：tool_message append到messages
-        # 为async_tool_updated调用：用tool_message的content创建符合async_tool_updated产出的ToolMessage的消息然后append到messages
-        # TODO
-
-        pass
-    @staticmethod
-    def _append_tool_call(tool_call: ToolCall, messages: list[BaseMessage]) -> ToolCall:
-        # 将tool_call无重复追加到最后一条AIMessage的tool_calls或者新建一条空的AIMessage(tool_calls=tool_calls)
-        # 对于对应同步工具的tool_call,直接追加tool_call本身；对于对应异步工具的tool_call, 追加的tool_call的name应为async_tool_updated，id为原始tool_call id加一段辨识字符串，args应为{"source_call_id":原始tool_call id}
-        # 返回实际被追加的工具调用
-        # TODO
-
-        pass
-    # ------
-    def _create_assist_tools(self):
-        return [
-            self._create_async_tool_updated_tool(),
-            self._create_id_to_async_tool_status_tool(),
-            self._create_subscribe_tool(),
-            self._create_unsubscribe_tool(),
-            self._create_stop_tool(),
-        ]
-
-    def _create_async_tool_updated_tool(self) -> BaseTool:
-        @tool("async_tool_updated")
-        def async_tool_updated(
-            source_call_id: str,
-        ) -> str:
-            """部分工具被调用时会返回tool_call id，这些工具为异步工具。异步工具会不断通过该工具产生新的输出：该工具输入异步工具被调用时返回的tool_call id，输出对应异步工具新的输出。该工具由系统调用，你不能主动调用该工具。如果对话历史中包含一条工具消息，并且该工具消息的结果尚未汇报给用户，那么你的下一次回复必须提到这个工具结果。如果同时还有一条更新的用户消息，那么需要同时回应两者：先简要汇报工具更新，再对用户消息作出回复。
-
-            Args:
-                source_call_id: 异步工具调用的tool_call id。
-            """
-            # 系统中创建ToolMessage时包含 {"running": bool, "tool_output": str}
-            return "这个工具不能被主动调用。"
-
-        return async_tool_updated
-
-    def _create_id_to_async_tool_status_tool(self) -> BaseTool:
-        @tool("id_to_async_tool_status")
-        async def id_to_async_tool_status(source_call_id: str) -> str:
-            """查询异步工具调用的最新运行状态。
-
-            Args:
-                source_call_id: 异步工具调用的tool_call id。
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"异步工具调用{source_call_id不存在}"
-            tool_status = await run.tool_class.astatus(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return {
-                "running": run.running
-                "status": tool_status
-            }
-
-        return id_to_async_tool_status
-
-    def _create_subscribe_tool(self) -> BaseTool:
-        @tool("subscribe_async_tool")
-        async def subscribe_async_tool(source_call_id: str) -> str:
-            """订阅异步工具调用的后续主动更新。被订阅的异步工具会使用async_tool_updated返回过程性输出。
-
-            Args:
-                source_call_id: 原始异步工具调用的tool_call id。
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"异步工具调用{source_call_id不存在}"
-            run.subscribed = True
-            await run.tool_class.asubscribe(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return f"订阅了异步工具{source_call_id}"
-
-        return subscribe_async_tool
-
-    def _create_unsubscribe_tool(self) -> BaseTool:
-        @tool("unsubscribe_async_tool")
-        async def unsubscribe_async_tool(source_call_id: str) -> str:
-            """取消订阅异步工具调用的后续主动更新。取消订阅的异步工具只会使用async_tool_updated返回其最终结果。
-
-            Args:
-                source_call_id: 原始异步工具调用的tool_call id。
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"异步工具调用{source_call_id不存在}"
-            run.subscribed = False
-            await run.tool_class.aunsubscribe(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            return f"取消订阅了异步工具{source_call_id}"
-
-        return unsubscribe_async_tool
-
-    def _create_stop_tool(self) -> BaseTool:
-        @tool("stop_async_tool")
-        async def stop_async_tool(source_call_id: str) -> str:
-            """终止仍在运行的异步工具调用。
-
-            Args:
-                source_call_id: 原始异步工具调用的tool_call id。
-            """
-            run = self._id_to_tool_runs.get(source_call_id)
-            if run is None or not isinstance(run, AsyncToolRun):
-                return f"异步工具调用{source_call_id不存在}"
-            await run.tool_class.astop(
-                run.tool_input,
-                run.tool_state,
-                self.state,
-            )
-            run.task.cancel()
-            return f"终止了异步工具{source_call_id}"
-
-        return stop_async_tool
-```
-# 实现
-
-### 实现位置
-
-Tool和ToolEngine及相关类型都放到`src/xtalk/models/agents/tools/core.py`，并在`src/xtalk/models/agents/tools/__init__.py`中导出必要类型（用于新建工具的类型、Agent会用的类型）；`src/xtalk/models/agents/tools/utils.py`中必要内容也迁移到core.py；然后根据 `### LLM Agent如何用ToolEngine` 更新src/xtalk/models/agents/experimental.py
-
-### LLM Agent如何用ToolEngine
-
-#### # __init__
-
-```python
-self._base_tools = tools
-self.tool_engine = ToolEngine(
-    tools=tools or [],
+engine = ToolEngine(
+    tools=[AddTool, SearchTool],
     state={},
 )
-self.model_with_tools = self.tool_engine.bind(self.model)
+model_with_tools = engine.bind(model)
 
-self._human_input_finished = True
-self._last_partial_human_text = ""
-self._active_partial_human_index: int | None = None
-self._active_partial_human_prefix = ""
-
-self._async_tool_update_queue: asyncio.Queue[AgentOutput] = asyncio.Queue()
-self.tool_engine.on_async_tool_update(self._on_async_tool_update)
-```
-
-#### # _stream_messages
-
-```python
-async def _stream_messages(self) -> AsyncIterator[AgentOutput]:
-    while True:
-        gathered = None
-
-        async for chunk in self.model_with_tools.astream(self.messages):
-            text = self.content_to_text(chunk.content)
-            if text:
-                yield text
-            gathered = chunk if gathered is None else gathered + chunk
-
-        tool_calls = ToolEngine.extract_tool_calls(gathered)
-        if not tool_calls:
-            return
-
-        for tool_call in tool_calls:
-            yield tool_call
-
-            tool_message = await self.tool_engine.ainvoke_and_append(
-                tool_call,
-                self._chat_history.messages,
-            )
-
-            yield build_tool_call_result(
-                tool_call=tool_call,
-                result_content=str(tool_message.content),
-            )
-```
-
-#### # async tool update callback
-
-```python
-def _on_async_tool_update(
-    self,
-    tool_call: ToolCall,
-    tool_message: ToolMessage,
-) -> None:
-    ToolEngine.append_tool_message(
-        tool_call,
-        tool_message,
-        self._chat_history.messages,
+message = await engine.ainvoke(
+    ToolCall(
+        id="call-add-1",
+        name="add",
+        args={"left": 2, "right": 3},
     )
-
-    if not self._human_input_finished:
-        return
-
-    self._async_tool_update_queue.put_nowait(
-        build_tool_call_result(
-            tool_call=tool_call,
-            result_content=str(tool_message.content),
-        )
-    )
+)
 ```
 
-#### # _loop_runner
+`bind()` 只负责向模型暴露工具 schema。原生工具必须由 ToolEngine 执行，
+不能绕过引擎直接调用绑定包装器。
+
+### 调用语义
+
+- `BaseTool`：调用 LangChain 的 `ainvoke()`，并保存文本化结果。
+- `SyncTool`：校验输入、等待最终输出并返回 ToolMessage。
+- `AsyncTool`：校验输入、调用 `aemit_initial()`、保存 `AsyncToolRun`、启动
+  后台更新任务，然后立即返回初始 ToolMessage。
+
+`invoke()` 只适用于同步上下文中的 `BaseTool` 和 `SyncTool`。已有事件循环时
+应使用 `await ainvoke()`；`AsyncTool` 必须使用持久事件循环中的
+`await ainvoke()`，否则后台更新无法继续运行。
+
+每个调用 ID 会在执行前预留。并发使用同一个 ID，或重复使用已完成调用的
+ID，都会抛出 `ValueError`。
+
+### 异步运行记录
+
+`AsyncToolRun` 保存：
+
+- 最新的 `Running` 或 `Finished`；
+- 工具类、输入和调用级状态；
+- `subscribed`、`running` 标志；
+- 后台 `task`；
+- 生命周期锁和后台异常。
+
+后台任务异常会记录到运行对象，并被读取以避免未处理 Task 警告。
+
+## 辅助工具
+
+只要存在一个 `AsyncTool`，ToolEngine 就会注册五个辅助工具：
+
+- `async_tool_updated`：仅供系统写入异步更新，不向 LLM 暴露调用 schema。
+- `id_to_async_tool_status`：查询运行状态、工具状态和错误。
+- `subscribe_async_tool`：订阅过程更新，并返回最新已知结果。
+- `unsubscribe_async_tool`：停止接收过程更新；最终结果仍会发送。
+- `stop_async_tool`：调用 `astop()` 并取消后台任务。
+
+后四个控制工具会绑定给模型。`async_tool_updated` 只作为 ToolCall/ToolMessage
+协议名称保留，避免模型把系统内部通知误当成可主动调用的工具。
+状态查询只用于用户明确要求查看当前状态的场景，不应被模型用于轮询。订阅
+成功后，模型应停止调用工具并等待系统主动推送更新。
+
+`subscribe_by_default=True` 会在异步任务启动前调用订阅Hook。未订阅的调用只
+主动反馈 `Finished`；已订阅调用会反馈 `Running` 和 `Finished`。
+
+## 消息历史协议
+
+对于每条 ToolMessage，历史中必须存在 ID 匹配的 AI ToolCall。ToolEngine 的
+`append_tool_message()` 和 `ainvoke_and_append()` 会维护这一约束，并拒绝：
+
+- 空调用 ID；
+- ToolCall 与 ToolMessage ID 不一致；
+- 同一 ID 的重复 ToolMessage；
+- 同一 ID 对应不同名称或参数。
+
+异步更新使用新的 `async_tool_updated` ToolCall。其参数包含原始
+`source_call_id`，消息内容为：
+
+```json
+{
+  "running": true,
+  "tool_output": "正在检索第一页"
+}
+```
+
+最终更新把 `running` 设为 `false`，并把 `ToolOutput.to_content()` 的结果写入
+`tool_output`。
+
+## ExperimentalAgent 接入
+
+`ExperimentalAgent` 为每个会话创建独立 ToolEngine，绑定模型，并注册异步
+更新回调。没有模型生成时，回调把合法的 ToolCall/ToolMessage 写入历史并
+通知会话 loop；模型正在生成时，更新会暂存到当前生成结束后再写入，避免
+同一结果被当前工具调用链和后续 loop 重复消费。
+
+当多条工具更新在模型开始生成前连续到达时，Agent 会保留每条下游事件，
+但合并成一次模型生成。生成过程中到达的新更新会触发下一次生成。
+用户请求使用绑定工具的模型；后台更新触发的主动汇报使用不绑定工具的模型，
+避免模型根据历史中的系统 ToolCall 再次调用内部通知或状态工具。
+
+### 与 ASR partial 并发
+
+ASR partial 会作为 HumanMessage 进入历史。如果工具更新插入到未完成的用户
+消息后面，后续 partial：
+
+- 以前一条 partial 为前缀时，只追加新增后缀；
+- 不再以前一条 partial 为前缀时，追加完整的新文本；
+- final 与最后一条 partial 相同时，不追加空 HumanMessage；
+- ASR final 生成结束、异常或取消时，都会复位生成状态。
+
+用户尚未说完时，异步更新只写入历史，不立即触发模型生成。ASR final 到达
+后，模型会同时看到工具更新和完整用户输入。
+
+## 关闭
+
+会话关闭时必须调用：
 
 ```python
-async def _loop_runner(self) -> AsyncIterator[AgentOutput]:
-    while True:
-        if self.proactive and len(self.messages) == 1:
-            self._chat_history.append_message(HumanMessage(content="你好。"))
-            async for item in self._stream_greeting():
-                yield item
-            break
-
-        try:
-            item = await asyncio.wait_for(
-                self._async_tool_update_queue.get(),
-                timeout=0.2,
-            )
-            yield item
-        except asyncio.TimeoutError:
-            pass
+await engine.shutdown()
 ```
 
-#### # deal with human message
+`shutdown()` 会阻止新调用，对仍运行的异步工具执行 `astop()`，取消后台
+任务并等待任务退出。重复调用 `shutdown()` 是安全的。
 
-```python
-def _append_or_update_partial_human_message(
-    self,
-    text: str,
-    *,
-    final: bool,
-) -> None:
-    if not text:
-        return
+## 当前限制
 
-    messages = self._chat_history.messages
-    active_message_is_last = (
-        self._active_partial_human_index is not None
-        and self._active_partial_human_index == len(messages) - 1
-        and isinstance(messages[-1], HumanMessage)
-    )
-
-    if active_message_is_last:
-        if text.startswith(self._active_partial_human_prefix):
-            messages[-1].content = text[len(self._active_partial_human_prefix):]
-        else:
-            messages[-1].content = text
-            self._active_partial_human_prefix = ""
-    else:
-        if self._last_partial_human_text and text.startswith(
-            self._last_partial_human_text
-        ):
-            content = text[len(self._last_partial_human_text):]
-            self._active_partial_human_prefix = self._last_partial_human_text
-        else:
-            content = text
-            self._active_partial_human_prefix = ""
-
-        self._chat_history.append_message(HumanMessage(content=content))
-        self._active_partial_human_index = len(messages) - 1
-
-    self._last_partial_human_text = text
-    self._human_input_finished = final
-
-    if final:
-        self._active_partial_human_index = None
-        self._active_partial_human_prefix = ""
-        self._last_partial_human_text = ""
-
-
-async def _handle_asr_partial(self, asr_text: str) -> AsyncIterator[AgentOutput]:
-    self._append_or_update_partial_human_message(asr_text, final=False)
-
-    if self.backchannel_model is None or self.backchannel_source_dir is None:
-        return
-
-    ...
-
-
-async def _handle_asr_final(self, asr_text: str) -> AsyncIterator[AgentOutput]:
-    self._append_or_update_partial_human_message(asr_text, final=True)
-
-    async for item in self._stream_messages():
-        yield item
-
-    self._already_backchanneled_text = ""
-    self._turn_already_to_backchannel_response = {}
-```
-
-
-## 未来拓展
-
-- LLM可更新tool的运行状态（“二次输入”）
+- 尚不支持 LLM 对运行中的工具提供“二次输入”。
+- `ToolEngineState` 的具体并发策略由应用和工具实现共同约定。
+- 真实模型对工具描述和主动更新的理解可能不同，应在单元测试之外增加可选的
+  端到端集成测试。

--- a/docs/docs/tool_design.zh.md
+++ b/docs/docs/tool_design.zh.md
@@ -111,6 +111,7 @@ class AddTool(SyncTool):
 ```python
 from collections.abc import Iterator
 from dataclasses import dataclass
+import time
 
 from xtalk.models.agents.tools import (
     AsyncTool,
@@ -131,6 +132,8 @@ class SearchInput(ToolInput):
 @dataclass
 class SearchState(ToolState):
     pages_done: int = 0
+    subscribed: bool = False
+    stopped: bool = False
 
 
 class SearchOutput(ToolOutput):
@@ -161,11 +164,54 @@ class SearchTool(AsyncTool):
         global_state: ToolEngineState,
     ) -> Iterator[ToolResult[SearchOutput]]:
         del global_state
+        time.sleep(2)  # 模拟耗时检索；默认异步桥接会在线程中执行此方法
         tool_state.pages_done = 1
         yield Running(content="正在检索第一页")
+        time.sleep(2)
         yield Finished(
             content=SearchOutput(content=f"搜索完成：{tool_input.query}")
         )
+
+    # 可选 Hook：查询状态、停止任务，以及同步订阅状态。
+    @classmethod
+    def status(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> str:
+        del tool_input, global_state
+        return f"已检索 {tool_state.pages_done} 页"
+
+    @classmethod
+    def stop(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.stopped = True
+
+    @classmethod
+    def subscribe(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.subscribed = True
+
+    @classmethod
+    def unsubscribe(
+        cls,
+        tool_input: SearchInput,
+        tool_state: SearchState,
+        global_state: ToolEngineState,
+    ) -> None:
+        del tool_input, global_state
+        tool_state.subscribed = False
 ```
 
 `emit_initial()` 必须快速返回 `Running`，且当前协议要求 `content` 包含
@@ -306,8 +352,9 @@ ID，都会抛出 `ValueError`。
 
 当多条工具更新在模型开始生成前连续到达时，Agent 会保留每条下游事件，
 但合并成一次模型生成。生成过程中到达的新更新会触发下一次生成。
-用户请求使用绑定工具的模型；后台更新触发的主动汇报使用不绑定工具的模型，
-避免模型根据历史中的系统 ToolCall 再次调用内部通知或状态工具。
+用户请求使用允许调用工具的模型。后台更新触发主动汇报时仍会绑定完整工具
+schema，使模型能够正确理解历史中的系统 ToolCall，但通过 `tool_choice="none"`
+禁止模型在该轮主动调用工具。
 
 ### 与 ASR partial 并发
 

--- a/docs/tutorial/introduce_a_new_model.md
+++ b/docs/tutorial/introduce_a_new_model.md
@@ -71,6 +71,10 @@ Notes:
 - `async_accept` is the main async runtime entrypoint.
 - `accept` bridges to `async_accept` for synchronous compatibility.
 - `clone()` should return a model instance suitable for a new session, avoiding shared mutable state across sessions.
+- Finite output streams finish the current response when their iterator ends.
+  A long-lived stream started by `loop` should also yield
+  `AgentTurnBoundary()` after each response. This triggers TTS flush and
+  response finish without ending the stream itself.
 
 ## 3. Use the New Model in Config
 

--- a/docs/tutorial/introduce_a_new_model.zh.md
+++ b/docs/tutorial/introduce_a_new_model.zh.md
@@ -71,6 +71,9 @@ class EchoAgent(Agent):
 - `async_accept` 是运行时主要使用的异步入口。
 - `accept` 桥接到 `async_accept`，用于兼容同步调用路径。
 - `clone()` 要返回新会话可用的模型实例，避免会话之间共享可变状态。
+- 普通输出流结束时会自动结束本轮回复；如果 `loop` 启动的输出流需要持续运行，
+  每次回复后应额外输出 `AgentTurnBoundary()`。它用于触发 TTS flush 和
+  response finish，不会结束输出流本身。
 
 ## 3. 让配置使用新模型
 

--- a/src/xtalk/models/agents/__init__.py
+++ b/src/xtalk/models/agents/__init__.py
@@ -1,7 +1,8 @@
-from .interfaces import Agent, AgentContext, AgentOutput
+from .interfaces import Agent, AgentContext, AgentOutput, AgentTurnBoundary
 
 __all__ = [
     "Agent",
     "AgentContext",
     "AgentOutput",
+    "AgentTurnBoundary",
 ]

--- a/src/xtalk/models/agents/experimental.py
+++ b/src/xtalk/models/agents/experimental.py
@@ -122,6 +122,9 @@ class ExperimentalAgent(Agent):
             state={},
         )
         self.model_with_tools = self.tool_engine.bind(self.model)
+        self.model_for_async_updates = (
+            self.tool_engine.bind_without_tool_calls(self.model)
+        )
         self._human_input_finished = True
         self._last_partial_human_text = ""
         self._active_partial_human_index: int | None = None
@@ -393,7 +396,11 @@ class ExperimentalAgent(Agent):
         *,
         allow_tools: bool,
     ) -> AsyncIterator[AgentOutput]:
-        streaming_model = self.model_with_tools if allow_tools else self.model
+        streaming_model = (
+            self.model_with_tools
+            if allow_tools
+            else self.model_for_async_updates
+        )
         while True:
             response_message = AIMessage(content="")
             gathered = None

--- a/src/xtalk/models/agents/experimental.py
+++ b/src/xtalk/models/agents/experimental.py
@@ -1,5 +1,17 @@
-from .interfaces import Agent, AgentContext, AgentOutput, ChatHistory
+from .interfaces import (
+    Agent,
+    AgentContext,
+    AgentOutput,
+    AgentTurnBoundary,
+    ChatHistory,
+)
 from .tools.utils import build_tool_call_result
+from .tools import (
+    AsyncTool,
+    SyncTool,
+    Tool,
+    ToolEngine,
+)
 from langchain.chat_models.base import BaseChatModel
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import (
@@ -62,7 +74,7 @@ class ExperimentalAgent(Agent):
         model: BaseChatModel | dict[str, Any],
         backchannel_model: BaseChatModel | dict[str, Any] | None = None,
         backchannel_source_dir: str | Path | None = None,
-        tools: list[BaseTool | Callable[[], BaseTool]] | None = None,
+        tools: list[Tool | Callable[[], Tool]] | None = None,
         system_prompt: str = "",
         proactive: bool = True,
     ) -> None:
@@ -76,7 +88,7 @@ class ExperimentalAgent(Agent):
             Optional model used to judge backchannel insertion.
         backchannel_source_dir : str | Path | None, optional
             Directory containing backchannel assets.
-        tools : list[BaseTool | Callable[[], BaseTool]] | None, optional
+        tools : list[Tool | Callable[[], Tool]] | None, optional
             Optional tool instances or factories.
         system_prompt : str, optional
             Additional system prompt appended after the base prompt.
@@ -104,7 +116,14 @@ class ExperimentalAgent(Agent):
         )
 
         self._base_tools = tools
-        self.tools = self._init_tools(tools) if tools else []
+        self.tools = self._init_tools(tools or [])
+        self.tool_engine = ToolEngine(
+            tools=self.tools,
+            state={},
+        )
+        self.model_with_tools = self.tool_engine.bind(self.model)
+        self._async_tool_update_queue: asyncio.Queue[AgentOutput] = asyncio.Queue()
+        self.tool_engine.on_async_tool_update(self._on_async_tool_update)
 
         # every time remove this prefix before judging backchannel
         self._already_backchanneled_text = ""
@@ -181,24 +200,32 @@ class ExperimentalAgent(Agent):
     ###
 
     async def _loop_runner(self) -> AsyncIterator[AgentOutput]:
+        # greeting: AI take initiative to call user on session start
+        if self.proactive and len(self.messages) == 1:
+            self._chat_history.append_message(HumanMessage(content="你好。"))
+            collector = TextCollector()
+            async for item in self._stream_and_collect_text(
+                self._stream_greeting(), collector
+            ):
+                yield item
+            yield AgentTurnBoundary()
+
         while True:
-            # greeting: AI take initiative to call user on session start
-            if self.proactive and len(self.messages) == 1:
-                self._chat_history.append_message(HumanMessage(content="你好。"))
-                collector = TextCollector()
-                async for item in self._stream_and_collect_text(
-                    self._stream_greeting(), collector
-                ):
-                    yield item
-                # since this should only be triggered once and no other logic in the loop, break temporarily
-                break
-            # avoid blocking the event loop
-            await asyncio.sleep(0.2)
+            item = await self._async_tool_update_queue.get()
+            yield item
+
+            while self._asr_final_response_generating:
+                await asyncio.sleep(0.05)
+
+            async for generated_item in self._stream_messages():
+                yield generated_item
+            yield AgentTurnBoundary()
 
     async def _handle_asr_final(self, asr_text: str) -> AsyncIterator[AgentOutput]:
         self._chat_history.append_message(HumanMessage(content=asr_text))
         async for item in self._stream_messages():
             yield item
+        yield AgentTurnBoundary()
         # reset backchannel state
         self._already_backchanneled_text = ""
         self._turn_already_to_backchannel_response = {}
@@ -283,11 +310,10 @@ class ExperimentalAgent(Agent):
                 yield text
 
     async def _stream_messages(self) -> AsyncIterator[AgentOutput]:
-        model_with_tools = self.model.bind_tools(self.tools) if self.tools else self.model
         while True:
             response_message = AIMessage(content="")
             gathered = None
-            async for chunk in model_with_tools.astream(self.messages):
+            async for chunk in self.model_with_tools.astream(self.messages):
                 text = self.content_to_text(chunk.content)
                 if text:
                     response_message.content += text
@@ -306,12 +332,44 @@ class ExperimentalAgent(Agent):
             self._chat_history.append_message(response_message)
             for tool_call in tool_calls:
                 yield tool_call
-                tool_result = await self._invoke_tool(tool_call)
-                self._chat_history.append_message(tool_result)
+                try:
+                    tool_result = await self.tool_engine.ainvoke_and_append(
+                        tool_call,
+                        self._chat_history.messages,
+                    )
+                except Exception as exc:
+                    tool_result = ToolMessage(
+                        content=f"Error invoking tool: {exc}",
+                        tool_call_id=tool_call["id"],
+                        name=tool_call["name"],
+                    )
+                    ToolEngine.append_tool_message(
+                        tool_call,
+                        tool_result,
+                        self._chat_history.messages,
+                    )
                 yield build_tool_call_result(
                     tool_call=tool_call,
                     result_content=str(tool_result.content),
                 )
+
+    def _on_async_tool_update(
+        self,
+        tool_call: ToolCall,
+        tool_message: ToolMessage,
+    ) -> None:
+        """Save an asynchronous tool update and notify the agent loop."""
+        ToolEngine.append_tool_message(
+            tool_call=tool_call,
+            tool_message=tool_message,
+            messages=self._chat_history.messages,
+        )
+        self._async_tool_update_queue.put_nowait(
+            build_tool_call_result(
+                tool_call=tool_call,
+                result_content=str(tool_message.content),
+            )
+        )
 
     def _load_backchannel_audio(self, backchannel_content: str) -> bytes | None:
         map_path = self.backchannel_source_dir / "map.json"
@@ -340,30 +398,29 @@ class ExperimentalAgent(Agent):
 
     # Tools
     @staticmethod
-    def _init_tools(tools: list[BaseTool | Callable[[], BaseTool]]) -> list[BaseTool]:
-        initialized_tools = []
-        for tool in tools:
-            if isinstance(tool, BaseTool):
-                initialized_tools.append(tool)
-            elif callable(tool):
-                initialized_tools.append(tool())
-        return initialized_tools
+    def _init_tools(
+        tools: list[Tool | Callable[[], Tool]],
+    ) -> list[Tool]:
+        """Initialize tool instances, native tool classes, and factories."""
 
-    async def _invoke_tool(
-        self,
-        tool_call: ToolCall,
-    ):
-        tool = next((t for t in self.tools if t.name == tool_call["name"]), None)
-        if not tool:
-            return ToolMessage(
-                content=f"Tool {tool_call['name']} not found",
-                tool_call_id=tool_call["id"],
-            )
-        try:
-            result: ToolMessage = await tool.ainvoke(tool_call["args"])
-            return result
-        except Exception as e:
-            return ToolMessage(
-                content=f"Error invoking tool {tool_call['name']}: {str(e)}",
-                tool_call_id=tool_call["id"],
-            )
+        initialized_tools: list[Tool] = []
+        for tool_item in tools:
+            if isinstance(tool_item, BaseTool):
+                initialized_tools.append(tool_item)
+                continue
+            if (
+                isinstance(tool_item, type)
+                and issubclass(tool_item, (AsyncTool, SyncTool))
+            ):
+                initialized_tools.append(tool_item)
+                continue
+            if callable(tool_item):
+                initialized_tool = tool_item()
+                if isinstance(initialized_tool, BaseTool) or (
+                    isinstance(initialized_tool, type)
+                    and issubclass(initialized_tool, (SyncTool, AsyncTool))
+                ):
+                    initialized_tools.append(initialized_tool)
+                    continue
+            raise TypeError(f"Unsupported tool: {tool_item!r}")
+        return initialized_tools

--- a/src/xtalk/models/agents/experimental.py
+++ b/src/xtalk/models/agents/experimental.py
@@ -122,6 +122,10 @@ class ExperimentalAgent(Agent):
             state={},
         )
         self.model_with_tools = self.tool_engine.bind(self.model)
+        self._human_input_finished = True
+        self._last_partial_human_text = ""
+        self._active_partial_human_index: int | None = None
+        self._active_partial_human_prefix = ""
         self._async_tool_update_queue: asyncio.Queue[AgentOutput] = asyncio.Queue()
         self.tool_engine.on_async_tool_update(self._on_async_tool_update)
 
@@ -221,8 +225,53 @@ class ExperimentalAgent(Agent):
                 yield generated_item
             yield AgentTurnBoundary()
 
+    def _append_or_update_partial_human_message(
+        self,
+        text: str,
+        *,
+        final: bool,
+    ) -> None:
+        if not text:
+            self._human_input_finished = final
+            if final:
+                self._active_partial_human_index = None
+                self._active_partial_human_prefix = ""
+                self._last_partial_human_text = ""
+            return
+        messages = self._chat_history.messages
+        active_message_is_last = (
+            self._active_partial_human_index is not None
+            and self._active_partial_human_index == len(messages) - 1
+            and isinstance(messages[-1], HumanMessage)
+        )
+        if active_message_is_last:
+            if text.startswith(self._active_partial_human_prefix):
+                messages[-1].content = text[len(self._active_partial_human_prefix) :]
+            else:
+                messages[-1].content = text
+                self._active_partial_human_prefix = ""
+        else:
+            if self._last_partial_human_text and text.startswith(
+                self._last_partial_human_text
+            ):
+                content = text[len(self._last_partial_human_text) :]
+                self._active_partial_human_prefix = self._last_partial_human_text
+            else:
+                content = text
+                self._active_partial_human_prefix = ""
+
+            self._chat_history.append_message(HumanMessage(content=content))
+            self._active_partial_human_index = len(messages) - 1
+        self._last_partial_human_text = text
+        self._human_input_finished = final
+
+        if final:
+            self._active_partial_human_index = None
+            self._active_partial_human_prefix = ""
+            self._last_partial_human_text = ""
+
     async def _handle_asr_final(self, asr_text: str) -> AsyncIterator[AgentOutput]:
-        self._chat_history.append_message(HumanMessage(content=asr_text))
+        self._append_or_update_partial_human_message(asr_text, final=True)
         async for item in self._stream_messages():
             yield item
         yield AgentTurnBoundary()
@@ -242,6 +291,7 @@ class ExperimentalAgent(Agent):
 
     # backchannel
     async def _handle_asr_partial(self, asr_text: str) -> AsyncIterator[AgentOutput]:
+        self._append_or_update_partial_human_message(asr_text, final=False)
         if self.backchannel_model is None or self.backchannel_source_dir is None:
             return
         # remove prefix from asr text to avoid repeated backchannel for the same content
@@ -364,6 +414,8 @@ class ExperimentalAgent(Agent):
             tool_message=tool_message,
             messages=self._chat_history.messages,
         )
+        if not self._human_input_finished:
+            return
         self._async_tool_update_queue.put_nowait(
             build_tool_call_result(
                 tool_call=tool_call,

--- a/src/xtalk/models/agents/experimental.py
+++ b/src/xtalk/models/agents/experimental.py
@@ -127,6 +127,10 @@ class ExperimentalAgent(Agent):
         self._active_partial_human_index: int | None = None
         self._active_partial_human_prefix = ""
         self._async_tool_update_queue: asyncio.Queue[AgentOutput] = asyncio.Queue()
+        self._model_generation_lock = asyncio.Lock()
+        self._pending_async_tool_updates: list[
+            tuple[ToolCall, ToolMessage, AgentOutput]
+        ] = []
         self.tool_engine.on_async_tool_update(self._on_async_tool_update)
 
         # every time remove this prefix before judging backchannel
@@ -154,9 +158,11 @@ class ExperimentalAgent(Agent):
                 yield item
         if context_type == "asr_final":
             self._asr_final_response_generating = True
-            async for item in self._handle_asr_final(context_data["text"]):
-                yield item
-            self._asr_final_response_generating = False
+            try:
+                async for item in self._handle_asr_final(context_data["text"]):
+                    yield item
+            finally:
+                self._asr_final_response_generating = False
         if context_type == "asr_partial":
             async for item in self._handle_asr_partial(context_data["text"]):
                 yield item
@@ -216,12 +222,18 @@ class ExperimentalAgent(Agent):
 
         while True:
             item = await self._async_tool_update_queue.get()
-            yield item
+            while True:
+                yield item
 
-            while self._asr_final_response_generating:
-                await asyncio.sleep(0.05)
+                while self._asr_final_response_generating:
+                    await asyncio.sleep(0.05)
 
-            async for generated_item in self._stream_messages():
+                try:
+                    item = self._async_tool_update_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+
+            async for generated_item in self._stream_messages(allow_tools=False):
                 yield generated_item
             yield AgentTurnBoundary()
 
@@ -260,8 +272,11 @@ class ExperimentalAgent(Agent):
                 content = text
                 self._active_partial_human_prefix = ""
 
-            self._chat_history.append_message(HumanMessage(content=content))
-            self._active_partial_human_index = len(messages) - 1
+            if content:
+                self._chat_history.append_message(HumanMessage(content=content))
+                self._active_partial_human_index = len(messages) - 1
+            else:
+                self._active_partial_human_index = None
         self._last_partial_human_text = text
         self._human_input_finished = final
 
@@ -359,11 +374,30 @@ class ExperimentalAgent(Agent):
             if text:
                 yield text
 
-    async def _stream_messages(self) -> AsyncIterator[AgentOutput]:
+    async def _stream_messages(
+        self,
+        *,
+        allow_tools: bool = True,
+    ) -> AsyncIterator[AgentOutput]:
+        async with self._model_generation_lock:
+            try:
+                async for item in self._stream_messages_unlocked(
+                    allow_tools=allow_tools,
+                ):
+                    yield item
+            finally:
+                self._flush_pending_async_tool_updates()
+
+    async def _stream_messages_unlocked(
+        self,
+        *,
+        allow_tools: bool,
+    ) -> AsyncIterator[AgentOutput]:
+        streaming_model = self.model_with_tools if allow_tools else self.model
         while True:
             response_message = AIMessage(content="")
             gathered = None
-            async for chunk in self.model_with_tools.astream(self.messages):
+            async for chunk in streaming_model.astream(self.messages):
                 text = self.content_to_text(chunk.content)
                 if text:
                     response_message.content += text
@@ -409,6 +443,26 @@ class ExperimentalAgent(Agent):
         tool_message: ToolMessage,
     ) -> None:
         """Save an asynchronous tool update and notify the agent loop."""
+
+        output = build_tool_call_result(
+            tool_call=tool_call,
+            result_content=str(tool_message.content),
+        )
+        if self._model_generation_lock.locked():
+            self._pending_async_tool_updates.append(
+                (tool_call, tool_message, output)
+            )
+            return
+        self._record_async_tool_update(tool_call, tool_message, output)
+
+    def _record_async_tool_update(
+        self,
+        tool_call: ToolCall,
+        tool_message: ToolMessage,
+        output: AgentOutput,
+    ) -> None:
+        """Append one deferred update and wake the loop when appropriate."""
+
         ToolEngine.append_tool_message(
             tool_call=tool_call,
             tool_message=tool_message,
@@ -416,12 +470,15 @@ class ExperimentalAgent(Agent):
         )
         if not self._human_input_finished:
             return
-        self._async_tool_update_queue.put_nowait(
-            build_tool_call_result(
-                tool_call=tool_call,
-                result_content=str(tool_message.content),
-            )
-        )
+        self._async_tool_update_queue.put_nowait(output)
+
+    def _flush_pending_async_tool_updates(self) -> None:
+        """Move updates deferred during generation into history and the queue."""
+
+        pending_updates = self._pending_async_tool_updates
+        self._pending_async_tool_updates = []
+        for tool_call, tool_message, output in pending_updates:
+            self._record_async_tool_update(tool_call, tool_message, output)
 
     def _load_backchannel_audio(self, backchannel_content: str) -> bytes | None:
         map_path = self.backchannel_source_dir / "map.json"

--- a/src/xtalk/models/agents/interfaces.py
+++ b/src/xtalk/models/agents/interfaces.py
@@ -23,7 +23,12 @@ class AgentContext(TypedDict):
     data: dict[str, Any]
 
 
-AgentOutput = Union[str, ToolCall, ToolCallResult]
+@dataclass(frozen=True)
+class AgentTurnBoundary:
+    """Mark the end of one agent response segment."""
+
+
+AgentOutput = Union[str, ToolCall, ToolCallResult, AgentTurnBoundary]
 T = TypeVar("T")
 
 

--- a/src/xtalk/models/agents/tools/__init__.py
+++ b/src/xtalk/models/agents/tools/__init__.py
@@ -15,6 +15,9 @@ from .core import (
     ToolOutput,
     ToolResult,
     ToolState,
+    ToolRun,
+    AsyncToolRun,
+    ToolEngine,
 )
 
 from .speech_control import (
@@ -40,6 +43,9 @@ __all__ = [
     "ToolOutput",
     "ToolResult",
     "ToolState",
+    "ToolRun",
+    "AsyncToolRun",
+    "ToolEngine",
     "build_set_voice_tool",
     "build_set_emotion_tool",
     "build_silence_tool",

--- a/src/xtalk/models/agents/tools/__init__.py
+++ b/src/xtalk/models/agents/tools/__init__.py
@@ -4,6 +4,19 @@ Includes tool definitions/factories for LLM tool-calling usage or prompt docs
 that help the model produce structured tool-call outputs.
 """
 
+from .core import (
+    AsyncTool,
+    Finished,
+    Running,
+    SyncTool,
+    Tool,
+    ToolEngineState,
+    ToolInput,
+    ToolOutput,
+    ToolResult,
+    ToolState,
+)
+
 from .speech_control import (
     build_set_voice_tool,
     build_set_emotion_tool,
@@ -17,6 +30,16 @@ from .retrievers import (
 )
 
 __all__ = [
+    "AsyncTool",
+    "Finished",
+    "Running",
+    "SyncTool",
+    "Tool",
+    "ToolEngineState",
+    "ToolInput",
+    "ToolOutput",
+    "ToolResult",
+    "ToolState",
     "build_set_voice_tool",
     "build_set_emotion_tool",
     "build_silence_tool",

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -1,4 +1,4 @@
-"""X-Talk 原生同步、异步工具的基础类型。"""
+"""Core types for X-Talk native synchronous and asynchronous tools."""
 
 from __future__ import annotations
 
@@ -36,34 +36,35 @@ from pydantic import BaseModel
 
 
 class ToolInput(BaseModel):
-    """X-Talk 原生工具输入模型的基类。"""
+    """Base input model for X-Talk native tools."""
 
 
 class ToolOutput(BaseModel):
-    """X-Talk 原生工具输出模型的基类。"""
+    """Base output model for X-Talk native tools."""
 
     def to_content(self) -> str:
-        """将结构化结果序列化为 ToolMessage 可保存的文本。"""
+        """Serialize the structured result for storage in a ToolMessage."""
 
         return self.model_dump_json()
 
 
 class _TextToolOutput(ToolOutput):
-    """将外部工具结果包装为原生工具输出。"""
+    """Wrap an external tool result as a native tool output."""
 
     content: str
 
     def to_content(self) -> str:
-        """返回外部工具的文本结果。"""
+        """Return the external tool result as text."""
 
         return self.content
 
 
 @dataclass
 class ToolState:
-    """一次异步工具调用独享的可变状态。
-    call_id 本次工具调用的唯一标识。
-    metadata 供具体工具保存进度等自定义状态的容器。
+    """Mutable state owned by one asynchronous tool call.
+
+    ``call_id`` uniquely identifies the call. ``metadata`` stores custom
+    progress and state owned by the concrete tool.
     """
 
     call_id: str = ""
@@ -75,8 +76,9 @@ TO = TypeVar("TO", bound=ToolOutput)
 
 @dataclass(frozen=True)
 class Running:
-    """异步工具仍在运行时产生的文本更新。
-    content 可写入 ToolMessage 的阶段性状态。
+    """Text update emitted while an asynchronous tool is still running.
+
+    ``content`` contains the intermediate state stored in a ToolMessage.
     """
 
     content: str
@@ -84,8 +86,9 @@ class Running:
 
 @dataclass(frozen=True)
 class Finished(Generic[TO]):
-    """异步工具完成时产生的结构化最终结果。
-    content 具体工具定义的 ``ToolOutput`` 子类实例。
+    """Structured final result emitted by an asynchronous tool.
+
+    ``content`` is the concrete ``ToolOutput`` instance declared by the tool.
     """
 
     content: TO
@@ -94,7 +97,7 @@ class Finished(Generic[TO]):
 ToolResult: TypeAlias = Running | Finished[TO]
 ToolEngineState: TypeAlias = Any
 
-# StopIteration 不能直接通过 asyncio Future 传播，因此用哨兵表示迭代结束。
+# StopIteration cannot cross an asyncio Future, so use a sentinel instead.
 _SENTINEL = object()
 _ASYNC_TOOL_UPDATED_NAME = "async_tool_updated"
 _ASYNC_TOOL_STATUS_NAME = "id_to_async_tool_status"
@@ -104,11 +107,17 @@ _STOP_ASYNC_TOOL_NAME = "stop_async_tool"
 
 
 def _next_or_sentinel(iterator: Iterator[ToolResult[TO]]) -> ToolResult[TO] | object:
-    """取出同步迭代器的下一项，耗尽时返回哨兵对象。
+    """Return the next iterator item or the exhaustion sentinel.
 
-    iterator 同步工具更新迭代器。
+    Parameters
+    ----------
+    iterator : Iterator[ToolResult[TO]]
+        Synchronous tool update iterator.
 
-    ToolResult[TO] 下一项工具结果，或表示迭代结束的 ``_SENTINEL``。
+    Returns
+    -------
+    ToolResult[TO] | object
+        The next result or ``_SENTINEL`` when the iterator is exhausted.
     """
 
     try:
@@ -118,7 +127,7 @@ def _next_or_sentinel(iterator: Iterator[ToolResult[TO]]) -> ToolResult[TO] | ob
 
 
 class _NativeTool(ABC):
-    """同步和异步原生工具共用的内部基类。"""
+    """Internal base class shared by native synchronous and async tools."""
 
     name: ClassVar[str | None] = None
 
@@ -140,11 +149,11 @@ class _NativeTool(ABC):
 
 
 class AsyncTool(_NativeTool):
-    """可产生阶段性更新的长耗时工具基类。
+    """Base class for long-running tools that emit incremental updates.
 
-    子类至少实现 ``emit_initial`` 和 ``emit_updates``。默认的异步方法会
-    在线程中执行对应同步方法；如果底层 SDK 本身提供 async API，子类可
-    覆写相应的 ``a*`` 方法，避免不必要的线程切换。
+    Subclasses implement ``emit_initial`` and ``emit_updates``. Default async
+    methods run their synchronous counterparts in worker threads. Tools backed
+    by native async SDKs may override the corresponding ``a*`` methods.
     """
 
     subscribe_by_default: ClassVar[bool] = False
@@ -153,10 +162,10 @@ class AsyncTool(_NativeTool):
     output_type: ClassVar[type[ToolOutput]]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """在具体子类创建时，从方法注解推断其三种数据类型。
+        """Infer input, state, and output types when a subclass is created.
 
-        工具作者只需写方法注解，无须手动声明 ``input_type``、
-        ``state_type`` 和 ``output_type``。抽象中间类会跳过推断。
+        Tool authors only need method annotations. Abstract intermediate
+        classes skip inference.
         """
 
         super().__init_subclass__(**kwargs)
@@ -193,7 +202,7 @@ class AsyncTool(_NativeTool):
             raw_method = cls.__dict__.get(method_name)
             if raw_method is None:
                 continue
-            # 类字典中的 classmethod 是描述符，需要取出底层函数的注解。
+            # classmethod values are descriptors; inspect the wrapped function.
             method = (
                 raw_method.__func__
                 if isinstance(raw_method, classmethod)
@@ -228,7 +237,7 @@ class AsyncTool(_NativeTool):
 
     @classmethod
     def _infer_output_type(cls, annotation: Any) -> type[ToolOutput] | None:
-        """递归寻找返回注解中包含的具体 ToolOutput 类型。"""
+        """Find the concrete ToolOutput type inside a return annotation."""
 
         if isinstance(annotation, type) and issubclass(annotation, ToolOutput):
             return annotation
@@ -255,10 +264,11 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> Running:
-        """立即生成满足 LLM 工具调用协议的首条结果。
+        """Immediately produce the first protocol-compliant tool result.
 
-        部分模型要求每个 tool call 后立刻出现对应的 ToolMessage，
-        因此这里先返回 ``Running``，真正工作由 ``emit_updates`` 继续执行。
+        Some models require every tool call to be followed immediately by a
+        ToolMessage. This method returns ``Running`` before the actual work
+        continues through ``emit_updates``.
         """
 
         raise NotImplementedError
@@ -271,7 +281,7 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> Running:
-        """在线程中生成首条结果，避免阻塞事件循环。"""
+        """Produce the initial result in a worker thread."""
 
         return await asyncio.to_thread(
             cls.emit_initial,
@@ -289,7 +299,7 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> Iterator[ToolResult[ToolOutput]]:
-        """依次产生阶段性更新，并以一个最终结果结束。"""
+        """Yield incremental updates and end with one final result."""
 
         raise NotImplementedError
 
@@ -300,7 +310,7 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> AsyncIterator[ToolResult[ToolOutput]]:
-        """把同步更新迭代器桥接成非阻塞的异步迭代器。"""
+        """Bridge the synchronous update iterator into an async iterator."""
 
         iterator = cls.emit_updates(tool_input, tool_state, global_state)
         while True:
@@ -316,10 +326,10 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> str:
-        """返回一次异步调用的最新可读状态。
+        """Return the latest human-readable status for one call.
 
-        具体工具可覆写该钩子，为 LLM 的主动状态查询提供信息。默认返回
-        空字符串，表示工具没有额外状态可报告。
+        Concrete tools may override this hook for model-initiated status
+        queries. The default empty string means no extra status is available.
         """
 
         return ""
@@ -342,10 +352,10 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> None:
-        """执行一次调用被终止时所需的工具侧清理。
+        """Perform tool-specific cleanup when a call is stopped.
 
-        默认不做任何事。持有外部任务或连接的工具应覆写它；ToolEngine
-        自身取消后台 Task 的职责不属于这个钩子。
+        Tools that own external tasks or connections should override this hook.
+        Cancelling the ToolEngine background task is handled by ToolEngine.
         """
 
     @classmethod
@@ -366,10 +376,10 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> None:
-        """当一次调用订阅阶段性更新时执行工具侧逻辑。
+        """Perform tool-specific work when progress updates are subscribed.
 
-        默认不做任何事。订阅只影响过程更新，最终结果仍应由 ToolEngine
-        写回消息历史。
+        Subscription affects intermediate updates only. ToolEngine always
+        writes the final result back to message history.
         """
 
     @classmethod
@@ -390,10 +400,10 @@ class AsyncTool(_NativeTool):
         tool_state: ToolState,
         global_state: ToolEngineState,
     ) -> None:
-        """当一次调用取消订阅阶段性更新时执行工具侧逻辑。
+        """Perform tool-specific work when progress updates are unsubscribed.
 
-        默认不做任何事。取消订阅只抑制过程更新，最终结果仍应由
-        ToolEngine 写回消息历史。
+        Unsubscription suppresses intermediate updates only. ToolEngine still
+        writes the final result back to message history.
         """
 
     @classmethod
@@ -409,17 +419,17 @@ class AsyncTool(_NativeTool):
 
 
 class SyncTool(_NativeTool):
-    """只返回一次结构化最终结果的原生工具基类。
+    """Base class for native tools that return one structured final result.
 
-    子类实现 ``invoke``；框架提供的 ``ainvoke`` 会自动把同步调用
-    放入线程，供异步 Agent 安全调用。
+    Subclasses implement ``invoke``. The framework-provided ``ainvoke`` runs
+    the synchronous implementation in a worker thread.
     """
 
     input_type: ClassVar[type[ToolInput]]
     output_type: ClassVar[type[ToolOutput]]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """在具体子类创建时，从 invoke 注解推断输入和输出类型。"""
+        """Infer input and output types from the invoke annotations."""
 
         super().__init_subclass__(**kwargs)
         if inspect.isabstract(cls):
@@ -480,9 +490,9 @@ Tool: TypeAlias = BaseTool | type[SyncTool] | type[AsyncTool]
 
 @dataclass
 class ToolRun:
-    """一次工具调用的结果封装。
+    """Result record for one tool call.
 
-    ``result`` 保存工具目前最新的运行结果。
+    ``result`` stores the latest available tool result.
     """
 
     result: ToolResult
@@ -490,7 +500,7 @@ class ToolRun:
 
 @dataclass
 class AsyncToolRun(ToolRun):
-    """一次异步工具调用的结果封装。"""
+    """Lifecycle record for one asynchronous tool call."""
 
     tool_class: type[AsyncTool]
     tool_input: ToolInput
@@ -503,14 +513,14 @@ class AsyncToolRun(ToolRun):
 
 
 class ToolEngine:
-    """管理 Agent 工具的调用和运行状态。"""
+    """Manage agent tool binding, invocation, and lifecycle state."""
 
     def __init__(
         self,
         tools: list[Tool],
         state: ToolEngineState,
     ) -> None:
-        """初始化工具引擎。"""
+        """Initialize the tool engine."""
         self.tools = list(tools)
         has_async_tool = any(
             isinstance(tool_item, type) and issubclass(tool_item, AsyncTool)
@@ -537,7 +547,7 @@ class ToolEngine:
 
     @staticmethod
     def _tool_name(tool: Tool) -> str:
-        """获取工具的名称。"""
+        """Return the registered name of a tool."""
         if isinstance(tool, BaseTool):
             name = tool.name
         else:
@@ -551,7 +561,7 @@ class ToolEngine:
         source_call_id: str,
         result: ToolResult,
     ) -> tuple[ToolCall, ToolMessage]:
-        """构建一个异步工具更新的 ToolCall 和 ToolMessage。"""
+        """Build the ToolCall and ToolMessage for one async update."""
 
         update_call_id = (
             f"{source_call_id}:{_ASYNC_TOOL_UPDATED_NAME}:{uuid4().hex}"
@@ -574,7 +584,7 @@ class ToolEngine:
 
     @staticmethod
     def _tool_result_payload(result: ToolResult) -> dict[str, Any]:
-        """将工具运行结果转换为可序列化的状态负载。"""
+        """Convert a tool result into a serializable status payload."""
 
         if isinstance(result, Running):
             return {
@@ -591,7 +601,7 @@ class ToolEngine:
         tool_call: ToolCall,
         messages: list[BaseMessage],
     ) -> None:
-        """确保消息历史中存在对应的 AI 工具调用声明。"""
+        """Ensure message history declares the corresponding AI tool call."""
 
         call_id = str(tool_call.get("id", "") or "")
         if not call_id:
@@ -627,7 +637,7 @@ class ToolEngine:
     def _find_pending_tool_call_message(
         messages: list[BaseMessage],
     ) -> tuple[AIMessage, int] | None:
-        """查找最近的未完成 AI 工具调用批次及合成调用插入位置。"""
+        """Find the latest pending AI tool-call batch and insertion index."""
 
         for index in range(len(messages) - 1, -1, -1):
             message = messages[index]
@@ -661,7 +671,7 @@ class ToolEngine:
         tool_message: ToolMessage,
         messages: list[BaseMessage],
     ) -> None:
-        """将工具调用和工具消息追加到消息历史。"""
+        """Append a tool call and its result to message history."""
 
         call_id = str(tool_call.get("id", "") or "")
         if not call_id:
@@ -684,7 +694,7 @@ class ToolEngine:
         tool_call: ToolCall,
         messages: list[BaseMessage],
     ) -> ToolMessage:
-        """异步调用工具并将结果追加到消息历史。"""
+        """Invoke a tool asynchronously and append its result to history."""
 
         tool_message = await self.ainvoke(tool_call)
         self.append_tool_message(tool_call, tool_message, messages)
@@ -695,7 +705,7 @@ class ToolEngine:
         tool_call: ToolCall,
         messages: list[BaseMessage],
     ) -> ToolMessage:
-        """同步调用工具并将结果追加到消息历史。"""
+        """Invoke a tool synchronously and append its result to history."""
 
         tool_message = self.invoke(tool_call)
         self.append_tool_message(tool_call, tool_message, messages)
@@ -703,7 +713,7 @@ class ToolEngine:
 
     @classmethod
     def _to_bindable_tool(cls, tool: Tool) -> BaseTool:
-        """将工具转换为聊天模型可绑定的 LangChain 工具。"""
+        """Convert a native tool into a LangChain-bindable tool schema."""
 
         if isinstance(tool, BaseTool):
             return tool
@@ -711,7 +721,7 @@ class ToolEngine:
         name = cls._tool_name(tool)
 
         def invoke_through_engine(**kwargs: Any) -> str:
-            """阻止绕过 ToolEngine 直接执行原生工具。"""
+            """Prevent native tool execution from bypassing ToolEngine."""
 
             del kwargs
             raise RuntimeError(
@@ -729,7 +739,7 @@ class ToolEngine:
         self,
         model: BaseChatModel,
     ) -> BaseChatModel | Runnable[Any, Any]:
-        """将引擎管理的工具绑定到聊天模型。"""
+        """Bind all engine-managed tools to a chat model."""
 
         if not self.tools:
             return model
@@ -740,12 +750,12 @@ class ToolEngine:
         self,
         callback: Callable[[ToolCall, ToolMessage], None],
     ) -> None:
-        """注册异步工具主动更新回调。"""
+        """Register the callback for proactive asynchronous tool updates."""
 
         self._async_tool_update_callback = callback
 
     def _create_async_tool_updated_tool(self) -> BaseTool:
-        """创建用于接收异步工具更新的系统工具。"""
+        """Create the system-only asynchronous update tool."""
 
         @tool(_ASYNC_TOOL_UPDATED_NAME)
         def async_tool_updated(source_call_id: str) -> str:
@@ -768,11 +778,15 @@ class ToolEngine:
         return async_tool_updated
 
     def _create_async_tool_status_tool(self) -> BaseTool:
-        """创建用于查询异步工具状态的工具。"""
+        """Create the asynchronous tool status query tool."""
 
         @tool(_ASYNC_TOOL_STATUS_NAME)
         async def id_to_async_tool_status(source_call_id: str) -> str:
             """Return the latest status of an asynchronous tool call.
+
+            Use this tool when the latest progress is needed without changing
+            the subscription state. The result reports whether the call is
+            still running, its tool-defined status, and any recorded error.
 
             Parameters
             ----------
@@ -802,11 +816,15 @@ class ToolEngine:
         return id_to_async_tool_status
 
     def _create_subscribe_tool(self) -> BaseTool:
-        """创建用于订阅异步工具更新的工具。"""
+        """Create the asynchronous tool subscription tool."""
 
         @tool(_SUBSCRIBE_ASYNC_TOOL_NAME)
         async def subscribe_async_tool(source_call_id: str) -> str:
             """Subscribe to progress updates from an asynchronous tool call.
+
+            After subscription, the system may deliver intermediate results
+            through ``async_tool_updated``. The subscription response also
+            includes the latest known result. Final results are always sent.
 
             Parameters
             ----------
@@ -850,11 +868,14 @@ class ToolEngine:
         return subscribe_async_tool
 
     def _create_unsubscribe_tool(self) -> BaseTool:
-        """创建用于取消订阅异步工具更新的工具。"""
+        """Create the asynchronous tool unsubscription tool."""
 
         @tool(_UNSUBSCRIBE_ASYNC_TOOL_NAME)
         async def unsubscribe_async_tool(source_call_id: str) -> str:
             """Stop receiving progress updates from an asynchronous tool call.
+
+            Unsubscribing suppresses intermediate updates only. The system
+            still delivers the final result through ``async_tool_updated``.
 
             Parameters
             ----------
@@ -896,11 +917,14 @@ class ToolEngine:
         return unsubscribe_async_tool
 
     def _create_stop_tool(self) -> BaseTool:
-        """创建异步工具停止工具。"""
+        """Create the asynchronous tool stop command."""
 
         @tool(_STOP_ASYNC_TOOL_NAME)
         async def stop_async_tool(source_call_id: str) -> str:
             """Stop an asynchronous tool call and release its resources.
+
+            Use this tool only for a call that is still running. Repeated stop
+            requests are safe and report the call as already stopped.
 
             Parameters
             ----------
@@ -947,7 +971,7 @@ class ToolEngine:
         return stop_async_tool
 
     async def _get_async_run(self, source_call_id: str) -> AsyncToolRun | None:
-        """按调用 ID 查找异步工具运行记录。"""
+        """Find an asynchronous tool run by its source call ID."""
 
         async with self._runs_lock:
             run = self._id_to_tool_runs.get(source_call_id)
@@ -955,7 +979,7 @@ class ToolEngine:
 
     @staticmethod
     def _async_run_not_found_content(source_call_id: str) -> str:
-        """构造异步工具调用不存在时的 JSON 结果。"""
+        """Build the JSON response for an unknown asynchronous tool call."""
 
         return json.dumps(
             {"error": f"Async tool run not found: {source_call_id}"},
@@ -963,7 +987,7 @@ class ToolEngine:
         )
 
     def _create_assist_tools(self) -> list[BaseTool]:
-        """创建异步工具协议所需的辅助工具。"""
+        """Create the assistant tools required by the async tool protocol."""
 
         return [
             self._create_async_tool_updated_tool(),
@@ -974,7 +998,7 @@ class ToolEngine:
         ]
 
     async def _reserve_call_id(self, call_id: str) -> None:
-        """为一次工具调用保留唯一的 call_id。"""
+        """Reserve a unique ID before starting a tool call."""
 
         async with self._runs_lock:
             if self._closed:
@@ -987,7 +1011,7 @@ class ToolEngine:
             self._reserved_call_ids.add(call_id)
 
     async def _store_run(self, call_id: str, run: ToolRun) -> None:
-        """保存工具运行记录并结束调用 ID 的预留状态。"""
+        """Store a tool run and complete its call ID reservation."""
 
         async with self._runs_lock:
             if self._closed:
@@ -996,7 +1020,7 @@ class ToolEngine:
             self._reserved_call_ids.discard(call_id)
 
     async def _release_call_id(self, call_id: str) -> None:
-        """释放一次工具调用的 call_id 预留状态。"""
+        """Release a call ID reserved by a failed tool invocation."""
 
         async with self._runs_lock:
             self._reserved_call_ids.discard(call_id)
@@ -1006,7 +1030,7 @@ class ToolEngine:
         call_id: str,
         run: AsyncToolRun,
     ) -> None:
-        """在引擎仍开放时订阅并启动异步工具的后台更新任务。"""
+        """Subscribe and start an async update task while the engine is open."""
 
         async with run.lifecycle_lock:
             async with self._runs_lock:
@@ -1027,7 +1051,7 @@ class ToolEngine:
                 run.task = task
 
     async def ainvoke(self, tool_call: ToolCall) -> ToolMessage:
-        """异步调用工具。"""
+        """Invoke a tool asynchronously."""
 
         if self._closed:
             raise RuntimeError("ToolEngine is closed")
@@ -1093,7 +1117,7 @@ class ToolEngine:
                 name=name,
             )
 
-        # AsyncTool 的调用逻辑
+        # Start the asynchronous tool and return its immediate protocol result.
         if isinstance(selected_tool, type) and issubclass(selected_tool, AsyncTool):
             tool_input = selected_tool.input_type.model_validate(args)
             tool_state = selected_tool.state_type(call_id=call_id)
@@ -1148,10 +1172,11 @@ class ToolEngine:
         raise NotImplementedError("Native tool invocation is not implemented yet")
 
     def invoke(self, tool_call: ToolCall) -> ToolMessage:
-        """从同步上下文调用一个同步工具。
+        """Invoke a synchronous tool from a synchronous context.
 
-        异步工具需要持续运行的事件循环来消费后续更新，因此必须通过
-        ``ainvoke`` 调用。已有事件循环的调用方也应直接等待 ``ainvoke``。
+        AsyncTool requires a persistent event loop for subsequent updates and
+        must use ``ainvoke``. Callers already inside an event loop should also
+        await ``ainvoke`` directly.
         """
 
         name = str(tool_call.get("name", "") or "")
@@ -1182,7 +1207,7 @@ class ToolEngine:
         self,
         call_id: str,
     ) -> None:
-        """持续消费一次异步工具调用的更新。"""
+        """Consume updates from one asynchronous tool call."""
 
         run = self._id_to_tool_runs.get(call_id)
         if not isinstance(run, AsyncToolRun):
@@ -1237,13 +1262,13 @@ class ToolEngine:
 
     @staticmethod
     def _consume_task_exception(task: asyncio.Task[None]) -> None:
-        """读取后台任务异常，避免产生未处理任务警告。"""
+        """Retrieve a background exception to avoid unhandled-task warnings."""
 
         if not task.cancelled():
             task.exception()
 
     async def shutdown(self) -> None:
-        """关闭工具引擎并取消所有仍在运行的异步工具调用。"""
+        """Close the engine and cancel all active asynchronous tool calls."""
 
         async with self._runs_lock:
             if self._closed:

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -20,7 +20,10 @@ from typing import (
     get_type_hints,
 )
 
-from langchain_core.tools import BaseTool
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import ToolCall, ToolMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
 
 
@@ -35,6 +38,17 @@ class ToolOutput(BaseModel):
         """将结构化结果序列化为 ToolMessage 可保存的文本。"""
 
         return self.model_dump_json()
+
+
+class _TextToolOutput(ToolOutput):
+    """将外部工具结果包装为原生工具输出。"""
+
+    content: str
+
+    def to_content(self) -> str:
+        """返回外部工具的文本结果。"""
+
+        return self.content
 
 
 @dataclass
@@ -451,6 +465,387 @@ class SyncTool(_NativeTool):
 Tool: TypeAlias = BaseTool | type[SyncTool] | type[AsyncTool]
 
 
+@dataclass
+class ToolRun:
+    """一次工具调用的结果封装。
+
+    ``result`` 保存工具目前最新的运行结果。
+    """
+
+    result: ToolResult
+
+
+@dataclass
+class AsyncToolRun(ToolRun):
+    """一次异步工具调用的结果封装。"""
+
+    tool_class: type[AsyncTool]
+    tool_input: ToolInput
+    tool_state: ToolState
+    subscribed: bool
+    running: bool
+    task: asyncio.Task[None] | None = None
+    error: BaseException | None = None
+
+
+class ToolEngine:
+    """管理 Agent 工具的调用和运行状态。"""
+
+    def __init__(
+        self,
+        tools: list[Tool],
+        state: ToolEngineState,
+    ) -> None:
+        """初始化工具引擎。"""
+        self.tools = list(tools)
+        self.state = state
+        self._state_lock = asyncio.Lock()
+        self._name_to_tool: dict[str, Tool] = {}
+        self._id_to_tool_runs: dict[str, ToolRun] = {}
+        self._closed = False
+        self._runs_lock = asyncio.Lock()
+        self._reserved_call_ids: set[str] = set()
+
+        for tool in self.tools:
+            name = self._tool_name(tool)
+            if name in self._name_to_tool:
+                raise ValueError(f"Duplicate tool name: {name}")
+            self._name_to_tool[name] = tool
+
+    @staticmethod
+    def _tool_name(tool: Tool) -> str:
+        """获取工具的名称。"""
+        if isinstance(tool, BaseTool):
+            name = tool.name
+        else:
+            name = tool.name or tool.__name__
+        if not name:
+            raise ValueError(f"Tool {tool} must have a name")
+        return name
+
+    @classmethod
+    def _to_bindable_tool(cls, tool: Tool) -> BaseTool:
+        """将工具转换为聊天模型可绑定的 LangChain 工具。"""
+
+        if isinstance(tool, BaseTool):
+            return tool
+
+        name = cls._tool_name(tool)
+
+        def invoke_through_engine(**kwargs: Any) -> str:
+            """阻止绕过 ToolEngine 直接执行原生工具。"""
+
+            del kwargs
+            raise RuntimeError(
+                f"Native tool {name} must be invoked through ToolEngine"
+            )
+
+        return StructuredTool.from_function(
+            func=invoke_through_engine,
+            name=name,
+            description=inspect.getdoc(tool) or f"Call the {name} tool.",
+            args_schema=tool.input_type,
+        )
+
+    def bind(
+        self,
+        model: BaseChatModel,
+    ) -> BaseChatModel | Runnable[Any, Any]:
+        """将引擎管理的工具绑定到聊天模型。"""
+
+        if not self.tools:
+            return model
+        bindable_tools = [self._to_bindable_tool(tool) for tool in self.tools]
+        return model.bind_tools(bindable_tools)
+
+    async def _reserve_call_id(self, call_id: str) -> None:
+        """为一次工具调用保留唯一的 call_id。"""
+
+        async with self._runs_lock:
+            if self._closed:
+                raise RuntimeError("ToolEngine is closed")
+            if (
+                call_id in self._reserved_call_ids
+                or call_id in self._id_to_tool_runs
+            ):
+                raise ValueError(f"Duplicate tool call id: {call_id}")
+            self._reserved_call_ids.add(call_id)
+
+    async def _store_run(self, call_id: str, run: ToolRun) -> None:
+        """保存工具运行记录并结束调用 ID 的预留状态。"""
+
+        async with self._runs_lock:
+            if self._closed:
+                raise RuntimeError("ToolEngine is closed")
+            self._id_to_tool_runs[call_id] = run
+            self._reserved_call_ids.discard(call_id)
+
+    async def _release_call_id(self, call_id: str) -> None:
+        """释放一次工具调用的 call_id 预留状态。"""
+
+        async with self._runs_lock:
+            self._reserved_call_ids.discard(call_id)
+
+    async def _start_async_run(
+        self,
+        call_id: str,
+        run: AsyncToolRun,
+    ) -> None:
+        """在引擎仍开放时订阅并启动异步工具的后台更新任务。"""
+
+        async with self._runs_lock:
+            if self._closed:
+                raise RuntimeError("ToolEngine is closed")
+            if run.subscribed:
+                async with self._state_lock:
+                    await run.tool_class.asubscribe(
+                        run.tool_input,
+                        run.tool_state,
+                        self.state,
+                    )
+            task = asyncio.create_task(self._consume_async_updates(call_id))
+            task.add_done_callback(self._consume_task_exception)
+            run.task = task
+
+    async def ainvoke(self, tool_call: ToolCall) -> ToolMessage:
+        """异步调用一个工具。"""
+
+        if self._closed:
+            raise RuntimeError("ToolEngine is closed")
+        call_id = str(tool_call.get("id", "") or "")
+        name = str(tool_call.get("name", "") or "")
+        args = tool_call.get("args", {})
+
+        if not call_id:
+            raise ValueError("ToolCall must have an id")
+        if not name:
+            raise ValueError("ToolCall must have a name")
+        if not isinstance(args, dict):
+            raise TypeError("ToolCall args must be a dict")
+
+        selected_tool = self._name_to_tool.get(name)
+        if selected_tool is None:
+            raise ValueError(f"Unknown tool: {name}")
+
+        if isinstance(selected_tool, BaseTool):
+            await self._reserve_call_id(call_id)
+
+            try:
+                result = await selected_tool.ainvoke(args)
+                content = result if isinstance(result, str) else str(result)
+                output = _TextToolOutput(content=content)
+                await self._store_run(
+                    call_id,
+                    ToolRun(result=Finished(content=output)),
+                )
+            except BaseException:
+                await self._release_call_id(call_id)
+                raise
+
+            return ToolMessage(
+                content=output.to_content(),
+                tool_call_id=call_id,
+                name=name,
+            )
+
+        if isinstance(selected_tool, type) and issubclass(selected_tool, SyncTool):
+            tool_input = selected_tool.input_type.model_validate(args)
+            await self._reserve_call_id(call_id)
+
+            try:
+                async with self._state_lock:
+                    output = await selected_tool.ainvoke(
+                        tool_input,
+                        self.state,
+                    )
+
+                finished = Finished(content=output)
+                await self._store_run(
+                    call_id,
+                    ToolRun(result=finished),
+                )
+            except BaseException:
+                await self._release_call_id(call_id)
+                raise
+
+            return ToolMessage(
+                content=output.to_content(),
+                tool_call_id=call_id,
+                name=name,
+            )
+
+        # AsyncTool 的调用逻辑
+        if isinstance(selected_tool, type) and issubclass(selected_tool, AsyncTool):
+            tool_input = selected_tool.input_type.model_validate(args)
+            tool_state = selected_tool.state_type(call_id=call_id)
+
+            await self._reserve_call_id(call_id)
+
+            try:
+                async with self._state_lock:
+                    initial = await selected_tool.aemit_initial(
+                        call_id,
+                        tool_input,
+                        tool_state,
+                        self.state,
+                    )
+
+                if not isinstance(initial, Running):
+                    raise TypeError("AsyncTool.aemit_initial() must return Running")
+                if (
+                    not isinstance(initial.content, str)
+                    or call_id not in initial.content
+                ):
+                    raise ValueError(
+                        "AsyncTool initial content must contain its tool call id"
+                    )
+
+                run = AsyncToolRun(
+                    result=initial,
+                    tool_class=selected_tool,
+                    tool_input=tool_input,
+                    tool_state=tool_state,
+                    subscribed=selected_tool.subscribe_by_default,
+                    running=True,
+                )
+                await self._store_run(call_id, run)
+            except BaseException:
+                await self._release_call_id(call_id)
+                raise
+
+            try:
+                await self._start_async_run(call_id, run)
+            except BaseException as exc:
+                run.error = exc
+                run.running = False
+                raise
+
+            return ToolMessage(
+                content=initial.content,
+                tool_call_id=call_id,
+                name=name,
+            )
+
+        raise NotImplementedError("Native tool invocation is not implemented yet")
+
+    def invoke(self, tool_call: ToolCall) -> ToolMessage:
+        """从同步上下文调用一个同步工具。
+
+        异步工具需要持续运行的事件循环来消费后续更新，因此必须通过
+        ``ainvoke`` 调用。已有事件循环的调用方也应直接等待 ``ainvoke``。
+        """
+
+        name = str(tool_call.get("name", "") or "")
+        if not name:
+            raise ValueError("ToolCall must have a name")
+
+        selected_tool = self._name_to_tool.get(name)
+        if selected_tool is None:
+            raise ValueError(f"Unknown tool: {name}")
+        if isinstance(selected_tool, type) and issubclass(
+            selected_tool,
+            AsyncTool,
+        ):
+            raise RuntimeError(
+                "AsyncTool must be invoked with await ToolEngine.ainvoke()"
+            )
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.ainvoke(tool_call))
+        raise RuntimeError(
+            "ToolEngine.invoke() cannot run inside an active event loop; "
+            "use await ToolEngine.ainvoke()"
+        )
+
+    async def _consume_async_updates(
+        self,
+        call_id: str,
+    ) -> None:
+        """持续消费一次异步工具调用的更新。"""
+
+        run = self._id_to_tool_runs.get(call_id)
+        if not isinstance(run, AsyncToolRun):
+            raise RuntimeError(f"Async tool run not found: {call_id}")
+
+        updates = run.tool_class.aemit_updates(
+            run.tool_input,
+            run.tool_state,
+            self.state,
+        )
+        try:
+            async for result in updates:
+                if not isinstance(result, (Running, Finished)):
+                    raise TypeError(
+                        "AsyncTool.aemit_updates() must yield Running or Finished"
+                    )
+                if (
+                    isinstance(result, Finished)
+                    and not isinstance(result.content, run.tool_class.output_type)
+                ):
+                    raise TypeError(
+                        "AsyncTool Finished content must match its output_type"
+                    )
+
+                run.result = result
+                if isinstance(result, Finished):
+                    return
+
+            raise RuntimeError(
+                f"Async tool {call_id} ended without a Finished result"
+            )
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            run.error = exc
+            raise
+        finally:
+            run.running = False
+
+    @staticmethod
+    def _consume_task_exception(task: asyncio.Task[None]) -> None:
+        """读取后台任务异常，避免产生未处理任务警告。"""
+
+        if not task.cancelled():
+            task.exception()
+
+    async def shutdown(self) -> None:
+        """关闭工具引擎，取消所有正在运行的异步工具调用。"""
+
+        async with self._runs_lock:
+            if self._closed:
+                return
+            self._closed = True
+            runs = [
+                run
+                for run in self._id_to_tool_runs.values()
+                if isinstance(run, AsyncToolRun)
+            ]
+
+        async def stop_run(run: AsyncToolRun) -> None:
+            if not run.running:
+                return
+            try:
+                async with self._state_lock:
+                    await run.tool_class.astop(
+                        run.tool_input,
+                        run.tool_state,
+                        self.state,
+                    )
+            except BaseException as exc:
+                run.error = exc
+            finally:
+                if run.task is not None and not run.task.done():
+                    run.task.cancel()
+                run.running = False
+
+        await asyncio.gather(*(stop_run(run) for run in runs), return_exceptions=True)
+        tasks = [run.task for run in runs if run.task is not None]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
 __all__ = [
     "AsyncTool",
     "Finished",
@@ -462,4 +857,7 @@ __all__ = [
     "ToolResult",
     "ToolState",
     "Tool",
+    "ToolRun",
+    "AsyncToolRun",
+    "ToolEngine",
 ]

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -750,6 +750,23 @@ class ToolEngine:
         ]
         return model.bind_tools(bindable_tools)
 
+    def bind_without_tool_calls(
+        self,
+        model: BaseChatModel,
+    ) -> BaseChatModel | Runnable[Any, Any]:
+        """Bind all tool schemas while preventing model-initiated calls."""
+
+        if not self.tools:
+            return model
+        bindable_tools = [
+            self._to_bindable_tool(tool)
+            for tool in self.tools
+        ]
+        return model.bind_tools(
+            bindable_tools,
+            tool_choice="none",
+        )
+
     def on_async_tool_update(
         self,
         callback: Callable[[ToolCall, ToolMessage], None],

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -1,0 +1,465 @@
+"""X-Talk 原生同步、异步工具的基础类型。"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import types
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    ClassVar,
+    Generic,
+    TypeAlias,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel
+
+
+class ToolInput(BaseModel):
+    """X-Talk 原生工具输入模型的基类。"""
+
+
+class ToolOutput(BaseModel):
+    """X-Talk 原生工具输出模型的基类。"""
+
+    def to_content(self) -> str:
+        """将结构化结果序列化为 ToolMessage 可保存的文本。"""
+
+        return self.model_dump_json()
+
+
+@dataclass
+class ToolState:
+    """一次异步工具调用独享的可变状态。
+    call_id 本次工具调用的唯一标识。
+    metadata 供具体工具保存进度等自定义状态的容器。
+    """
+
+    call_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+TO = TypeVar("TO", bound=ToolOutput)
+
+
+@dataclass(frozen=True)
+class Running:
+    """异步工具仍在运行时产生的文本更新。
+    content 可写入 ToolMessage 的阶段性状态。
+    """
+
+    content: str
+
+
+@dataclass(frozen=True)
+class Finished(Generic[TO]):
+    """异步工具完成时产生的结构化最终结果。
+    content 具体工具定义的 ``ToolOutput`` 子类实例。
+    """
+
+    content: TO
+
+
+ToolResult: TypeAlias = Running | Finished[TO]
+ToolEngineState: TypeAlias = Any
+
+# StopIteration 不能直接通过 asyncio Future 传播，因此用哨兵表示迭代结束。
+_SENTINEL = object()
+
+
+def _next_or_sentinel(iterator: Iterator[ToolResult[TO]]) -> ToolResult[TO] | object:
+    """取出同步迭代器的下一项，耗尽时返回哨兵对象。
+
+    iterator 同步工具更新迭代器。
+
+    ToolResult[TO] 下一项工具结果，或表示迭代结束的 ``_SENTINEL``。
+    """
+
+    try:
+        return next(iterator)
+    except StopIteration:
+        return _SENTINEL
+
+
+class _NativeTool(ABC):
+    """同步和异步原生工具共用的内部基类。"""
+
+    name: ClassVar[str | None] = None
+
+    @staticmethod
+    def _validate_input_type(value: Any) -> type[ToolInput]:
+        """Validate and return a native tool input type."""
+
+        if isinstance(value, type) and issubclass(value, ToolInput):
+            return value
+        raise TypeError("tool_input must be annotated as a ToolInput subclass")
+
+    @staticmethod
+    def _validate_output_type(value: Any) -> type[ToolOutput]:
+        """Validate and return a native tool output type."""
+
+        if isinstance(value, type) and issubclass(value, ToolOutput):
+            return value
+        raise TypeError("return must be annotated as a ToolOutput subclass")
+
+
+class AsyncTool(_NativeTool):
+    """可产生阶段性更新的长耗时工具基类。
+
+    子类至少实现 ``emit_initial`` 和 ``emit_updates``。默认的异步方法会
+    在线程中执行对应同步方法；如果底层 SDK 本身提供 async API，子类可
+    覆写相应的 ``a*`` 方法，避免不必要的线程切换。
+    """
+
+    subscribe_by_default: ClassVar[bool] = False
+    input_type: ClassVar[type[ToolInput]]
+    state_type: ClassVar[type[ToolState]]
+    output_type: ClassVar[type[ToolOutput]]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """在具体子类创建时，从方法注解推断其三种数据类型。
+
+        工具作者只需写方法注解，无须手动声明 ``input_type``、
+        ``state_type`` 和 ``output_type``。抽象中间类会跳过推断。
+        """
+
+        super().__init_subclass__(**kwargs)
+        if inspect.isabstract(cls):
+            return
+        cls.input_type, cls.state_type, cls.output_type = (
+            cls._infer_types_from_method_annotations()
+        )
+
+    @classmethod
+    def _infer_types_from_method_annotations(
+        cls,
+    ) -> tuple[type[ToolInput], type[ToolState], type[ToolOutput]]:
+        """Infer native asynchronous tool types from lifecycle methods."""
+
+        input_type = getattr(cls, "input_type", None)
+        state_type = getattr(cls, "state_type", None)
+        output_type = getattr(cls, "output_type", None)
+
+        for method_name in (
+            "emit_initial",
+            "aemit_initial",
+            "emit_updates",
+            "aemit_updates",
+            "status",
+            "astatus",
+            "stop",
+            "astop",
+            "subscribe",
+            "asubscribe",
+            "unsubscribe",
+            "aunsubscribe",
+        ):
+            raw_method = cls.__dict__.get(method_name)
+            if raw_method is None:
+                continue
+            # 类字典中的 classmethod 是描述符，需要取出底层函数的注解。
+            method = (
+                raw_method.__func__
+                if isinstance(raw_method, classmethod)
+                else raw_method
+            )
+            hints = get_type_hints(method)
+
+            if "tool_input" in hints:
+                input_type = cls._validate_input_type(hints["tool_input"])
+            if "tool_state" in hints:
+                state_type = cls._validate_state_type(hints["tool_state"])
+            if "return" in hints:
+                inferred_output_type = cls._infer_output_type(hints["return"])
+                if inferred_output_type is not None:
+                    output_type = inferred_output_type
+
+        if input_type is None:
+            raise TypeError(f"{cls.__name__} must annotate tool_input")
+        if state_type is None:
+            raise TypeError(f"{cls.__name__} must annotate tool_state")
+        if output_type is None:
+            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
+        return input_type, state_type, output_type
+
+    @staticmethod
+    def _validate_state_type(value: Any) -> type[ToolState]:
+        """Validate and return an asynchronous tool state type."""
+
+        if isinstance(value, type) and issubclass(value, ToolState):
+            return value
+        raise TypeError("tool_state must be annotated as a ToolState subclass")
+
+    @classmethod
+    def _infer_output_type(cls, annotation: Any) -> type[ToolOutput] | None:
+        """递归寻找返回注解中包含的具体 ToolOutput 类型。"""
+
+        if isinstance(annotation, type) and issubclass(annotation, ToolOutput):
+            return annotation
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin is Finished and args:
+            return cls._infer_output_type(args[0])
+        if origin in {Iterator, AsyncIterator} and args:
+            return cls._infer_output_type(args[0])
+        if origin in {Union, types.UnionType}:
+            for arg in args:
+                output_type = cls._infer_output_type(arg)
+                if output_type is not None:
+                    return output_type
+        return None
+
+    @classmethod
+    @abstractmethod
+    def emit_initial(
+        cls,
+        tool_call_id: str,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> Running:
+        """立即生成满足 LLM 工具调用协议的首条结果。
+
+        部分模型要求每个 tool call 后立刻出现对应的 ToolMessage，
+        因此这里先返回 ``Running``，真正工作由 ``emit_updates`` 继续执行。
+        """
+
+        raise NotImplementedError
+
+    @classmethod
+    async def aemit_initial(
+        cls,
+        tool_call_id: str,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> Running:
+        """在线程中生成首条结果，避免阻塞事件循环。"""
+
+        return await asyncio.to_thread(
+            cls.emit_initial,
+            tool_call_id,
+            tool_input,
+            tool_state,
+            global_state,
+        )
+
+    @classmethod
+    @abstractmethod
+    def emit_updates(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> Iterator[ToolResult[ToolOutput]]:
+        """依次产生阶段性更新，并以一个最终结果结束。"""
+
+        raise NotImplementedError
+
+    @classmethod
+    async def aemit_updates(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> AsyncIterator[ToolResult[ToolOutput]]:
+        """把同步更新迭代器桥接成非阻塞的异步迭代器。"""
+
+        iterator = cls.emit_updates(tool_input, tool_state, global_state)
+        while True:
+            item = await asyncio.to_thread(_next_or_sentinel, iterator)
+            if item is _SENTINEL:
+                return
+            yield item
+
+    @classmethod
+    def status(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> str:
+        """返回一次异步调用的最新可读状态。
+
+        具体工具可覆写该钩子，为 LLM 的主动状态查询提供信息。默认返回
+        空字符串，表示工具没有额外状态可报告。
+        """
+
+        return ""
+
+    @classmethod
+    async def astatus(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> str:
+        """Query synchronous tool status without blocking the event loop."""
+
+        return await asyncio.to_thread(cls.status, tool_input, tool_state, global_state)
+
+    @classmethod
+    def stop(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """执行一次调用被终止时所需的工具侧清理。
+
+        默认不做任何事。持有外部任务或连接的工具应覆写它；ToolEngine
+        自身取消后台 Task 的职责不属于这个钩子。
+        """
+
+    @classmethod
+    async def astop(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """Run the synchronous stop hook without blocking the event loop."""
+
+        await asyncio.to_thread(cls.stop, tool_input, tool_state, global_state)
+
+    @classmethod
+    def subscribe(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """当一次调用订阅阶段性更新时执行工具侧逻辑。
+
+        默认不做任何事。订阅只影响过程更新，最终结果仍应由 ToolEngine
+        写回消息历史。
+        """
+
+    @classmethod
+    async def asubscribe(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """Run the synchronous subscribe hook without blocking the event loop."""
+
+        await asyncio.to_thread(cls.subscribe, tool_input, tool_state, global_state)
+
+    @classmethod
+    def unsubscribe(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """当一次调用取消订阅阶段性更新时执行工具侧逻辑。
+
+        默认不做任何事。取消订阅只抑制过程更新，最终结果仍应由
+        ToolEngine 写回消息历史。
+        """
+
+    @classmethod
+    async def aunsubscribe(
+        cls,
+        tool_input: ToolInput,
+        tool_state: ToolState,
+        global_state: ToolEngineState,
+    ) -> None:
+        """Run the synchronous unsubscribe hook without blocking the event loop."""
+
+        await asyncio.to_thread(cls.unsubscribe, tool_input, tool_state, global_state)
+
+
+class SyncTool(_NativeTool):
+    """只返回一次结构化最终结果的原生工具基类。
+
+    子类实现 ``invoke``；框架提供的 ``ainvoke`` 会自动把同步调用
+    放入线程，供异步 Agent 安全调用。
+    """
+
+    input_type: ClassVar[type[ToolInput]]
+    output_type: ClassVar[type[ToolOutput]]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """在具体子类创建时，从 invoke 注解推断输入和输出类型。"""
+
+        super().__init_subclass__(**kwargs)
+        if inspect.isabstract(cls):
+            return
+        cls.input_type, cls.output_type = cls._infer_types_from_method_annotations()
+
+    @classmethod
+    def _infer_types_from_method_annotations(
+        cls,
+    ) -> tuple[type[ToolInput], type[ToolOutput]]:
+        """Infer native synchronous tool types from ``invoke`` annotations."""
+
+        input_type = getattr(cls, "input_type", None)
+        output_type = getattr(cls, "output_type", None)
+        raw_method = cls.__dict__.get("invoke")
+        if raw_method is not None:
+            method = (
+                raw_method.__func__
+                if isinstance(raw_method, classmethod)
+                else raw_method
+            )
+            hints = get_type_hints(method)
+            if "tool_input" in hints:
+                input_type = cls._validate_input_type(hints["tool_input"])
+            if "return" in hints:
+                output_type = cls._validate_output_type(hints["return"])
+
+        if input_type is None:
+            raise TypeError(f"{cls.__name__} must annotate tool_input")
+        if output_type is None:
+            raise TypeError(f"{cls.__name__} must annotate a ToolOutput return type")
+        return input_type, output_type
+
+    @classmethod
+    @abstractmethod
+    def invoke(
+        cls,
+        tool_input: ToolInput,
+        global_state: ToolEngineState,
+    ) -> ToolOutput:
+        """Execute the tool and return its final structured output."""
+
+        raise NotImplementedError
+
+    @classmethod
+    async def ainvoke(
+        cls,
+        tool_input: ToolInput,
+        global_state: ToolEngineState,
+    ) -> ToolOutput:
+        """Run the synchronous implementation without blocking the event loop."""
+
+        return await asyncio.to_thread(cls.invoke, tool_input, global_state)
+
+
+Tool: TypeAlias = BaseTool | type[SyncTool] | type[AsyncTool]
+
+
+__all__ = [
+    "AsyncTool",
+    "Finished",
+    "Running",
+    "SyncTool",
+    "ToolEngineState",
+    "ToolInput",
+    "ToolOutput",
+    "ToolResult",
+    "ToolState",
+    "Tool",
+]

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import types
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
 from typing import (
     Any,
+    Callable,
     ClassVar,
     Generic,
     TypeAlias,
@@ -19,11 +21,17 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+from uuid import uuid4
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import ToolCall, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langchain_core.runnables import Runnable
-from langchain_core.tools import BaseTool, StructuredTool
+from langchain_core.tools import BaseTool, StructuredTool, tool
 from pydantic import BaseModel
 
 
@@ -88,6 +96,11 @@ ToolEngineState: TypeAlias = Any
 
 # StopIteration 不能直接通过 asyncio Future 传播，因此用哨兵表示迭代结束。
 _SENTINEL = object()
+_ASYNC_TOOL_UPDATED_NAME = "async_tool_updated"
+_ASYNC_TOOL_STATUS_NAME = "id_to_async_tool_status"
+_SUBSCRIBE_ASYNC_TOOL_NAME = "subscribe_async_tool"
+_UNSUBSCRIBE_ASYNC_TOOL_NAME = "unsubscribe_async_tool"
+_STOP_ASYNC_TOOL_NAME = "stop_async_tool"
 
 
 def _next_or_sentinel(iterator: Iterator[ToolResult[TO]]) -> ToolResult[TO] | object:
@@ -484,6 +497,7 @@ class AsyncToolRun(ToolRun):
     tool_state: ToolState
     subscribed: bool
     running: bool
+    lifecycle_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     task: asyncio.Task[None] | None = None
     error: BaseException | None = None
 
@@ -498,6 +512,12 @@ class ToolEngine:
     ) -> None:
         """初始化工具引擎。"""
         self.tools = list(tools)
+        has_async_tool = any(
+            isinstance(tool_item, type) and issubclass(tool_item, AsyncTool)
+            for tool_item in self.tools
+        )
+        if has_async_tool:
+            self.tools.extend(self._create_assist_tools())
         self.state = state
         self._state_lock = asyncio.Lock()
         self._name_to_tool: dict[str, Tool] = {}
@@ -505,12 +525,15 @@ class ToolEngine:
         self._closed = False
         self._runs_lock = asyncio.Lock()
         self._reserved_call_ids: set[str] = set()
+        self._async_tool_update_callback: (
+            Callable[[ToolCall, ToolMessage], None] | None
+        ) = None
 
-        for tool in self.tools:
-            name = self._tool_name(tool)
+        for tool_item in self.tools:
+            name = self._tool_name(tool_item)
             if name in self._name_to_tool:
                 raise ValueError(f"Duplicate tool name: {name}")
-            self._name_to_tool[name] = tool
+            self._name_to_tool[name] = tool_item
 
     @staticmethod
     def _tool_name(tool: Tool) -> str:
@@ -522,6 +545,161 @@ class ToolEngine:
         if not name:
             raise ValueError(f"Tool {tool} must have a name")
         return name
+
+    @staticmethod
+    def _build_async_tool_update(
+        source_call_id: str,
+        result: ToolResult,
+    ) -> tuple[ToolCall, ToolMessage]:
+        """构建一个异步工具更新的 ToolCall 和 ToolMessage。"""
+
+        update_call_id = (
+            f"{source_call_id}:{_ASYNC_TOOL_UPDATED_NAME}:{uuid4().hex}"
+        )
+        tool_call = ToolCall(
+            id=update_call_id,
+            name=_ASYNC_TOOL_UPDATED_NAME,
+            args={"source_call_id": source_call_id},
+        )
+
+        tool_message = ToolMessage(
+            content=json.dumps(
+                ToolEngine._tool_result_payload(result),
+                ensure_ascii=False,
+            ),
+            tool_call_id=update_call_id,
+            name=_ASYNC_TOOL_UPDATED_NAME,
+        )
+        return tool_call, tool_message
+
+    @staticmethod
+    def _tool_result_payload(result: ToolResult) -> dict[str, Any]:
+        """将工具运行结果转换为可序列化的状态负载。"""
+
+        if isinstance(result, Running):
+            return {
+                "running": True,
+                "tool_output": result.content,
+            }
+        return {
+            "running": False,
+            "tool_output": result.content.to_content(),
+        }
+
+    @staticmethod
+    def _append_tool_call(
+        tool_call: ToolCall,
+        messages: list[BaseMessage],
+    ) -> None:
+        """确保消息历史中存在对应的 AI 工具调用声明。"""
+
+        call_id = str(tool_call.get("id", "") or "")
+        if not call_id:
+            raise ValueError("ToolCall must have an id")
+
+        for message in reversed(messages):
+            if not isinstance(message, AIMessage):
+                continue
+            for existing_call in message.tool_calls:
+                if str(existing_call.get("id", "") or "") != call_id:
+                    continue
+                if (
+                    existing_call.get("name") != tool_call.get("name")
+                    or existing_call.get("args", {}) != tool_call.get("args", {})
+                ):
+                    raise ValueError(f"Conflicting ToolCall id: {call_id}")
+                return
+
+        pending_batch = ToolEngine._find_pending_tool_call_message(messages)
+        if pending_batch is not None:
+            pending_message, insertion_index = pending_batch
+            pending_message.tool_calls.insert(insertion_index, tool_call)
+            return
+
+        messages.append(
+            AIMessage(
+                content="",
+                tool_calls=[tool_call],
+            )
+        )
+
+    @staticmethod
+    def _find_pending_tool_call_message(
+        messages: list[BaseMessage],
+    ) -> tuple[AIMessage, int] | None:
+        """查找最近的未完成 AI 工具调用批次及合成调用插入位置。"""
+
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if not isinstance(message, AIMessage):
+                continue
+            if not message.tool_calls:
+                return None
+
+            trailing_messages = messages[index + 1 :]
+            if not all(
+                isinstance(trailing_message, ToolMessage)
+                for trailing_message in trailing_messages
+            ):
+                return None
+
+            answered_ids = {
+                str(trailing_message.tool_call_id or "")
+                for trailing_message in trailing_messages
+            }
+            if any(
+                str(existing_call.get("id", "") or "") not in answered_ids
+                for existing_call in message.tool_calls
+            ):
+                return message, len(trailing_messages)
+            return None
+        return None
+
+    @staticmethod
+    def append_tool_message(
+        tool_call: ToolCall,
+        tool_message: ToolMessage,
+        messages: list[BaseMessage],
+    ) -> None:
+        """将工具调用和工具消息追加到消息历史。"""
+
+        call_id = str(tool_call.get("id", "") or "")
+        if not call_id:
+            raise ValueError("ToolCall must have an id")
+        if str(tool_message.tool_call_id or "") != call_id:
+            raise ValueError("ToolMessage tool_call_id must match ToolCall id")
+        if any(
+            isinstance(message, ToolMessage)
+            and str(message.tool_call_id or "") == call_id
+            for message in messages
+        ):
+            raise ValueError(
+                f"ToolMessage for this call id {call_id} already exists"
+            )
+        ToolEngine._append_tool_call(tool_call, messages)
+        messages.append(tool_message)
+
+    async def ainvoke_and_append(
+        self,
+        tool_call: ToolCall,
+        messages: list[BaseMessage],
+    ) -> ToolMessage:
+        """异步调用工具并将结果追加到消息历史。"""
+
+        tool_message = await self.ainvoke(tool_call)
+        self.append_tool_message(tool_call, tool_message, messages)
+        return tool_message
+
+    def invoke_and_append(
+        self,
+        tool_call: ToolCall,
+        messages: list[BaseMessage],
+    ) -> ToolMessage:
+        """同步调用工具并将结果追加到消息历史。"""
+
+        tool_message = self.invoke(tool_call)
+        self.append_tool_message(tool_call, tool_message, messages)
+        return tool_message
 
     @classmethod
     def _to_bindable_tool(cls, tool: Tool) -> BaseTool:
@@ -558,6 +736,243 @@ class ToolEngine:
         bindable_tools = [self._to_bindable_tool(tool) for tool in self.tools]
         return model.bind_tools(bindable_tools)
 
+    def on_async_tool_update(
+        self,
+        callback: Callable[[ToolCall, ToolMessage], None],
+    ) -> None:
+        """注册异步工具主动更新回调。"""
+
+        self._async_tool_update_callback = callback
+
+    def _create_async_tool_updated_tool(self) -> BaseTool:
+        """创建用于接收异步工具更新的系统工具。"""
+
+        @tool(_ASYNC_TOOL_UPDATED_NAME)
+        def async_tool_updated(source_call_id: str) -> str:
+            """Receive an update from an asynchronous tool.
+
+            This tool is called only by the system. Never call it directly.
+            Report any unreported update in the next response. If a new user
+            message is also present, briefly report the update before replying
+            to the user.
+
+            Parameters
+            ----------
+            source_call_id : str
+                The ID returned by the original asynchronous tool call.
+            """
+
+            del source_call_id
+            return "This tool can only be invoked by ToolEngine."
+
+        return async_tool_updated
+
+    def _create_async_tool_status_tool(self) -> BaseTool:
+        """创建用于查询异步工具状态的工具。"""
+
+        @tool(_ASYNC_TOOL_STATUS_NAME)
+        async def id_to_async_tool_status(source_call_id: str) -> str:
+            """Return the latest status of an asynchronous tool call.
+
+            Parameters
+            ----------
+            source_call_id : str
+                The ID returned by the original asynchronous tool call.
+            """
+
+            async with self._runs_lock:
+                run = self._id_to_tool_runs.get(source_call_id)
+
+            if not isinstance(run, AsyncToolRun):
+                return self._async_run_not_found_content(source_call_id)
+            async with self._state_lock:
+                status = await run.tool_class.astatus(
+                    run.tool_input,
+                    run.tool_state,
+                    self.state,
+                )
+            return json.dumps(
+                {
+                    "running": run.running,
+                    "status": status,
+                    "error": str(run.error) if run.error is not None else None,
+                },
+                ensure_ascii=False,
+            )
+        return id_to_async_tool_status
+
+    def _create_subscribe_tool(self) -> BaseTool:
+        """创建用于订阅异步工具更新的工具。"""
+
+        @tool(_SUBSCRIBE_ASYNC_TOOL_NAME)
+        async def subscribe_async_tool(source_call_id: str) -> str:
+            """Subscribe to progress updates from an asynchronous tool call.
+
+            Parameters
+            ----------
+            source_call_id : str
+                The ID returned by the original asynchronous tool call.
+            """
+
+            run = await self._get_async_run(source_call_id)
+            if run is None:
+                return self._async_run_not_found_content(source_call_id)
+
+            async with run.lifecycle_lock:
+                if run.subscribed:
+                    return json.dumps(
+                        {
+                            "subscribed": True,
+                            "running": run.running,
+                            "latest": self._tool_result_payload(run.result),
+                        },
+                        ensure_ascii=False,
+                    )
+                run.subscribed = True
+                try:
+                    async with self._state_lock:
+                        await run.tool_class.asubscribe(
+                            run.tool_input,
+                            run.tool_state,
+                            self.state,
+                        )
+                except BaseException:
+                    run.subscribed = False
+                    raise
+                return json.dumps(
+                    {
+                        "subscribed": True,
+                        "running": run.running,
+                        "latest": self._tool_result_payload(run.result),
+                    },
+                    ensure_ascii=False,
+                )
+        return subscribe_async_tool
+
+    def _create_unsubscribe_tool(self) -> BaseTool:
+        """创建用于取消订阅异步工具更新的工具。"""
+
+        @tool(_UNSUBSCRIBE_ASYNC_TOOL_NAME)
+        async def unsubscribe_async_tool(source_call_id: str) -> str:
+            """Stop receiving progress updates from an asynchronous tool call.
+
+            Parameters
+            ----------
+            source_call_id : str
+                The ID returned by the original asynchronous tool call.
+            """
+
+            run = await self._get_async_run(source_call_id)
+            if run is None:
+                return self._async_run_not_found_content(source_call_id)
+
+            async with run.lifecycle_lock:
+                if not run.subscribed:
+                    return json.dumps(
+                        {
+                            "subscribed": False,
+                            "running": run.running,
+                        },
+                        ensure_ascii=False,
+                    )
+                run.subscribed = False
+                try:
+                    async with self._state_lock:
+                        await run.tool_class.aunsubscribe(
+                            run.tool_input,
+                            run.tool_state,
+                            self.state,
+                        )
+                except BaseException:
+                    run.subscribed = True
+                    raise
+                return json.dumps(
+                    {
+                        "subscribed": False,
+                        "running": run.running,
+                    },
+                    ensure_ascii=False,
+                )
+        return unsubscribe_async_tool
+
+    def _create_stop_tool(self) -> BaseTool:
+        """创建异步工具停止工具。"""
+
+        @tool(_STOP_ASYNC_TOOL_NAME)
+        async def stop_async_tool(source_call_id: str) -> str:
+            """Stop an asynchronous tool call and release its resources.
+
+            Parameters
+            ----------
+            source_call_id : str
+                The ID returned by the original asynchronous tool call.
+            """
+
+            run = await self._get_async_run(source_call_id)
+            if run is None:
+                return self._async_run_not_found_content(source_call_id)
+
+            async with run.lifecycle_lock:
+                if not run.running:
+                    return json.dumps(
+                        {
+                            "running": False,
+                            "stopped": True,
+                        },
+                        ensure_ascii=False,
+                    )
+                run.running = False
+                try:
+                    async with self._state_lock:
+                        await run.tool_class.astop(
+                            run.tool_input,
+                            run.tool_state,
+                            self.state,
+                        )
+                except BaseException as exc:
+                    run.error = exc
+                    raise
+                finally:
+                    if run.task is not None and not run.task.done():
+                        run.task.cancel()
+                    run.running = False
+
+                return json.dumps(
+                    {
+                        "running": False,
+                        "stopped": True,
+                    },
+                    ensure_ascii=False,
+                )
+        return stop_async_tool
+
+    async def _get_async_run(self, source_call_id: str) -> AsyncToolRun | None:
+        """按调用 ID 查找异步工具运行记录。"""
+
+        async with self._runs_lock:
+            run = self._id_to_tool_runs.get(source_call_id)
+        return run if isinstance(run, AsyncToolRun) else None
+
+    @staticmethod
+    def _async_run_not_found_content(source_call_id: str) -> str:
+        """构造异步工具调用不存在时的 JSON 结果。"""
+
+        return json.dumps(
+            {"error": f"Async tool run not found: {source_call_id}"},
+            ensure_ascii=False,
+        )
+
+    def _create_assist_tools(self) -> list[BaseTool]:
+        """创建异步工具协议所需的辅助工具。"""
+
+        return [
+            self._create_async_tool_updated_tool(),
+            self._create_async_tool_status_tool(),
+            self._create_subscribe_tool(),
+            self._create_unsubscribe_tool(),
+            self._create_stop_tool(),
+        ]
+
     async def _reserve_call_id(self, call_id: str) -> None:
         """为一次工具调用保留唯一的 call_id。"""
 
@@ -593,9 +1008,10 @@ class ToolEngine:
     ) -> None:
         """在引擎仍开放时订阅并启动异步工具的后台更新任务。"""
 
-        async with self._runs_lock:
-            if self._closed:
-                raise RuntimeError("ToolEngine is closed")
+        async with run.lifecycle_lock:
+            async with self._runs_lock:
+                if self._closed:
+                    raise RuntimeError("ToolEngine is closed")
             if run.subscribed:
                 async with self._state_lock:
                     await run.tool_class.asubscribe(
@@ -603,12 +1019,15 @@ class ToolEngine:
                         run.tool_state,
                         self.state,
                     )
-            task = asyncio.create_task(self._consume_async_updates(call_id))
-            task.add_done_callback(self._consume_task_exception)
-            run.task = task
+            async with self._runs_lock:
+                if self._closed:
+                    raise RuntimeError("ToolEngine is closed")
+                task = asyncio.create_task(self._consume_async_updates(call_id))
+                task.add_done_callback(self._consume_task_exception)
+                run.task = task
 
     async def ainvoke(self, tool_call: ToolCall) -> ToolMessage:
-        """异步调用一个工具。"""
+        """异步调用工具。"""
 
         if self._closed:
             raise RuntimeError("ToolEngine is closed")
@@ -789,6 +1208,19 @@ class ToolEngine:
                     )
 
                 run.result = result
+
+                should_notify = (
+                    run.subscribed
+                    or isinstance(result, Finished)
+                )
+                callback = self._async_tool_update_callback
+                if should_notify and callback is not None:
+                    tool_call, tool_message = self._build_async_tool_update(
+                        call_id,
+                        result,
+                    )
+                    callback(tool_call, tool_message)
+
                 if isinstance(result, Finished):
                     return
 
@@ -811,7 +1243,7 @@ class ToolEngine:
             task.exception()
 
     async def shutdown(self) -> None:
-        """关闭工具引擎，取消所有正在运行的异步工具调用。"""
+        """关闭工具引擎并取消所有仍在运行的异步工具调用。"""
 
         async with self._runs_lock:
             if self._closed:
@@ -824,21 +1256,22 @@ class ToolEngine:
             ]
 
         async def stop_run(run: AsyncToolRun) -> None:
-            if not run.running:
-                return
-            try:
-                async with self._state_lock:
-                    await run.tool_class.astop(
-                        run.tool_input,
-                        run.tool_state,
-                        self.state,
-                    )
-            except BaseException as exc:
-                run.error = exc
-            finally:
-                if run.task is not None and not run.task.done():
-                    run.task.cancel()
-                run.running = False
+            async with run.lifecycle_lock:
+                if not run.running:
+                    return
+                try:
+                    async with self._state_lock:
+                        await run.tool_class.astop(
+                            run.tool_input,
+                            run.tool_state,
+                            self.state,
+                        )
+                except BaseException as exc:
+                    run.error = exc
+                finally:
+                    if run.task is not None and not run.task.done():
+                        run.task.cancel()
+                    run.running = False
 
         await asyncio.gather(*(stop_run(run) for run in runs), return_exceptions=True)
         tasks = [run.task for run in runs if run.task is not None]

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -754,7 +754,18 @@ class ToolEngine:
         self,
         model: BaseChatModel,
     ) -> BaseChatModel | Runnable[Any, Any]:
-        """Bind all tool schemas while preventing model-initiated calls."""
+        """Bind tool schemas while preventing model-initiated calls.
+
+        Parameters
+        ----------
+        model : BaseChatModel
+            Chat model that should receive the registered tool schemas.
+
+        Returns
+        -------
+        BaseChatModel or Runnable[Any, Any]
+            Model binding that exposes the schemas with tool choice disabled.
+        """
 
         if not self.tools:
             return model

--- a/src/xtalk/models/agents/tools/core.py
+++ b/src/xtalk/models/agents/tools/core.py
@@ -743,7 +743,11 @@ class ToolEngine:
 
         if not self.tools:
             return model
-        bindable_tools = [self._to_bindable_tool(tool) for tool in self.tools]
+        bindable_tools = [
+            self._to_bindable_tool(tool)
+            for tool in self.tools
+            if self._tool_name(tool) != _ASYNC_TOOL_UPDATED_NAME
+        ]
         return model.bind_tools(bindable_tools)
 
     def on_async_tool_update(
@@ -787,6 +791,9 @@ class ToolEngine:
             Use this tool when the latest progress is needed without changing
             the subscription state. The result reports whether the call is
             still running, its tool-defined status, and any recorded error.
+            Call it only when the user explicitly asks for the current status.
+            Never poll it repeatedly; subscribe and wait for system updates
+            when future progress is needed.
 
             Parameters
             ----------
@@ -825,6 +832,8 @@ class ToolEngine:
             After subscription, the system may deliver intermediate results
             through ``async_tool_updated``. The subscription response also
             includes the latest known result. Final results are always sent.
+            After subscribing, stop calling tools and wait for the system to
+            deliver updates. Do not poll the status tool.
 
             Parameters
             ----------

--- a/src/xtalk/serving/modules/llm_agent_generation_manager.py
+++ b/src/xtalk/serving/modules/llm_agent_generation_manager.py
@@ -7,7 +7,7 @@ import asyncio
 from typing import Any, AsyncIterator
 
 from ...models import Agent, Models
-from ...models.agents import AgentOutput
+from ...models.agents import AgentOutput, AgentTurnBoundary
 from ...log_utils import logger
 from ..event_bus import EventBus
 from ..events import (
@@ -113,6 +113,9 @@ class LLMAgentConsumptionManager(Manager):
             return
 
         agent.model = new_model
+        if hasattr(agent, "tool_engine"):
+            agent.model_with_tools = agent.tool_engine.bind(new_model)
+            return
         if not hasattr(agent, "_model_with_tools"):
             return
 
@@ -136,7 +139,7 @@ class LLMAgentConsumptionManager(Manager):
         iterator = event.stream.__aiter__()
         async with self._streams_lock:
             if not self._active_streams:
-                self._reset_turn_output_state_locked()
+                self._reset_turn_output_state()
 
             task = asyncio.create_task(
                 self._consume_stream(
@@ -240,6 +243,7 @@ class LLMAgentConsumptionManager(Manager):
                 self.session_id,
             )
             await self._publish_error("llm_stream_error", str(exc))
+            await self._finish_current_turn()
         finally:
             await self._finalize_stream(
                 task=task,
@@ -256,6 +260,10 @@ class LLMAgentConsumptionManager(Manager):
 
         async with self._output_lock:
             if task not in self._active_streams:
+                return
+
+            if isinstance(item, AgentTurnBoundary):
+                await self._finish_current_turn_locked()
                 return
 
             if not self._turn_first_chunk_generated:
@@ -304,26 +312,37 @@ class LLMAgentConsumptionManager(Manager):
         """Finalize one stream and emit turn-finish events when it is the last."""
 
         try:
+            should_finish = False
             async with self._streams_lock:
                 popped_iterator = self._active_streams.pop(task, None)
                 if popped_iterator is None:
                     return
-                if self._active_streams:
-                    return
-
-                final_text = self._turn_accumulated_text
-                tts_started = self._turn_tts_started
-                has_text_output = bool(final_text) or tts_started
-                self._reset_turn_output_state_locked()
-                if not has_text_output:
-                    return
-                if tts_started:
-                    await self.event_bus.publish(
-                        TurnTTSFlushRequested(session_id=self.session_id)
-                    )
-                await self._publish_llm_response_finish(final_text)
+                should_finish = not self._active_streams
+            if should_finish:
+                await self._finish_current_turn()
         finally:
             await self._close_iterator(iterator)
+
+    async def _finish_current_turn(self) -> None:
+        """Finish the current shared turn under the output lock."""
+
+        async with self._output_lock:
+            await self._finish_current_turn_locked()
+
+    async def _finish_current_turn_locked(self) -> None:
+        """Flush and finish the current turn while holding the output lock."""
+
+        final_text = self._turn_accumulated_text
+        tts_started = self._turn_tts_started
+        has_text_output = bool(final_text) or tts_started
+        self._reset_turn_output_state()
+        if not has_text_output:
+            return
+        if tts_started:
+            await self.event_bus.publish(
+                TurnTTSFlushRequested(session_id=self.session_id)
+            )
+        await self._publish_llm_response_finish(final_text)
 
     def _detach_all_streams_locked(
         self,
@@ -334,11 +353,11 @@ class LLMAgentConsumptionManager(Manager):
         iterators = list(self._active_streams.values())
         self._active_streams.clear()
         self._resume_event.set()
-        self._reset_turn_output_state_locked()
+        self._reset_turn_output_state()
         return tasks, iterators
 
-    def _reset_turn_output_state_locked(self) -> None:
-        """Reset per-turn shared output state while holding ``_streams_lock``."""
+    def _reset_turn_output_state(self) -> None:
+        """Reset the shared per-turn output state."""
 
         self._turn_accumulated_text = ""
         self._turn_first_chunk_generated = False
@@ -444,3 +463,7 @@ class LLMAgentConsumptionManager(Manager):
             tasks, iterators = self._detach_all_streams_locked()
         await self._cancel_tasks(tasks)
         await self._close_iterators(iterators)
+
+        agent = self.models.get(Agent)
+        if agent is not None and hasattr(agent, "tool_engine"):
+            await agent.tool_engine.shutdown()


### PR DESCRIPTION
## Summary

  This PR adds native synchronous and asynchronous tool support and integrates the new ToolEngine with ExperimentalAgent.

  - Add `SyncTool` and `AsyncTool` interfaces with annotation-based input, state, and output type inference.
  - Add ToolEngine support for tool binding, invocation, lifecycle tracking, message history, status queries, subscriptions, cancellation,
  and shutdown.
  - Integrate asynchronous tool updates with ExperimentalAgent and the agent generation manager.
  - Handle ASR partials interrupted by tool updates without duplicating user text or producing empty HumanMessages.
  - Coalesce queued tool updates into one model generation.
  - Update the English and Chinese tool design documentation.

  ## Validation

  - Ran local smoke checks for synchronous and asynchronous tool invocation, progress updates, final results, status queries,
  cancellation, and shutdown.
  - Verified ToolCall and ToolMessage history ordering with local message-protocol checks.
  - Verified ASR partial merging and queued update coalescing with local regression checks.
  - Ran `python -m compileall -q src/xtalk`.
  - Ran the examples documented in the English and Chinese tool design documents.

  ## Notes

  - No external API key or real tool-calling model was used.
  - Async tools that mutate shared ToolEngineState must provide their own short-lived synchronization.