### PR TITLE
Improve frontend VAD sensitivity and redesign the sample voice UI

### DIFF
--- a/examples/sample_app/static/css/index.css
+++ b/examples/sample_app/static/css/index.css
@@ -333,6 +333,23 @@ svg {
     height: 18px;
 }
 
+.message-copy-button .icon-check {
+    display: none;
+}
+
+.message-copy-button.is-copied {
+    color: var(--text-muted);
+    opacity: 1;
+}
+
+.message-copy-button.is-copied .icon-copy {
+    display: none;
+}
+
+.message-copy-button.is-copied .icon-check {
+    display: block;
+}
+
 .chat-mini-orb {
     position: fixed;
     z-index: 23;

--- a/examples/sample_app/static/css/index.css
+++ b/examples/sample_app/static/css/index.css
@@ -1,431 +1,940 @@
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+:root {
+    color-scheme: light dark;
+    --bg: #f7f7f5;
+    --surface: rgba(255, 255, 255, 0.86);
+    --surface-solid: #ffffff;
+    --surface-muted: #ececea;
+    --surface-hover: #e5e5e2;
+    --sidebar-bg: #f0f0ee;
+    --text: #18181b;
+    --text-muted: #71717a;
+    --border: rgba(24, 24, 27, 0.12);
+    --shadow: 0 20px 60px rgba(24, 24, 27, 0.12);
+    --backdrop: rgba(9, 9, 11, 0.25);
+    --primary: #18181b;
+    --primary-text: #ffffff;
+    --danger: #18181b;
+    --focus: #6d78ff;
+    --orb-blue: #7884ff;
+    --orb-lavender: #b7c0ff;
+    --orb-white: #f8fbff;
+    --drawer-width-left: 320px;
+    --drawer-width-right: 360px;
+    --topbar-height: 72px;
+    --dock-offset: max(24px, env(safe-area-inset-bottom));
 }
 
-body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-    background: #0f172a;
-    color: #e5e7eb;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
-
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1rem;
-    width: 100%;
-}
-
-header {
-    background: #1e293b;
-    border-bottom: 1px solid #334155;
-    padding: 1rem 0;
-}
-
-header h1 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-}
-
-.status {
-    display: flex;
-    gap: 2rem;
-    margin-bottom: 1rem;
-    font-size: 0.875rem;
-}
-
-.status span {
-    color: #60a5fa;
-    font-weight: 600;
-}
-
-.controls {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-
-button {
-    padding: 0.5rem 1rem;
-    background: #3b82f6;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
-    transition: background 0.2s;
-}
-
-button:hover:not(:disabled) {
-    background: #2563eb;
-}
-
-button:disabled {
-    background: #475569;
-    cursor: not-allowed;
-    opacity: 0.6;
-}
-
-button.is-loading {
-    position: relative;
-}
-
-button.is-loading::after {
-    content: "";
-    width: 0.8rem;
-    height: 0.8rem;
-    margin-left: 0.5rem;
-    display: inline-block;
-    vertical-align: -0.12rem;
-    border: 2px solid rgba(255, 255, 255, 0.35);
-    border-top-color: #ffffff;
-    border-radius: 999px;
-    animation: button-spin 0.8s linear infinite;
-}
-
-@keyframes button-spin {
-    to {
-        transform: rotate(360deg);
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #050505;
+        --surface: rgba(31, 31, 31, 0.9);
+        --surface-solid: #171717;
+        --surface-muted: #262626;
+        --surface-hover: #303030;
+        --sidebar-bg: #171717;
+        --text: #f4f4f5;
+        --text-muted: #a1a1aa;
+        --border: rgba(255, 255, 255, 0.12);
+        --shadow: 0 24px 72px rgba(0, 0, 0, 0.48);
+        --backdrop: rgba(0, 0, 0, 0.56);
+        --primary: #f4f4f5;
+        --primary-text: #18181b;
+        --danger: #f4f4f5;
     }
 }
 
-main {
-    flex: 1;
-    padding: 2rem 1rem;
+* {
+    box-sizing: border-box;
 }
 
-.app-shell {
+html,
+body {
+    width: 100%;
+    min-height: 100%;
+    margin: 0;
+}
+
+body {
+    min-height: 100vh;
+    min-height: 100dvh;
+    overflow: hidden;
+    background: var(--bg);
+    color: var(--text);
+    font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+button,
+select {
+    color: inherit;
+    font: inherit;
+}
+
+button {
+    border: 0;
+}
+
+button:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 3px;
+}
+
+button:disabled,
+select:disabled {
+    cursor: not-allowed;
+    opacity: 0.42;
+}
+
+svg {
+    display: block;
+    width: 24px;
+    height: 24px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.8;
+}
+
+.app {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    isolation: isolate;
+    overflow: hidden;
+}
+
+.topbar {
+    position: fixed;
+    z-index: 20;
+    inset: 0 0 auto;
+    height: var(--topbar-height);
+    padding: max(12px, env(safe-area-inset-top)) 24px 8px;
     display: grid;
-    grid-template-columns: 280px minmax(0, 1fr);
-    gap: 1rem;
-    align-items: start;
+    grid-template-columns: 48px 1fr 48px;
+    align-items: center;
+    pointer-events: none;
 }
 
-.content-area {
-    min-width: 0;
+.topbar > * {
+    pointer-events: auto;
 }
 
-.sidebar {
-    position: sticky;
-    top: 1rem;
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.875rem;
-    max-height: calc(100vh - 2rem);
+.brand {
+    justify-self: center;
+    font-size: 18px;
+    font-weight: 650;
+    letter-spacing: -0.025em;
 }
 
-.sidebar-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.75rem;
+.icon-button,
+.control-button {
+    display: inline-grid;
+    place-items: center;
+    cursor: pointer;
+    background: transparent;
+    transition: background-color 160ms ease, color 160ms ease, transform 160ms ease, opacity 160ms ease;
 }
 
-.sidebar-eyebrow {
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: #94a3b8;
-    margin-bottom: 0.2rem;
+.icon-button {
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
 }
 
-.sidebar h2 {
-    font-size: 1.1rem;
+.icon-button:hover:not(:disabled) {
+    background: var(--surface-muted);
 }
 
-.sidebar-action,
-.new-session-btn {
+.icon-button:active:not(:disabled),
+.control-button:active:not(:disabled) {
+    transform: scale(0.95);
+}
+
+.topbar .icon-button:last-child {
+    justify-self: end;
+}
+
+.workspace {
     width: 100%;
+    height: 100%;
+    padding: calc(var(--topbar-height) + 12px) 24px calc(112px + var(--dock-offset));
 }
 
-.sidebar-action {
-    width: auto;
-    padding-inline: 0.85rem;
-    background: #334155;
-}
-
-.sidebar-action:hover:not(:disabled) {
-    background: #475569;
-}
-
-.new-session-btn {
-    background: #0f766e;
-}
-
-.new-session-btn:hover:not(:disabled) {
-    background: #0d9488;
-}
-
-.sidebar-empty {
-    font-size: 0.8125rem;
-    color: #94a3b8;
-    padding: 0.5rem 0.25rem;
-}
-
-.session-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    overflow-y: auto;
-    padding-right: 0.25rem;
-}
-
-.session-item {
+.view-panel {
     width: 100%;
-    border: 1px solid #334155;
-    border-radius: 0.65rem;
-    background: #0f172a;
-    color: #e5e7eb;
-    padding: 0.85rem 0.9rem;
-    text-align: left;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.session-item:hover:not(:disabled) {
-    background: #132033;
-}
-
-.session-item.active {
-    border-color: #60a5fa;
-    background: #12233a;
-    box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.3);
-}
-
-.session-title {
-    font-size: 0.9rem;
-    font-weight: 600;
-    line-height: 1.35;
-    color: #f8fafc;
-}
-
-.session-meta {
-    font-size: 0.72rem;
-    color: #94a3b8;
-}
-
-.latency-bar {
-    display: flex;
-    gap: 1.5rem;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-    padding: 0.5rem 0.75rem;
-    background: #1e293b;
-    border: 1px solid #334155;
-    border-radius: 0.5rem;
-    font-size: 0.75rem;
-    color: #94a3b8;
-}
-
-.latency-item span {
-    color: #60a5fa;
-    font-weight: 600;
-}
-
-.latency-e2e {
-    color: #fbbf24;
-    font-weight: 600;
-}
-
-.card {
-    background: #1e293b;
-    border: 1px solid #334155;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin-bottom: 1rem;
+    height: 100%;
 }
 
 .is-hidden {
     display: none !important;
 }
 
+.orb-view {
+    display: grid;
+    place-items: center;
+}
+
+.orb-button {
+    position: relative;
+    width: clamp(220px, 27vw, 360px);
+    aspect-ratio: 1;
+    padding: 0;
+    border-radius: 50%;
+    cursor: pointer;
+    background: transparent;
+    filter: drop-shadow(0 28px 56px rgba(91, 105, 230, 0.18));
+    transition: transform 220ms ease, filter 220ms ease;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.orb-button:hover {
+    transform: scale(1.018);
+    filter: drop-shadow(0 32px 68px rgba(91, 105, 230, 0.25));
+}
+
+.orb-button:active {
+    transform: scale(0.985);
+}
+
 #waveform {
-    width: 100%;
-    height: 200px;
     display: block;
-    background: #0f172a;
-    border-radius: 0.375rem;
-}
-
-.recent-audio-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.875rem;
-}
-
-.recent-audio-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-
-.recent-audio-toggle {
-    background: #0f766e;
-}
-
-.recent-audio-toggle:hover:not(:disabled) {
-    background: #0d9488;
-}
-
-.recent-audio-status {
-    font-size: 0.8125rem;
-    color: #94a3b8;
-}
-
-.recent-audio-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 0.625rem;
-    padding: 0.875rem;
-    border-radius: 0.5rem;
-    background: #0f172a;
-    border: 1px solid #334155;
-}
-
-.recent-audio-player {
     width: 100%;
+    height: 100%;
+    border-radius: 50%;
 }
 
-.recent-audio-hint {
-    font-size: 0.75rem;
-    color: #94a3b8;
-}
-
-.chat-card-label {
-    font-size: 0.75rem;
-    color: #94a3b8;
-    margin-bottom: 0.625rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+.chat-view {
+    position: relative;
+    width: min(860px, 100%);
+    margin: 0 auto;
+    padding: 0;
 }
 
 #messages {
-    max-height: 400px;
-    overflow-y: auto;
+    height: 100%;
+    padding: 28px 2px 112px;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 14px;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+}
+
+#messages:empty::before {
+    content: "暂无对话记录";
+    margin: auto;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.message-row {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+}
+
+.message-row-user {
+    align-items: flex-end;
+}
+
+.message-row-info {
+    align-items: center;
 }
 
 .message {
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    line-height: 1.4;
-    max-width: 80%;
-    word-wrap: break-word;
+    max-width: min(78%, 680px);
+    padding: 11px 15px;
+    border-radius: 18px;
+    font-size: 15px;
+    line-height: 1.58;
+    overflow-wrap: anywhere;
 }
 
 .message-user {
-    background: #334155;
     align-self: flex-end;
+    background: var(--surface-muted);
+    border-bottom-right-radius: 6px;
 }
 
 .message-assistant {
-    background: #1e3a5f;
     align-self: flex-start;
+    padding-left: 2px;
+    background: transparent;
 }
 
 .message-info {
-    background: #374151;
     align-self: center;
-    font-style: italic;
-    color: #94a3b8;
+    padding: 6px 12px;
+    color: var(--text-muted);
+    background: transparent;
+    font-size: 13px;
 }
 
 .message-tool {
-    background: #111827;
-    border: 1px solid #475569;
     align-self: flex-start;
     max-width: 100%;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: var(--surface);
 }
 
 .message-tool-label {
-    font-size: 0.75rem;
-    color: #fbbf24;
-    margin-bottom: 0.4rem;
+    margin-bottom: 8px;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
 }
 
 .message-tool-args {
     margin: 0;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 0.8125rem;
-    line-height: 1.45;
-    white-space: pre-wrap;
-    word-break: break-word;
-    color: #cbd5e1;
-}
-
-.toggle-bar {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-}
-
-.toggle-btn {
-    background: #475569;
-    font-size: 0.75rem;
-    padding: 0.375rem 0.75rem;
-}
-
-.toggle-btn.active {
-    background: #3b82f6;
-}
-
-.panel .panel-label {
-    font-size: 0.75rem;
-    color: #94a3b8;
-    margin-bottom: 0.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.panel .panel-content {
-    font-size: 0.875rem;
+    color: inherit;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
     line-height: 1.5;
     white-space: pre-wrap;
-    word-wrap: break-word;
-    max-height: 200px;
+}
+
+.message-actions {
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+}
+
+.message-copy-button {
+    width: 30px;
+    height: 28px;
+    padding: 0;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    border-radius: 8px;
+    color: var(--text-muted);
+    background: transparent;
+    opacity: 0.78;
+    transition: color 140ms ease, background-color 140ms ease, opacity 140ms ease;
+}
+
+.message-copy-button:hover {
+    color: var(--text);
+    background: var(--surface-muted);
+    opacity: 1;
+}
+
+.message-copy-button svg {
+    width: 18px;
+    height: 18px;
+}
+
+.chat-mini-orb {
+    position: fixed;
+    z-index: 23;
+    left: 50%;
+    bottom: calc(var(--dock-offset) + 80px);
+    width: 72px;
+    height: 72px;
+    padding: 0;
+    cursor: pointer;
+    border-radius: 50%;
+    background: transparent;
+    filter: drop-shadow(0 12px 24px rgba(91, 105, 230, 0.26));
+    transform: translateX(-50%);
+    transition: left 240ms cubic-bezier(0.22, 1, 0.36, 1), transform 180ms ease, opacity 180ms ease;
+}
+
+.chat-mini-orb:hover {
+    transform: translateX(-50%) scale(1.06);
+}
+
+.chat-mini-orb:active {
+    transform: translateX(-50%) scale(0.96);
+}
+
+.chat-mini-orb > span {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 46% 70%, rgba(255, 255, 255, 0.96) 0 13%, transparent 48%),
+        linear-gradient(150deg, var(--orb-blue), var(--orb-lavender) 58%, var(--orb-white));
+}
+
+.chat-mini-orb[data-stream-state="processing"] > span {
+    animation: mini-orb-pulse 1.2s ease-in-out infinite;
+}
+
+.chat-mini-orb[data-stream-state="speaking"] > span {
+    animation: mini-orb-pulse 0.72s ease-in-out infinite;
+}
+
+.chat-mini-orb.is-muted {
+    opacity: 0.5;
+}
+
+@keyframes mini-orb-pulse {
+    50% { transform: scale(1.07); }
+}
+
+.control-dock {
+    position: fixed;
+    z-index: 24;
+    left: 50%;
+    bottom: var(--dock-offset);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    transform: translateX(-50%);
+}
+
+.control-button {
+    position: relative;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+}
+
+.control-button-secondary {
+    background: var(--surface-muted);
+}
+
+.control-button-secondary:hover:not(:disabled) {
+    background: var(--surface-hover);
+}
+
+.control-button-primary {
+    color: var(--primary-text);
+    background: var(--primary);
+}
+
+.control-button-primary:hover:not(:disabled) {
+    filter: brightness(0.9);
+}
+
+.control-button svg {
+    width: 26px;
+    height: 26px;
+}
+
+.control-button[data-action="start"] .icon-close,
+.control-button[data-action="stop"] .icon-wave,
+.control-button:not(.is-muted) .icon-mic-off,
+.control-button.is-muted .icon-mic {
+    display: none;
+}
+
+.control-button.is-muted {
+    color: #fff;
+    background: #d83a3a;
+}
+
+.control-button.is-loading svg {
+    visibility: hidden;
+}
+
+.control-spinner {
+    position: absolute;
+    inset: 50% auto auto 50%;
+    display: none;
+    width: 20px;
+    height: 20px;
+    margin: -10px 0 0 -10px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 700ms linear infinite;
+}
+
+.is-loading > .control-spinner {
+    display: block;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.drawer-backdrop {
+    position: fixed;
+    z-index: 38;
+    inset: 0;
+    display: block;
+    visibility: hidden;
+    cursor: default;
+    background: var(--backdrop);
+    opacity: 0;
+    transition: opacity 220ms ease, visibility 0s linear 220ms;
+}
+
+.drawer-backdrop.is-visible {
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
+}
+
+.app-drawer {
+    position: fixed;
+    z-index: 40;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--surface-solid);
+    box-shadow: var(--shadow);
+    transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: transform;
+}
+
+.app-drawer-left {
+    left: 0;
+    width: min(var(--drawer-width-left), 90vw);
+    border-right: 1px solid var(--border);
+    background: var(--sidebar-bg);
+    box-shadow: none;
+    transform: translateX(-102%);
+}
+
+.app-drawer-right {
+    right: 0;
+    width: min(var(--drawer-width-right), 92vw);
+    border-left: 1px solid var(--border);
+    transform: translateX(102%);
+}
+
+.app-drawer.is-open {
+    transform: translateX(0);
+}
+
+.drawer-header {
+    min-height: 78px;
+    padding: max(18px, env(safe-area-inset-top)) 18px 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.drawer-header h2 {
+    margin: 2px 0 0;
+    font-size: 18px;
+    letter-spacing: -0.02em;
+}
+
+.sessions-drawer-header {
+    min-height: 58px;
+    padding: max(10px, env(safe-area-inset-top)) 10px 6px 16px;
+    border-bottom: 0;
+}
+
+.sessions-drawer-header h2 {
+    font-size: 17px;
+    font-weight: 680;
+}
+
+.drawer-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.sessions-drawer-header .icon-button {
+    width: 36px;
+    height: 36px;
+    background: transparent;
+}
+
+.sessions-drawer-header .icon-button:hover:not(:disabled) {
+    background: var(--surface-hover);
+}
+
+.drawer-eyebrow {
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 680;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.icon-button-quiet {
+    flex: 0 0 auto;
+    background: var(--surface-muted);
+}
+
+.new-session-button {
+    margin: 2px 8px 10px;
+    min-height: 44px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    border-radius: 10px;
+    color: var(--text);
+    background: var(--surface-muted);
+    font-weight: 590;
+    text-align: left;
+}
+
+.new-session-button:hover:not(:disabled) {
+    background: var(--surface-hover);
+}
+
+.new-session-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+
+
+.sidebar-empty {
+    padding: 18px;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.session-list {
+    min-height: 0;
+    padding: 0 8px max(16px, env(safe-area-inset-bottom));
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1px;
     overflow-y: auto;
 }
 
-footer {
-    background: #1e293b;
-    border-top: 1px solid #334155;
-    padding: 1rem;
-    text-align: center;
-    font-size: 0.875rem;
-    color: #94a3b8;
+.session-item {
+    width: 100%;
+    min-height: 40px;
+    padding: 9px 10px;
+    display: block;
+    cursor: pointer;
+    border-radius: 9px;
+    color: var(--text);
+    background: transparent;
+    text-align: left;
+}
+
+.session-item:hover,
+.session-item.active {
+    background: var(--surface-muted);
+}
+
+.session-item.active {
+    box-shadow: none;
+}
+
+.session-title {
+    overflow: hidden;
+    font-size: 14px;
+    font-weight: 460;
+    line-height: 1.55;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+
+
+.debug-scroll {
+    min-height: 0;
+    padding: 14px 14px max(20px, env(safe-area-inset-bottom));
+    flex: 1;
+    overflow-y: auto;
+}
+
+.debug-section,
+.debug-details {
+    margin-bottom: 10px;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: var(--surface);
+}
+
+.debug-section {
+    padding: 14px;
+}
+
+.debug-section h3,
+.debug-section label {
+    display: block;
+    margin: 0 0 12px;
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.runtime-grid,
+.latency-grid {
+    margin: 0;
+}
+
+.runtime-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.runtime-grid div,
+.latency-grid div {
+    min-width: 0;
+}
+
+.runtime-grid .runtime-session {
+    grid-column: 1 / -1;
+}
+
+.runtime-grid dt,
+.latency-grid dt {
+    margin-bottom: 4px;
+    color: var(--text-muted);
+    font-size: 10px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.runtime-grid dd,
+.latency-grid dd {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    overflow-wrap: anywhere;
+}
+
+#voice-select {
+    width: 100%;
+    min-height: 42px;
+    padding: 0 36px 0 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    color: var(--text);
+    background: var(--surface-solid);
+}
+
+.debug-details {
+    overflow: hidden;
+}
+
+.debug-details summary {
+    min-height: 46px;
+    padding: 0 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 630;
+    list-style: none;
+}
+
+.debug-details summary::-webkit-details-marker {
+    display: none;
+}
+
+.debug-details summary::after {
+    content: "+";
+    margin-left: auto;
+    color: var(--text-muted);
+    font-size: 18px;
+    font-weight: 400;
+}
+
+.debug-details[open] summary::after {
+    content: "−";
+}
+
+.summary-value {
+    margin-left: auto;
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.latency-grid {
+    padding: 0 14px 14px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.debug-content {
+    min-height: 54px;
+    max-height: 230px;
+    padding: 0 14px 14px;
+    overflow-y: auto;
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.debug-content:empty::before {
+    content: "--";
+}
+
+.recent-audio-panel {
+    padding: 0 14px 14px;
+}
+
+.recent-audio-status {
+    margin-bottom: 10px;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+}
+
+.recent-audio-player {
+    width: 100%;
+    height: 38px;
+}
+
+.toast-region {
+    position: fixed;
+    z-index: 60;
+    top: calc(var(--topbar-height) + 8px);
+    left: 50%;
+    width: min(420px, calc(100vw - 32px));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    pointer-events: none;
+    transform: translateX(-50%);
+}
+
+.toast {
+    padding: 11px 14px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    color: var(--text);
+    background: var(--surface-solid);
+    box-shadow: var(--shadow);
+    font-size: 13px;
+    line-height: 1.45;
+    animation: toast-in 180ms ease-out;
+}
+
+.toast-success {
+    border-color: rgba(34, 197, 94, 0.42);
+}
+
+.toast-error {
+    border-color: rgba(239, 68, 68, 0.52);
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateY(-8px); }
+}
+
+@media (min-width: 901px) {
+    .topbar,
+    .workspace,
+    .control-dock,
+    .chat-mini-orb {
+        transition: left 240ms cubic-bezier(0.22, 1, 0.36, 1),
+            width 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    body[data-drawer="sessions"] .drawer-backdrop {
+        visibility: hidden;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    body[data-drawer="sessions"] .topbar {
+        left: var(--drawer-width-left);
+    }
+
+    body[data-drawer="sessions"] .workspace {
+        width: calc(100% - var(--drawer-width-left));
+        margin-left: var(--drawer-width-left);
+    }
+
+    body[data-drawer="sessions"] .control-dock,
+    body[data-drawer="sessions"] .chat-mini-orb {
+        left: calc(50% + var(--drawer-width-left) / 2);
+    }
 }
 
 @media (max-width: 640px) {
-    .recent-audio-header {
-        align-items: flex-start;
+    :root {
+        --topbar-height: 68px;
+        --dock-offset: max(18px, env(safe-area-inset-bottom));
+    }
+
+    .topbar {
+        padding-right: 14px;
+        padding-left: 14px;
+    }
+
+    .workspace {
+        padding: calc(var(--topbar-height) + 4px) 16px calc(102px + var(--dock-offset));
+    }
+
+    .orb-button {
+        width: min(58vw, 280px);
+        min-width: 210px;
+    }
+
+    .chat-view {
+        padding-top: 0;
+    }
+
+    #messages {
+        height: 100%;
+        padding-top: 20px;
+        padding-bottom: 96px;
+        gap: 12px;
+    }
+
+    .chat-mini-orb {
+        bottom: calc(var(--dock-offset) + 76px);
+        width: 64px;
+        height: 64px;
+    }
+
+    .message {
+        max-width: 88%;
+        font-size: 14px;
+    }
+
+    .control-dock {
+        gap: 10px;
+        padding: 7px;
+    }
+
+    .control-button {
+        width: 52px;
+        height: 52px;
+    }
+
+    .app-drawer-left,
+    .app-drawer-right {
+        width: min(86vw, 360px);
     }
 }
 
-@media (max-width: 960px) {
-    .app-shell {
-        grid-template-columns: 1fr;
-    }
-
-    .sidebar {
-        position: static;
-        max-height: none;
-    }
-
-    .session-list {
-        max-height: 240px;
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
     }
 }

--- a/examples/sample_app/static/js/index.js
+++ b/examples/sample_app/static/js/index.js
@@ -1,14 +1,4 @@
-async function loadXtalk() {
-    try {
-        console
-        return await import("../../xtalk/index.js");
-    } catch (e) {
-        console.log("Failed to load local xtalk-client, falling back to CDN:", e)
-        return await import("https://unpkg.com/xtalk-client@latest/dist/index.js");
-    }
-}
-
-const { createSession } = await loadXtalk();
+const { createSession } = await import("../../xtalk/index.js");
 
 function resolveAppURL(path) {
     const baseURL = new URL("./", window.location.href);
@@ -28,39 +18,45 @@ const session = createSession(getWebSocketURL(), {
     },
 });
 
-const $btnStart = document.getElementById('btn-start');
-const $btnStop = document.getElementById('btn-stop');
+const $btnCall = document.getElementById('btn-call');
 const $btnMute = document.getElementById('btn-mute');
 const $btnNewSession = document.getElementById('btn-new-session');
 const $btnRefreshSessions = document.getElementById('btn-refresh-sessions');
-const $voiceSelect = document.getElementById('voice-select');
 const $btnUploadFile = document.getElementById('btn-upload-file');
 const $fileInput = document.getElementById('file-input');
+const $voiceSelect = document.getElementById('voice-select');
 const $sessionList = document.getElementById('session-list');
 const $sessionListEmpty = document.getElementById('session-list-empty');
+const $connectionState = document.getElementById('connection-state');
 const $streamState = document.getElementById('stream-state');
+const $mutedState = document.getElementById('muted-state');
 const $sessionId = document.getElementById('session-id');
 const $waveform = document.getElementById('waveform');
+const $orbView = document.getElementById('orb-view');
+const $chatView = document.getElementById('chat-view');
+const $btnShowChat = document.getElementById('btn-show-chat');
+const $btnShowOrb = document.getElementById('btn-show-orb');
 const $messages = document.getElementById('messages');
+const $sessionsDrawer = document.getElementById('sessions-drawer');
+const $debugDrawer = document.getElementById('debug-drawer');
+const $drawerBackdrop = document.getElementById('drawer-backdrop');
+const $btnToggleSessions = document.getElementById('btn-toggle-sessions');
+const $btnToggleDebug = document.getElementById('btn-toggle-debug');
+const $btnCloseSessions = document.getElementById('btn-close-sessions');
+const $btnCloseDebug = document.getElementById('btn-close-debug');
 const $thoughtContent = document.getElementById('thought-content');
 const $captionContent = document.getElementById('caption-content');
 const $retrievalContent = document.getElementById('retrieval-content');
-const $panelThought = document.getElementById('panel-thought');
-const $panelCaption = document.getElementById('panel-caption');
-const $panelRetrieval = document.getElementById('panel-retrieval');
-const $btnToggleThought = document.getElementById('btn-toggle-thought');
-const $btnToggleCaption = document.getElementById('btn-toggle-caption');
-const $btnToggleRetrieval = document.getElementById('btn-toggle-retrieval');
 const $latencyNetwork = document.getElementById('latency-network');
 const $latencyAsr = document.getElementById('latency-asr');
 const $latencyLlmFirst = document.getElementById('latency-llm-first');
 const $latencyLlmSentence = document.getElementById('latency-llm-sentence');
 const $latencyTts = document.getElementById('latency-tts');
 const $latencyE2e = document.getElementById('latency-e2e');
-const $btnToggleRecentAudio = document.getElementById('btn-toggle-recent-audio');
-const $recentAudioCard = document.getElementById('recent-audio-card');
+const $recentAudioDetails = document.getElementById('recent-audio-details');
 const $recentAudioStatus = document.getElementById('recent-audio-status');
 const $recentAudioPlayer = document.getElementById('recent-audio-player');
+const $toastRegion = document.getElementById('toast-region');
 
 let audioCtx = null;
 let inputAnalyser = null;
@@ -85,6 +81,11 @@ let toolCallCacheKey = '';
 let chatTimeline = [];
 let chatTimelineIndexByKey = new Map();
 let isStarting = false;
+let isStopping = false;
+let isUploading = false;
+let voiceOptionsLoaded = false;
+let currentDrawer = null;
+let currentMainView = 'orb';
 
 const FULL_AUDIO_CHANNELS = 2;
 const FULL_AUDIO_BYTES_PER_SAMPLE = 2;
@@ -98,28 +99,98 @@ let recentAudioSnapshotDirty = false;
 const canvasCtx = $waveform.getContext('2d');
 
 const STATE_COLORS = {
-    idle: '#6b7280',
-    listening: '#34d399',
-    processing: '#fbbf24',
-    speaking: '#93c5fd'
+    idle: ['#7380ff', '#c8d0ff', '#f8fbff'],
+    listening: ['#6978ff', '#aab8ff', '#f9fbff'],
+    processing: ['#8b78ff', '#c2b8ff', '#fffaff'],
+    speaking: ['#5e73ff', '#9eafff', '#f8fbff'],
 };
 
-function setConnectionButtons(isConnected) {
-    const isReconnecting = session.state.connectionState === 'reconnecting';
-    const startDisabled = isStarting || isConnected || isReconnecting;
-    const stopDisabled = isStarting || (!isConnected && !isReconnecting);
+function isLiveConnection() {
+    return session.state.connectionState === 'connected'
+        || session.state.connectionState === 'reconnecting';
+}
 
-    $btnStart.disabled = startDisabled;
-    $btnStart.textContent = isStarting ? 'Starting...' : 'Start';
-    $btnStart.classList.toggle('is-loading', isStarting);
+function renderControls() {
+    const isLive = isLiveConnection();
+    const isMuted = session.muted;
+    const isCallPending = isStarting || isStopping;
+    const callAction = isLive ? 'stop' : 'start';
+    const callLabel = isLive ? '停止对话' : '开始对话';
+    const pendingLabel = isStopping ? '正在停止对话' : '正在开始对话';
 
-    $btnStop.disabled = stopDisabled;
+    $btnCall.dataset.action = callAction;
+    $btnCall.disabled = isCallPending;
+    $btnCall.classList.toggle('is-loading', isCallPending);
+    $btnCall.setAttribute('aria-label', isCallPending ? pendingLabel : callLabel);
+    $btnCall.setAttribute('aria-busy', String(isCallPending));
+    $btnCall.title = isCallPending ? pendingLabel : callLabel;
+
+    $btnMute.disabled = !isLive || isCallPending;
+    $btnMute.classList.toggle('is-muted', isMuted);
+    $btnMute.setAttribute('aria-pressed', String(isMuted));
+    $btnMute.setAttribute('aria-label', isMuted ? '打开麦克风' : '关闭麦克风');
+    $btnMute.title = isMuted ? '打开麦克风' : '关闭麦克风';
+
+    $btnUploadFile.disabled = isUploading || !session.state.sessionId;
+    $btnUploadFile.classList.toggle('is-loading', isUploading);
+    $voiceSelect.disabled = !voiceOptionsLoaded || !isLive;
+
+    $connectionState.textContent = isStarting
+        ? 'starting'
+        : isStopping
+            ? 'stopping'
+            : session.state.connectionState;
+    $streamState.textContent = session.state.streamState;
+    $mutedState.textContent = String(isMuted);
+    $sessionId.textContent = session.state.sessionId || '--';
+    $btnShowChat.dataset.streamState = session.state.streamState;
+    $btnShowChat.classList.toggle('is-muted', isMuted);
+    $btnShowOrb.dataset.streamState = session.state.streamState;
+    $btnShowOrb.classList.toggle('is-muted', isMuted);
 }
 
 function resetRealtimeUI() {
     stopVisualization();
     isStarting = false;
-    setConnectionButtons(false);
+    isStopping = false;
+    renderControls();
+}
+
+function showToast(message, type = 'error') {
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.textContent = message;
+    $toastRegion.appendChild(toast);
+    window.setTimeout(() => toast.remove(), 4200);
+}
+
+function setMainView(view) {
+    currentMainView = view === 'chat' ? 'chat' : 'orb';
+    const showChat = currentMainView === 'chat';
+    $orbView.classList.toggle('is-hidden', showChat);
+    $chatView.classList.toggle('is-hidden', !showChat);
+    $orbView.setAttribute('aria-hidden', String(showChat));
+    $chatView.setAttribute('aria-hidden', String(!showChat));
+    if (!showChat) {
+        resizeCanvas();
+        if (!isActive) drawWaveform(true);
+    }
+}
+
+function setDrawer(drawer) {
+    currentDrawer = drawer;
+    const sessionsOpen = drawer === 'sessions';
+    const debugOpen = drawer === 'debug';
+    const anyOpen = sessionsOpen || debugOpen;
+
+    document.body.dataset.drawer = drawer || '';
+    $sessionsDrawer.classList.toggle('is-open', sessionsOpen);
+    $debugDrawer.classList.toggle('is-open', debugOpen);
+    $drawerBackdrop.classList.toggle('is-visible', anyOpen);
+    $sessionsDrawer.setAttribute('aria-hidden', String(!sessionsOpen));
+    $debugDrawer.setAttribute('aria-hidden', String(!debugOpen));
+    $btnToggleSessions.setAttribute('aria-expanded', String(sessionsOpen));
+    $btnToggleDebug.setAttribute('aria-expanded', String(debugOpen));
 }
 
 function formatSessionTitle(item) {
@@ -128,9 +199,9 @@ function formatSessionTitle(item) {
         return title;
     }
     if (item?.session_id === session.state.sessionId) {
-        return 'Current Draft';
+        return '新会话';
     }
-    return `Session ${String(item?.session_id || '').slice(0, 8) || '--'}`;
+    return `会话 ${String(item?.session_id || '').slice(0, 8) || '--'}`;
 }
 
 function renderSessions() {
@@ -150,14 +221,10 @@ function renderSessions() {
         title.className = 'session-title';
         title.textContent = formatSessionTitle(item);
 
-        const meta = document.createElement('div');
-        meta.className = 'session-meta';
-        meta.textContent = item.session_id;
-
         button.appendChild(title);
-        button.appendChild(meta);
         button.addEventListener('click', async () => {
             if (item.session_id === session.state.sessionId) {
+                setDrawer(null);
                 return;
             }
             try {
@@ -165,8 +232,10 @@ function renderSessions() {
                 resetRealtimeUI();
                 await session.switchSession(item.session_id);
                 renderSessions();
+                setMainView('chat');
+                setDrawer(null);
             } catch (error) {
-                alert('Failed to switch session: ' + (error?.message || error));
+                showToast('切换会话失败：' + (error?.message || error));
             }
         });
 
@@ -303,12 +372,52 @@ function appendLocalInfoMessage(content) {
     });
 }
 
+async function copyMessageText(text) {
+    try {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(text);
+        } else {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.setAttribute('readonly', '');
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            const copied = document.execCommand('copy');
+            textArea.remove();
+            if (!copied) throw new Error('Clipboard API unavailable');
+        }
+        showToast('消息已复制', 'success');
+    } catch (error) {
+        showToast('复制失败：' + (error?.message || error));
+    }
+}
+
+function createMessageCopyButton(text) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'message-copy-button';
+    button.setAttribute('aria-label', '复制消息');
+    button.title = '复制消息';
+    button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2"></rect><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path></svg>';
+    button.addEventListener('click', async () => {
+        await copyMessageText(text);
+    });
+    return button;
+}
+
 function renderChatTimeline() {
     $messages.innerHTML = '';
     for (const entry of chatTimeline) {
-        const el = document.createElement('div');
+        const role = entry.kind === 'tool' ? 'tool' : entry.role;
+        const row = document.createElement('div');
+        row.className = 'message-row message-row-' + role;
+
+        const message = document.createElement('div');
+        let copyText = '';
         if (entry.kind === 'tool') {
-            el.className = 'message message-tool';
+            message.className = 'message message-tool';
 
             const label = document.createElement('div');
             label.className = 'message-tool-label';
@@ -318,13 +427,23 @@ function renderChatTimeline() {
             args.className = 'message-tool-args';
             args.textContent = entry.argsText;
 
-            el.appendChild(label);
-            el.appendChild(args);
+            message.appendChild(label);
+            message.appendChild(args);
+            copyText = `Tool Call: ${entry.name}\n${entry.argsText}`;
         } else {
-            el.className = 'message message-' + entry.role;
-            el.textContent = entry.content;
+            message.className = 'message message-' + entry.role;
+            message.textContent = entry.content;
+            copyText = entry.content;
         }
-        $messages.appendChild(el);
+        row.appendChild(message);
+
+        if (role !== 'info') {
+            const actions = document.createElement('div');
+            actions.className = 'message-actions';
+            actions.appendChild(createMessageCopyButton(copyText));
+            row.appendChild(actions);
+        }
+        $messages.appendChild(row);
     }
     $messages.scrollTop = $messages.scrollHeight;
 }
@@ -395,24 +514,20 @@ function resizeCanvas() {
     }
 }
 
-function drawWaveform() {
-    if (!isActive) return;
-    rafId = requestAnimationFrame(drawWaveform);
+function drawWaveform(renderOnce = false) {
+    if (!isActive && !renderOnce) return;
+    if (!renderOnce) {
+        rafId = requestAnimationFrame(() => drawWaveform(false));
+    }
 
+    resizeCanvas();
     const w = $waveform.width;
     const h = $waveform.height;
-
-    canvasCtx.fillStyle = '#0f172a';
-    canvasCtx.fillRect(0, 0, w, h);
-
-    canvasCtx.strokeStyle = '#1f2937';
-    canvasCtx.lineWidth = 1;
-    canvasCtx.beginPath();
-    canvasCtx.moveTo(0, h / 2);
-    canvasCtx.lineTo(w, h / 2);
-    canvasCtx.stroke();
-
-    const color = STATE_COLORS[currentStreamState] || '#6b7280';
+    const dpr = window.devicePixelRatio || 1;
+    const centerX = w / 2;
+    const centerY = h / 2;
+    const palette = STATE_COLORS[currentStreamState] || STATE_COLORS.idle;
+    const time = performance.now() / 1000;
     let dataArray = null;
     let bufferLength = 0;
 
@@ -426,22 +541,78 @@ function drawWaveform() {
         bufferLength = inputBufferLength;
     }
 
+    let energy = 0;
     if (dataArray && bufferLength) {
-        const sliceWidth = w / bufferLength;
-        canvasCtx.strokeStyle = color;
-        canvasCtx.lineWidth = 2;
-        canvasCtx.beginPath();
-        let x = 0;
-        for (let i = 0; i < bufferLength; i++) {
-            const v = dataArray[i] / 128.0;
-            const y = (v * h) / 2;
-            if (i === 0) canvasCtx.moveTo(x, y);
-            else canvasCtx.lineTo(x, y);
-            x += sliceWidth;
+        const stride = Math.max(1, Math.floor(bufferLength / 256));
+        let samples = 0;
+        for (let i = 0; i < bufferLength; i += stride) {
+            const sample = (dataArray[i] - 128) / 128;
+            energy += sample * sample;
+            samples += 1;
         }
-        canvasCtx.lineTo(w, h / 2);
-        canvasCtx.stroke();
+        energy = samples > 0 ? Math.sqrt(energy / samples) : 0;
     }
+
+    const statePulse = currentStreamState === 'processing'
+        ? 0.018 * Math.sin(time * 3.2)
+        : currentStreamState === 'speaking'
+            ? 0.014 * Math.sin(time * 5.2)
+            : 0.008 * Math.sin(time * 1.8);
+    const audioScale = Math.min(0.14, energy * 0.52);
+    const radius = Math.min(w, h) * 0.39 * (1 + statePulse + audioScale);
+    const isMuted = session.muted;
+
+    canvasCtx.clearRect(0, 0, w, h);
+    canvasCtx.save();
+    canvasCtx.globalAlpha = isMuted ? 0.48 : 1;
+    canvasCtx.shadowColor = 'rgba(104, 119, 255, 0.34)';
+    canvasCtx.shadowBlur = (24 + energy * 70) * dpr;
+
+    const baseGradient = canvasCtx.createLinearGradient(
+        centerX - radius * 0.65,
+        centerY - radius,
+        centerX + radius * 0.55,
+        centerY + radius,
+    );
+    baseGradient.addColorStop(0, palette[0]);
+    baseGradient.addColorStop(0.56, palette[1]);
+    baseGradient.addColorStop(1, palette[2]);
+    canvasCtx.fillStyle = baseGradient;
+    canvasCtx.beginPath();
+    canvasCtx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    canvasCtx.fill();
+
+    canvasCtx.shadowBlur = 0;
+    canvasCtx.clip();
+    const cloudX = centerX + Math.sin(time * 0.48) * radius * 0.08;
+    const cloudY = centerY + radius * 0.3 + Math.cos(time * 0.42) * radius * 0.05;
+    const cloudGradient = canvasCtx.createRadialGradient(
+        cloudX,
+        cloudY,
+        radius * 0.03,
+        cloudX,
+        cloudY,
+        radius * 0.78,
+    );
+    cloudGradient.addColorStop(0, 'rgba(255, 255, 255, 0.92)');
+    cloudGradient.addColorStop(0.32, 'rgba(255, 255, 255, 0.5)');
+    cloudGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    canvasCtx.fillStyle = cloudGradient;
+    canvasCtx.fillRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+
+    const sheenGradient = canvasCtx.createRadialGradient(
+        centerX - radius * 0.42,
+        centerY - radius * 0.45,
+        0,
+        centerX - radius * 0.42,
+        centerY - radius * 0.45,
+        radius * 0.72,
+    );
+    sheenGradient.addColorStop(0, 'rgba(255, 255, 255, 0.26)');
+    sheenGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    canvasCtx.fillStyle = sheenGradient;
+    canvasCtx.fillRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+    canvasCtx.restore();
 }
 
 function startVisualization() {
@@ -453,27 +624,20 @@ function startVisualization() {
 }
 
 function stopVisualization() {
-    if (!isActive) return;
     isActive = false;
     if (rafId) {
         cancelAnimationFrame(rafId);
         rafId = null;
     }
-    const w = $waveform.width;
-    const h = $waveform.height;
-    canvasCtx.fillStyle = '#0f172a';
-    canvasCtx.fillRect(0, 0, w, h);
+    resizeCanvas();
+    drawWaveform(true);
 }
 
 function updateRecentAudioStatus(text) {
     $recentAudioStatus.textContent = text;
 }
 
-function setRecentAudioVisible(visible) {
-    $recentAudioCard.classList.toggle('is-hidden', !visible);
-    $recentAudioCard.setAttribute('aria-hidden', visible ? 'false' : 'true');
-    $btnToggleRecentAudio.textContent = visible ? 'Hide Recent Audio' : 'Recent 60s Audio';
-}
+
 
 function revokeRecentAudioUrl() {
     if (recentAudioObjectUrl) {
@@ -596,11 +760,12 @@ function refreshRecentAudioSnapshot(force = false) {
 }
 
 session.onStateChange((state) => {
-    $streamState.textContent = state.streamState;
-    $sessionId.textContent = state.sessionId || '--';
     currentStreamState = state.streamState;
-    setConnectionButtons(state.connectionState === 'connected');
+    renderControls();
     renderSessions();
+    if (!isActive) {
+        drawWaveform(true);
+    }
 
     if (state.sessionId !== timelineSessionId) {
         resetChatTimeline(state.sessionId);
@@ -663,59 +828,48 @@ session.onFullAudioChunk((pcmChunkInt16, sampleRate) => {
     }
 });
 
-$btnStart.addEventListener('click', async () => {
-    if (isStarting) {
+$btnCall.addEventListener('click', async () => {
+    if (isStarting) return;
+
+    if (isLiveConnection()) {
+        isStopping = true;
+        renderControls();
+        try {
+            await session.close();
+            stopVisualization();
+        } catch (error) {
+            showToast('停止对话失败：' + (error?.message || error));
+        } finally {
+            isStopping = false;
+            renderControls();
+        }
         return;
     }
 
     isStarting = true;
-    setConnectionButtons(false);
+    renderControls();
     try {
         resetRecentAudioBuffer();
         await session.open();
         startVisualization();
-        setConnectionButtons(true);
+        setMainView('orb');
         await refreshSessions();
-    } catch (e) {
-        alert('Failed to start: ' + (e?.message || e));
+    } catch (error) {
+        showToast('开始对话失败：' + (error?.message || error));
     } finally {
         isStarting = false;
-        setConnectionButtons(session.state.connectionState === 'connected');
-    }
-});
-
-$btnStop.addEventListener('click', async () => {
-    try {
-        await session.close();
-        resetRealtimeUI();
-    } catch (e) {
-        alert('Failed to stop: ' + (e?.message || e));
+        renderControls();
     }
 });
 
 $btnMute.addEventListener('click', () => {
-    try {
-        session.muted = !session.muted;
-        $btnMute.textContent = session.muted ? 'Unmute' : 'Mute';
-    } catch (e) {
-        alert('Failed to toggle mute: ' + (e?.message || e));
-    }
+    if (!isLiveConnection()) return;
+    session.muted = !session.muted;
+    renderControls();
 });
 
-function setupToggle(btn, panel) {
-    btn.addEventListener('click', () => {
-        const active = btn.classList.toggle('active');
-        panel.style.display = active ? '' : 'none';
-    });
-}
-setupToggle($btnToggleThought, $panelThought);
-setupToggle($btnToggleCaption, $panelCaption);
-setupToggle($btnToggleRetrieval, $panelRetrieval);
-
-$btnToggleRecentAudio.addEventListener('click', () => {
-    const willOpen = $recentAudioCard.classList.contains('is-hidden');
-    setRecentAudioVisible(willOpen);
-    if (willOpen) {
+$recentAudioDetails.addEventListener('toggle', () => {
+    if ($recentAudioDetails.open) {
         refreshRecentAudioSnapshot(true);
     }
 });
@@ -738,13 +892,36 @@ $btnNewSession.addEventListener('click', async () => {
             renderChatTimeline();
         }
         renderSessions();
+        setMainView('orb');
+        setDrawer(null);
     } catch (error) {
-        alert('Failed to create draft session: ' + (error?.message || error));
+        showToast('新建会话失败：' + (error?.message || error));
+    }
+});
+
+$btnToggleSessions.addEventListener('click', () => {
+    setDrawer(currentDrawer === 'sessions' ? null : 'sessions');
+});
+
+$btnToggleDebug.addEventListener('click', () => {
+    setDrawer(currentDrawer === 'debug' ? null : 'debug');
+});
+
+$btnCloseSessions.addEventListener('click', () => setDrawer(null));
+$btnCloseDebug.addEventListener('click', () => setDrawer(null));
+$drawerBackdrop.addEventListener('click', () => setDrawer(null));
+$btnShowChat.addEventListener('click', () => setMainView('chat'));
+$btnShowOrb.addEventListener('click', () => setMainView('orb'));
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && currentDrawer) {
+        setDrawer(null);
     }
 });
 
 window.addEventListener('resize', () => {
     resizeCanvas();
+    if (!isActive) drawWaveform(true);
 });
 
 window.addEventListener('beforeunload', () => {
@@ -755,8 +932,9 @@ window.addEventListener('beforeunload', () => {
     revokeRecentAudioUrl();
 });
 
-setConnectionButtons(false);
-setRecentAudioVisible(false);
+renderControls();
+resizeCanvas();
+drawWaveform(true);
 
 let availableAudios = [];
 
@@ -787,41 +965,65 @@ async function loadReferenceAudios() {
             $voiceSelect.appendChild(option);
         });
 
-        $voiceSelect.disabled = false;
+        voiceOptionsLoaded = availableAudios.length > 0;
+        renderControls();
     } catch (error) {
         console.error('Failed to load reference audios:', error);
+        voiceOptionsLoaded = false;
         $voiceSelect.innerHTML = '<option value="">Load failed</option>';
+        renderControls();
     }
 }
 
-$voiceSelect.addEventListener('change', (e) => {
-    const selectedName = e.target.value;
-    const selectedAudio = availableAudios.find(a => (a.name || a.path) === selectedName);
-    if (selectedAudio) {
-        const voiceName = selectedAudio.name || selectedName;
-        session.changeVoice(voiceName);
+$voiceSelect.addEventListener('change', async (event) => {
+    const selectedName = event.target.value;
+    const selectedAudio = availableAudios.find((audio) => (audio.name || audio.path) === selectedName);
+    if (!selectedAudio) return;
+
+    const voiceName = selectedAudio.name || selectedName;
+    $voiceSelect.disabled = true;
+    try {
+        await session.changeVoice(voiceName);
         session.state.currentVoiceName = voiceName;
         session.state.currentVoicePath = selectedAudio.path || null;
         syncVoiceSelectValue(voiceName);
+        showToast(`已切换语音：${voiceName}`, 'success');
+    } catch (error) {
+        showToast('切换语音失败：' + (error?.message || error));
+        syncVoiceSelectValue(session.state.currentVoiceName);
+    } finally {
+        renderControls();
     }
 });
 
 $btnUploadFile.addEventListener('click', () => {
+    if (!session.state.sessionId) {
+        showToast('请先开始或选择一个会话。');
+        return;
+    }
     $fileInput.click();
 });
 
-$fileInput.addEventListener('change', async (e) => {
-    const file = e.target.files?.[0];
+$fileInput.addEventListener('change', async (event) => {
+    const file = event.target.files?.[0];
     if (!file) return;
+
+    isUploading = true;
+    renderControls();
     try {
         await session.uploadFile(file);
-    } catch (err) {
-        alert('Failed to upload file: ' + (err?.message || err));
+        showToast(`已上传：${file.name}`, 'success');
+    } catch (error) {
+        showToast('上传失败：' + (error?.message || error));
+    } finally {
+        isUploading = false;
+        renderControls();
+        $fileInput.value = '';
     }
-    $fileInput.value = '';
 });
 
 loadReferenceAudios();
 refreshSessions().catch((error) => {
     console.error('Initial session load failed:', error);
+    showToast('加载会话列表失败：' + (error?.message || error));
 });

--- a/examples/sample_app/static/js/index.js
+++ b/examples/sample_app/static/js/index.js
@@ -388,21 +388,35 @@ async function copyMessageText(text) {
             textArea.remove();
             if (!copied) throw new Error('Clipboard API unavailable');
         }
-        showToast('消息已复制', 'success');
+        return true;
     } catch (error) {
         showToast('复制失败：' + (error?.message || error));
+        return false;
     }
 }
 
 function createMessageCopyButton(text) {
     const button = document.createElement('button');
+    let feedbackTimer = null;
     button.type = 'button';
     button.className = 'message-copy-button';
     button.setAttribute('aria-label', '复制消息');
     button.title = '复制消息';
-    button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2"></rect><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path></svg>';
+    button.innerHTML = '<svg class="icon-copy" viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="8" width="11" height="11" rx="2"></rect><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path></svg><svg class="icon-check" viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 4 4L19 6"></path></svg>';
     button.addEventListener('click', async () => {
-        await copyMessageText(text);
+        const copied = await copyMessageText(text);
+        if (!copied) return;
+
+        button.classList.add('is-copied');
+        button.setAttribute('aria-label', '已复制');
+        button.title = '已复制';
+        if (feedbackTimer) window.clearTimeout(feedbackTimer);
+        feedbackTimer = window.setTimeout(() => {
+            button.classList.remove('is-copied');
+            button.setAttribute('aria-label', '复制消息');
+            button.title = '复制消息';
+            feedbackTimer = null;
+        }, 1600);
     });
     return button;
 }

--- a/examples/sample_app/templates/index.html
+++ b/examples/sample_app/templates/index.html
@@ -1,101 +1,207 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
 
 <head>
     <meta charset="utf-8" />
-    <title>Xtalk Dev</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>XTalk</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f7f7f5" media="(prefers-color-scheme: light)" />
     <link rel="stylesheet" href="./static/css/index.css" />
 </head>
 
 <body>
-    <header>
-        <div class="container">
-            <h1>Xtalk Dev</h1>
-            <div class="status">
-                <div>State: <span id="stream-state">--</span></div>
-                <div>Session: <span id="session-id">--</span></div>
+    <div class="app">
+        <button id="drawer-backdrop" class="drawer-backdrop" type="button" tabindex="-1"
+            aria-label="关闭侧边栏"></button>
+
+        <aside id="sessions-drawer" class="app-drawer app-drawer-left" aria-hidden="true"
+            aria-labelledby="sessions-title">
+            <div class="drawer-header sessions-drawer-header">
+                <h2 id="sessions-title">XTalk</h2>
+                <div class="drawer-header-actions">
+                    <button id="btn-refresh-sessions" class="icon-button icon-button-quiet" type="button"
+                        aria-label="刷新会话列表" title="刷新会话列表">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M20 11a8 8 0 1 0-2.34 5.66M20 5v6h-6" />
+                        </svg>
+                    </button>
+                    <button id="btn-close-sessions" class="icon-button icon-button-quiet" type="button"
+                        aria-label="关闭会话列表">
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M6 6l12 12M18 6L6 18" />
+                        </svg>
+                    </button>
+                </div>
             </div>
-            <div class="controls">
-                <button id="btn-start">Start</button>
-                <button id="btn-stop">Stop</button>
-                <button id="btn-mute">Mute</button>
+
+            <button id="btn-new-session" class="new-session-button" type="button">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M12 5v14M5 12h14" />
+                </svg>
+                <span>新聊天</span>
+            </button>
+
+            <div id="session-list-empty" class="sidebar-empty">暂无会话。</div>
+            <div id="session-list" class="session-list" role="list"></div>
+        </aside>
+
+        <aside id="debug-drawer" class="app-drawer app-drawer-right" aria-hidden="true"
+            aria-labelledby="debug-title">
+            <div class="drawer-header">
+                <div>
+                    <div class="drawer-eyebrow">Inspector</div>
+                    <h2 id="debug-title">调试信息</h2>
+                </div>
+                <button id="btn-close-debug" class="icon-button icon-button-quiet" type="button"
+                    aria-label="关闭调试信息">
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M6 6l12 12M18 6L6 18" />
+                    </svg>
+                </button>
             </div>
-            <div class="controls">
-                <div class="voice-selector">
-                    <label for="voice-select">Voice:</label>
+
+            <div class="debug-scroll">
+                <section class="debug-section" aria-labelledby="runtime-title">
+                    <h3 id="runtime-title">Runtime</h3>
+                    <dl class="runtime-grid">
+                        <div>
+                            <dt>Connection</dt>
+                            <dd id="connection-state">disconnected</dd>
+                        </div>
+                        <div>
+                            <dt>Stream</dt>
+                            <dd id="stream-state">idle</dd>
+                        </div>
+                        <div>
+                            <dt>Muted</dt>
+                            <dd id="muted-state">false</dd>
+                        </div>
+                        <div class="runtime-session">
+                            <dt>Session</dt>
+                            <dd id="session-id">--</dd>
+                        </div>
+                    </dl>
+                </section>
+
+                <section class="debug-section" aria-labelledby="voice-title">
+                    <label id="voice-title" for="voice-select">Voice</label>
                     <select id="voice-select" disabled>
                         <option value="">Loading...</option>
                     </select>
-                </div>
-                <div class="upload-btn">
-                    <button id="btn-upload-file">Upload Doc</button>
-                    <input id="file-input" type="file" accept="text/*,.pdf,application/pdf" style="display:none;" />
-                </div>
-                <button id="btn-toggle-recent-audio" class="recent-audio-toggle">Recent 60s Audio</button>
+                </section>
+
+                <details class="debug-details" open>
+                    <summary>
+                        <span>Latency</span>
+                        <span class="summary-value"><span id="latency-e2e">--</span> ms E2E</span>
+                    </summary>
+                    <dl class="latency-grid">
+                        <div><dt>Network</dt><dd><span id="latency-network">--</span> ms</dd></div>
+                        <div><dt>ASR</dt><dd><span id="latency-asr">--</span> ms</dd></div>
+                        <div><dt>LLM First Token</dt><dd><span id="latency-llm-first">--</span> ms</dd></div>
+                        <div><dt>LLM Sentence</dt><dd><span id="latency-llm-sentence">--</span> ms</dd></div>
+                        <div><dt>TTS First Chunk</dt><dd><span id="latency-tts">--</span> ms</dd></div>
+                    </dl>
+                </details>
+
+                <details class="debug-details">
+                    <summary>Thought</summary>
+                    <div id="thought-content" class="debug-content"></div>
+                </details>
+
+                <details class="debug-details">
+                    <summary>Caption</summary>
+                    <div id="caption-content" class="debug-content"></div>
+                </details>
+
+                <details class="debug-details">
+                    <summary>Retrieval</summary>
+                    <div id="retrieval-content" class="debug-content"></div>
+                </details>
+
+                <details id="recent-audio-details" class="debug-details">
+                    <summary>Recent 60s Audio</summary>
+                    <div class="recent-audio-panel">
+                        <div id="recent-audio-status" class="recent-audio-status">
+                            Waiting for server full audio stream
+                        </div>
+                        <audio id="recent-audio-player" class="recent-audio-player" controls
+                            preload="metadata"></audio>
+                    </div>
+                </details>
             </div>
-        </div>
-    </header>
-    <main class="container app-shell">
-        <aside class="sidebar card">
-            <div class="sidebar-header">
-                <div>
-                    <div class="sidebar-eyebrow">History</div>
-                    <h2>Sessions</h2>
-                </div>
-                <button id="btn-refresh-sessions" class="sidebar-action">Refresh</button>
-            </div>
-            <button id="btn-new-session" class="new-session-btn">New Session</button>
-            <div id="session-list-empty" class="sidebar-empty">No sessions yet.</div>
-            <div id="session-list" class="session-list" role="list"></div>
         </aside>
-        <section class="content-area">
-            <div id="latency-bar" class="latency-bar">
-                <span class="latency-item">Network: <span id="latency-network">--</span>ms</span>
-                <span class="latency-item">ASR: <span id="latency-asr">--</span>ms</span>
-                <span class="latency-item">LLM First Token: <span id="latency-llm-first">--</span>ms</span>
-                <span class="latency-item">LLM Sentence: <span id="latency-llm-sentence">--</span>ms</span>
-                <span class="latency-item">TTS First Chunk: <span id="latency-tts">--</span>ms</span>
-                <span class="latency-item latency-e2e">E2E: <span id="latency-e2e">--</span>ms</span>
-            </div>
-            <div id="recent-audio-card" class="card recent-audio-card is-hidden" aria-hidden="true">
-                <div class="recent-audio-header">
-                    <span id="recent-audio-status" class="recent-audio-status">Waiting for server full audio stream</span>
-                </div>
-                <div id="recent-audio-panel" class="recent-audio-panel">
-                    <audio id="recent-audio-player" class="recent-audio-player" controls preload="metadata"></audio>
-                    <div class="recent-audio-hint">Shows a snapshot of the latest 60 seconds of server full audio.</div>
-                </div>
-            </div>
-            <div class="card">
-                <canvas id="waveform"></canvas>
-            </div>
-            <div class="card">
-                <div class="chat-card-label">Chat</div>
-                <div id="messages"></div>
-            </div>
-            <div class="toggle-bar">
-                <button id="btn-toggle-thought" class="toggle-btn active">Thought</button>
-                <button id="btn-toggle-caption" class="toggle-btn active">Caption</button>
-                <button id="btn-toggle-retrieval" class="toggle-btn active">Retrieval</button>
-            </div>
-            <div id="panel-thought" class="card panel">
-                <div class="panel-label">Thought</div>
-                <div id="thought-content" class="panel-content"></div>
-            </div>
-            <div id="panel-caption" class="card panel">
-                <div class="panel-label">Caption</div>
-                <div id="caption-content" class="panel-content"></div>
-            </div>
-            <div id="panel-retrieval" class="card panel">
-                <div class="panel-label">Retrieval</div>
-                <div id="retrieval-content" class="panel-content"></div>
-            </div>
-        </section>
-    </main>
-    <footer>
-        Xtalk Dev
-    </footer>
+
+        <header class="topbar">
+            <button id="btn-toggle-sessions" class="icon-button" type="button" aria-label="打开会话列表"
+                aria-controls="sessions-drawer" aria-expanded="false">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M4 7h16M4 12h16M4 17h16" />
+                </svg>
+            </button>
+            <div class="brand">XTalk</div>
+            <button id="btn-toggle-debug" class="icon-button" type="button" aria-label="打开调试信息"
+                aria-controls="debug-drawer" aria-expanded="false">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M4 7h10M18 7h2M4 17h2M10 17h10M14 4v6M6 14v6" />
+                </svg>
+            </button>
+        </header>
+
+        <main class="workspace">
+            <section id="orb-view" class="view-panel orb-view" aria-hidden="false">
+                <button id="btn-show-chat" class="orb-button" type="button" aria-label="显示聊天记录">
+                    <canvas id="waveform"></canvas>
+                </button>
+            </section>
+
+            <section id="chat-view" class="view-panel chat-view is-hidden" aria-hidden="true"
+                aria-label="对话记录">
+                <div id="messages" aria-live="polite"></div>
+                <button id="btn-show-orb" class="chat-mini-orb" type="button" aria-label="返回语音圆球模式"
+                    title="返回语音圆球模式">
+                    <span aria-hidden="true"></span>
+                </button>
+            </section>
+        </main>
+
+        <div class="control-dock" aria-label="语音控制">
+            <button id="btn-upload-file" class="control-button control-button-secondary" type="button"
+                aria-label="上传文件" title="上传文件">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M12 5v14M5 12h14" />
+                </svg>
+                <span class="control-spinner" aria-hidden="true"></span>
+            </button>
+            <input id="file-input" type="file" accept="text/*,.pdf,application/pdf" hidden />
+
+            <button id="btn-mute" class="control-button control-button-secondary" type="button"
+                aria-label="关闭麦克风" aria-pressed="false" title="关闭麦克风" disabled>
+                <svg class="icon-mic" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3Z" />
+                    <path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6" />
+                </svg>
+                <svg class="icon-mic-off" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M9 9v3a3 3 0 0 0 4.2 2.75M15 10V6a3 3 0 0 0-5.5-1.65M5 11a7 7 0 0 0 11.3 5.52M19 11a7 7 0 0 1-.76 3.18M12 18v3M9 21h6M4 4l16 16" />
+                </svg>
+            </button>
+
+            <button id="btn-call" class="control-button control-button-primary" type="button"
+                data-action="start" aria-label="开始对话" title="开始对话">
+                <svg class="icon-wave" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M4 12v1M8 9v7M12 5v14M16 8v9M20 11v3" />
+                </svg>
+                <svg class="icon-close" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 6l12 12M18 6L6 18" />
+                </svg>
+                <span class="control-spinner" aria-hidden="true"></span>
+            </button>
+        </div>
+
+        <div id="toast-region" class="toast-region" aria-live="polite" aria-atomic="true"></div>
+    </div>
+
     <script type="module" src="./static/js/index.js"></script>
 </body>
 

--- a/frontend/src/platforms/web.ts
+++ b/frontend/src/platforms/web.ts
@@ -307,8 +307,8 @@ class WebInputAudioSession extends BaseInputAudioSession {
         vadFrameSamples: 512,
         vadNegativeFramesBeforeEnd: 50,
         vadConfig: {
-            positiveSpeechThreshold: 0.8,
-            negativeSpeechThreshold: 0.2,
+            positiveSpeechThreshold: 0.2,
+            negativeSpeechThreshold: 0.1,
             preSpeechPadMs: 30,
             redemptionMs: 500,
             minSpeechMs: 250,


### PR DESCRIPTION
## Summary

- Lower the default web VAD start and end thresholds to improve quiet-speech detection.
- Redesign `examples/sample_app` as a responsive live-voice interface with an animated orb and a dedicated conversation view.
- Add collapsible session and diagnostics panels while preserving latency, thought, caption, retrieval, voice selection, upload, and recent-audio tools.
- Consolidate start/stop and mute controls, add reverse-proxy-safe relative asset paths, and provide inline copy confirmation for messages.

## Why

The previous VAD start threshold was too high and could miss the beginning of quiet speech. The sample web application also exposed developer diagnostics as the primary interface, which made the main voice workflow harder to understand and use.

## User impact

Users should see more responsive speech detection and a clearer voice-first experience on desktop and mobile. Existing session history, audio capture, uploads, voice switching, and diagnostics remain available through the side panels.

## Validation

- `npm run build` in `frontend` (all webpack targets compiled successfully)
- `node --check examples/sample_app/static/js/index.js`
- DOM reference and interaction assertion checks
- Sample app smoke test with dummy models: page, CSS, JS, client bundle, and voice API returned HTTP 200
- Reverse-proxy prefix URL resolution checks
- `git diff --check`